### PR TITLE
Update volatile qualifiers in wait and lock API

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -351,6 +351,17 @@ specification.
 
 \chapter{Changes to this Document}\label{sec:changelog}
 
+\section{Version 1.4}
+
+\begin{itemize}
+
+\item The type of the \VAR{ivar} argument to \FUNC{shmem\_wait} routines was
+updated from \VAR{volatile} to \VAR{const volatile}.
+
+\item The \VAR{volatile} qualifier was removed from the \VAR{lock} arguments in
+the lock API.
+
+\end{itemize}
 
 \section{Version 1.2}
 This section summarizes the changes from the \openshmem specification Version

--- a/content/shmem_lock.tex
+++ b/content/shmem_lock.tex
@@ -5,9 +5,9 @@
 \begin{apidefinition}
 
 \begin{Csynopsis}
-void shmem_clear_lock(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| long *lock);
-void shmem_set_lock(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| long *lock);
-int shmem_test_lock(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| long *lock);
+void shmem_clear_lock(long *lock);
+void shmem_set_lock(long *lock);
+int shmem_test_lock(long *lock);
 \end{Csynopsis}
 
 \begin{Fsynopsis}

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -5,16 +5,16 @@
 \begin{apidefinition}
 
 \begin{Csynopsis}
-void shmem_int_wait(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| int *ivar, int cmp_value);
-void shmem_int_wait_until(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| int *ivar, int cmp, int cmp_value);
-void shmem_long_wait(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| long *ivar, long cmp_value);
-void shmem_long_wait_until(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| long *ivar, int cmp, long cmp_value);
-void shmem_longlong_wait(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| long long *ivar, long long cmp_value);
-void shmem_longlong_wait_until(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| long long *ivar, int cmp, long long cmp_value);
-void shmem_short_wait(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| short *ivar, short cmp_value);
-void shmem_short_wait_until(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| short *ivar, int cmp, short cmp_value);
-void shmem_wait(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| long *ivar, long cmp_value);
-void shmem_wait_until(|\aftergroup\colorswapnt|volatile|\aftergroup\prevcolor| long *ivar, int cmp, long cmp_value);
+void shmem_int_wait(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| int *ivar, int cmp_value);
+void shmem_int_wait_until(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| int *ivar, int cmp, int cmp_value);
+void shmem_long_wait(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| long *ivar, long cmp_value);
+void shmem_long_wait_until(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| long *ivar, int cmp, long cmp_value);
+void shmem_longlong_wait(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| long long *ivar, long long cmp_value);
+void shmem_longlong_wait_until(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| long long *ivar, int cmp, long long cmp_value);
+void shmem_short_wait(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| short *ivar, short cmp_value);
+void shmem_short_wait_until(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| short *ivar, int cmp, short cmp_value);
+void shmem_wait(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| long *ivar, long cmp_value);
+void shmem_wait_until(|\aftergroup\colorswapnt|const volatile|\aftergroup\prevcolor| long *ivar, int cmp, long cmp_value);
 \end{Csynopsis}
 
 \begin{Fsynopsis}
@@ -101,6 +101,13 @@ CALL SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)
     \FUNC{shmem\_wait\_until} operations can be used to portably ensure
     visibility of updates that occurred and were ordered prior to the update
     satisfying the wait operation.}
+
+    \newtext{
+    The \VAR{ivar} argument is qualified as \VAR{const} because the
+    \FUNC{shmem\_wait} routine does not update the location pointed to by
+    \VAR{ivar}. It is further qualified as \VAR{volatile}, because the value
+    may change during the \FUNC{shmem\_wait} call as a result of updates made
+    by other PEs.}
 
 }
 


### PR DESCRIPTION
Ref: redmine ticket #211 (http://www.openshmem.org/redmine/issues/211).