### PR TITLE
Remove volatile qualifiers in wait and lock APIs

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -351,6 +351,16 @@ specification.
 
 \chapter{Changes to this Document}\label{sec:changelog}
 
+\section{Version 1.4}
+
+\begin{itemize}
+
+\item Volatile qualifiers were added to several API routines in version 1.3 of
+the OpenSHMEM specification; however, they were later found to be unnecessary.
+Thus, the \VAR{volatile} qualifier was removed from the \VAR{ivar} arguments to
+\FUNC{shmem\_wait} routines and the \VAR{lock} arguments in the lock API.
+
+\end{itemize}
 
 \section{Version 1.3}
 This section summarizes the changes from the \openshmem specification Version

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -339,7 +339,7 @@ specification.
     \FUNC{start\_pes} & 1.2 & Yes & \FUNC{shmem\_init} \\ \hline
     \FUNC{SHMEM\_PUT} & 1.2 & Yes & \FUNC{SHMEM\_PUT8} or \FUNC{SHMEM\_PUT64} \\ \hline
     \FUNC{SHMEM\_CACHE} & 1.3 & Yes & (none) \\ \hline
-    \_SHMEM\_* constants & 1.3 & Yes & (none) \\ \hline
+    \_SHMEM\_* constants & 1.3 & Yes & SHMEM\_* \\ \hline
     \hline
     \end{tabular}
 \end{center}
@@ -354,7 +354,7 @@ specification.
 
 \section{Version 1.3}
 This section summarizes the changes from the \openshmem specification Version
-1.2 to Version 1.3. Many major changes to the specification was introduced in Version 1.3. This includes non-blocking RMA operations, 
+1.2 to Version 1.3. Many major changes to the specification were introduced in Version 1.3. This includes non-blocking RMA operations, 
 generic interfaces for various OpenSHMEM interfaces, atomic \FUNC{Put} and \FUNC{Get} operations,  and Alltoall interfaces. 
 
 

--- a/content/frontmatter.tex
+++ b/content/frontmatter.tex
@@ -4,9 +4,9 @@
 \pagestyle{fancy}
 \fancyhead{}
 \fancyhead[LE,LO]{\insertDocVersion}
-%\fancyhead[CO,CE]{--- DRAFT ---}
-%\SetWatermarkText{DRAFT}
-%\SetWatermarkScale{1}
+\fancyhead[CO,CE]{--- DRAFT ---}
+\SetWatermarkText{DRAFT}
+\SetWatermarkScale{1}
 \fancyfoot[CE,CO]{\thepage} %affects page numbering for the first pages, 
                             %except the first ToC page
 

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -57,8 +57,8 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     an element (32 bits or 64 bits) times \VAR{PE\_size}.
     The \VAR{source} object contains \VAR{PE\_size} blocks of data (the size of each
     block defined by \VAR{nelems}) and each block of data is sent to a different \ac{PE}. 
-    \ac{PE} \VAR{i} sends the \VAR{j}th block of its \VAR{source} object to
-    \ac{PE} \VAR{j} and that block of data is placed in the \VAR{i}th block of
+    \ac{PE} \VAR{i} sends the \jth block of its \VAR{source} object to
+    \ac{PE} \VAR{j} and that block of data is placed in the \ith block of
     the \VAR{dest} object of \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, this routine assumes
@@ -101,7 +101,7 @@ constraints, which are as follows:
     This routine restores \VAR{pSync} to its original contents.  Multiple calls
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
-    You must ensure the that the \VAR{pSync} array is not being updated by any
+    You must ensure that the \VAR{pSync} array is not being updated by any
     \ac{PE} in the \activeset{} while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoall} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -63,8 +63,8 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     in the \activeset{} exchanges \VAR{nelems} strided data elements of size
     32 bits (for \FUNC{shmem\_alltoalls32}) or 64 bits (for \FUNC{shmem\_alltoalls64})
     with all other \acp{PE} in the set. Both strides, \VAR{dst} and \VAR{sst}, must be greater
-    than or equal to \CONST{1}. The \VAR{sst}*\VAR{j}th block sent from \ac{PE} \VAR{i} to
-    \ac{PE} \VAR{j} is placed in the \VAR{dst}*\VAR{i}th block of the \VAR{dest} data object on
+    than or equal to \CONST{1}. The \VAR{sst}*\jth block sent from \ac{PE} \VAR{i} to
+    \ac{PE} \VAR{j} is placed in the \VAR{dst}*\ith block of the \VAR{dest} data object on
     \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, these routines assume

--- a/content/shmem_lock.tex
+++ b/content/shmem_lock.tex
@@ -4,9 +4,9 @@
 \begin{apidefinition}
 
 \begin{Csynopsis}
-void shmem_clear_lock(volatile long *lock);
-void shmem_set_lock(volatile long *lock);
-int shmem_test_lock(volatile long *lock);
+void shmem_clear_lock(long *lock);
+void shmem_set_lock(long *lock);
+int shmem_test_lock(long *lock);
 \end{Csynopsis}
 
 \begin{Fsynopsis}

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -7,10 +7,10 @@
 \textbf{AND} \newline
 Performs a bitwise AND function across a set of processing elements (\ac{PE}s).\newline
 \begin{Csynopsis}
+void shmem_short_and_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 void shmem_int_and_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_long_and_to_all(long *dest, const long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long *pWrk, long *pSync);
 void shmem_longlong_and_to_all(long long *dest, const long long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long long *pWrk, long *pSync);
-void shmem_short_and_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 \end{Csynopsis}
 
 \begin{Fsynopsis}
@@ -22,13 +22,13 @@ CALL SHMEM_INT8_AND_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \textbf{MAX} \newline
 Performs a maximum function reduction across a set of processing elements (\ac{PE}s).\newline
 \begin{Csynopsis}
+void shmem_short_max_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
+void shmem_int_max_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_double_max_to_all(double *dest, const double *source, int nreduce, int PE_start, int logPE_stride, int PE_size, double *pWrk, long *pSync);
 void shmem_float_max_to_all(float *dest, const float *source, int nreduce, int PE_start, int logPE_stride, int PE_size, float *pWrk, long *pSync);
-void shmem_int_max_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_long_max_to_all(long *dest, const long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long *pWrk, long *pSync);
 void shmem_longdouble_max_to_all(long double *dest, const long double *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long double *pWrk, long *pSync);
 void shmem_longlong_max_to_all(long long *dest, const long long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long long *pWrk, long *pSync);
-void shmem_short_max_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 \end{Csynopsis}
 
 \begin{Fsynopsis}
@@ -43,13 +43,13 @@ CALL SHMEM_REAL16_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_s
 \textbf{MIN} \newline
 Performs a minimum function reduction across a set of processing elements (\ac{PE}s).\newline
 \begin{Csynopsis}
+void shmem_short_min_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
+void shmem_int_min_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_double_min_to_all(double *dest, const double *source, int nreduce, int PE_start, int logPE_stride, int PE_size, double *pWrk, long *pSync);
 void shmem_float_min_to_all(float *dest, const float *source, int nreduce, int PE_start, int logPE_stride, int PE_size, float *pWrk, long *pSync);
-void shmem_int_min_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_long_min_to_all(long *dest, const long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long *pWrk, long *pSync);
 void shmem_longdouble_min_to_all(long double *dest, const long double *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long double *pWrk, long *pSync);
 void shmem_longlong_min_to_all(long long *dest, const long long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long long *pWrk, long *pSync);
-void shmem_short_min_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 \end{Csynopsis}
 
 \begin{Fsynopsis}
@@ -66,13 +66,13 @@ Performs a sum reduction across a set of processing elements (\ac{PE}s).\newline
 \begin{Csynopsis}
 void shmem_complexd_sum_to_all(double complex *dest, const double complex *source, int nreduce, int PE_start, int logPE_stride, int PE_size, double complex *pWrk, long |\mbox{*pSync);}|
 void shmem_complexf_sum_to_all(float complex *dest, const float complex *source, int nreduce, int PE_start, int logPE_stride, int PE_size, float complex *pWrk, long *pSync);
+void shmem_short_sum_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
+void shmem_int_sum_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_double_sum_to_all(double *dest, const double *source, int nreduce, int PE_start, int logPE_stride, int PE_size, double *pWrk, long *pSync);
 void shmem_float_sum_to_all(float *dest, const float *source, int nreduce, int PE_start, int logPE_stride, int PE_size, float *pWrk, long *pSync);
-void shmem_int_sum_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_long_sum_to_all(long *dest, const long *source, int nreduce, int PE_start, int logPE_stride,int PE_size, long *pWrk, long *pSync);
 void shmem_longdouble_sum_to_all(long double *dest, const long double *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long double *pWrk, long *pSync);
 void shmem_longlong_sum_to_all(long long *dest, const long long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long long *pWrk, long *pSync);
-void shmem_short_sum_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 \end{Csynopsis}
 
 \begin{Fsynopsis}
@@ -91,13 +91,13 @@ Performs a product reduction across a set of processing elements (\ac{PE}s).\new
 \begin{Csynopsis}
 void shmem_complexd_prod_to_all(double complex *dest, const double complex *source, int nreduce, int PE_start, int logPE_stride, int PE_size, double complex *pWrk, long |\mbox{*pSync);}|
 void shmem_complexf_prod_to_all(float complex *dest, const float complex *source, int |\mbox{nreduce,}| int PE_start, int logPE_stride, int PE_size, float complex *pWrk, long *pSync);
+void shmem_short_prod_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
+void shmem_int_prod_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_double_prod_to_all(double *dest, const double *source, int nreduce, int PE_start, int logPE_stride, int PE_size, double *pWrk, long *pSync);
 void shmem_float_prod_to_all(float *dest, const float *source, int nreduce, int PE_start, int logPE_stride, int PE_size, float *pWrk, long *pSync);
-void shmem_int_prod_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_long_prod_to_all(long *dest, const long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long *pWrk, long *pSync);
 void shmem_longdouble_prod_to_all(long double *dest, const long double *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long double *pWrk, long *pSync);
 void shmem_longlong_prod_to_all(long long *dest, const long long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long long *pWrk, long *pSync);
-void shmem_short_prod_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 \end{Csynopsis}
 
 \begin{Fsynopsis}
@@ -114,10 +114,10 @@ CALL SHMEM_REAL16_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_
 \textbf{OR} \newline
 Performs  a  bitwise  OR  function reduction across a set of processing elements (\ac{PE}s).\newline
 \begin{Csynopsis}
+void shmem_short_or_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 void shmem_int_or_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_long_or_to_all(long *dest, const long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long *pWrk, long *pSync);
 void shmem_longlong_or_to_all(long long *dest, const long long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long long *pWrk, long *pSync);
-void shmem_short_or_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 \end{Csynopsis}
 
 \begin{Fsynopsis}
@@ -129,10 +129,10 @@ CALL SHMEM_INT8_OR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size
 \textbf{XOR}\newline
 Performs  a  bitwise  EXCLUSIVE OR reduction across a set of processing elements (\ac{PE}s).\newline
 \begin{Csynopsis}
+void shmem_short_xor_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 void shmem_int_xor_to_all(int *dest, const int *source, int nreduce, int PE_start, int logPE_stride, int PE_size, int *pWrk, long *pSync);
 void shmem_long_xor_to_all(long *dest, const long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long *pWrk, long *pSync);
 void shmem_longlong_xor_to_all(long long *dest, const long long *source, int nreduce, int PE_start, int logPE_stride, int PE_size, long long *pWrk, long *pSync);
-void shmem_short_xor_to_all(short *dest, const short *source, int nreduce, int PE_start, int logPE_stride, int PE_size, short *pWrk, long *pSync);
 \end{Csynopsis}
 
 \begin{Fsynopsis}

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -5,14 +5,14 @@
 \begin{apidefinition}
 
 \begin{Csynopsis}
+void shmem_short_wait(volatile short *ivar, short cmp_value);
+void shmem_short_wait_until(volatile short *ivar, int cmp, short cmp_value);
 void shmem_int_wait(volatile int *ivar, int cmp_value);
 void shmem_int_wait_until(volatile int *ivar, int cmp, int cmp_value);
 void shmem_long_wait(volatile long *ivar, long cmp_value);
 void shmem_long_wait_until(volatile long *ivar, int cmp, long cmp_value);
 void shmem_longlong_wait(volatile long long *ivar, long long cmp_value);
 void shmem_longlong_wait_until(volatile long long *ivar, int cmp, long long cmp_value);
-void shmem_short_wait(volatile short *ivar, short cmp_value);
-void shmem_short_wait_until(volatile short *ivar, int cmp, short cmp_value);
 void shmem_wait(volatile long *ivar, long cmp_value);
 void shmem_wait_until(volatile long *ivar, int cmp, long cmp_value);
 \end{Csynopsis}

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -5,16 +5,16 @@
 \begin{apidefinition}
 
 \begin{Csynopsis}
-void shmem_short_wait(volatile short *ivar, short cmp_value);
-void shmem_short_wait_until(volatile short *ivar, int cmp, short cmp_value);
-void shmem_int_wait(volatile int *ivar, int cmp_value);
-void shmem_int_wait_until(volatile int *ivar, int cmp, int cmp_value);
-void shmem_long_wait(volatile long *ivar, long cmp_value);
-void shmem_long_wait_until(volatile long *ivar, int cmp, long cmp_value);
-void shmem_longlong_wait(volatile long long *ivar, long long cmp_value);
-void shmem_longlong_wait_until(volatile long long *ivar, int cmp, long long cmp_value);
-void shmem_wait(volatile long *ivar, long cmp_value);
-void shmem_wait_until(volatile long *ivar, int cmp, long cmp_value);
+void shmem_short_wait(short *ivar, short cmp_value);
+void shmem_short_wait_until(short *ivar, int cmp, short cmp_value);
+void shmem_int_wait(int *ivar, int cmp_value);
+void shmem_int_wait_until(int *ivar, int cmp, int cmp_value);
+void shmem_long_wait(long *ivar, long cmp_value);
+void shmem_long_wait_until(long *ivar, int cmp, long cmp_value);
+void shmem_longlong_wait(long long *ivar, long long cmp_value);
+void shmem_longlong_wait_until(long long *ivar, int cmp, long long cmp_value);
+void shmem_wait(long *ivar, long cmp_value);
+void shmem_wait_until(long *ivar, int cmp, long cmp_value);
 \end{Csynopsis}
 
 \begin{Fsynopsis}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -63,6 +63,8 @@
 \newcommand{\activeset}{\textit{Active~set}\xspace} % why here and not others?
 \newcommand{\shmemprefix}{\textit{SHMEM\_}}
 \newcommand{\shmemprefixC}{\textit{\_SHMEM\_}}
+\newcommand{\ith}{${\textit{i}^{\text{\tiny th}}}$}
+\newcommand{\jth}{${\textit{j}^{\text{\tiny th}}}$}
 
 \begin{acronym}
 \acro{RMA}{\emph{Remote Memory Access}}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -29,7 +29,7 @@
 
 \newcommand{\newtext}[1]{\textcolor{ForestGreen}{#1}}
 \newcommand{\oldtext}[1]{\textcolor{magenta}{\sout{#1}}}
-\newcommand{\insertDocVersion}{1.3}
+\newcommand{\insertDocVersion}{1.5}
 \newcommand{\OSH}{\emph{OpenSHMEM}}
 \newcommand{\openshmem}{{Open\-SHMEM}\xspace}
 \newcommand{\FUNC}[1]{\textit{#1}}

--- a/utils/packages.tex
+++ b/utils/packages.tex
@@ -44,8 +44,8 @@
 \usepackage{enumitem}
 \usepackage{framed}
 \usepackage{pbox} 
-%\usepackage{draftcopy}
-%\usepackage{draftwatermark}
+\usepackage{draftcopy}
+\usepackage{draftwatermark}
 \usepackage{wrapfig}
 \usepackage{caption}
 \usepackage{subcaption}

--- a/utils/packages.tex
+++ b/utils/packages.tex
@@ -13,6 +13,7 @@
 \usepackage{listings}
 % note sure after here
 \usepackage{makeidx}
+\usepackage{amsmath}
 \usepackage[UKenglish]{isodate}
 \usepackage{ifthen}
 \usepackage{textcomp}


### PR DESCRIPTION
Alternative to #3 that completely removes the volatile qualifiers added in OpenSHMEM 1.3