### PR TITLE
Remove volatile qualifiers in wait and lock API

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -351,6 +351,16 @@ specification.
 
 \chapter{Changes to this Document}\label{sec:changelog}
 
+\section{Version 1.4}
+
+\begin{itemize}
+
+\item Volatile qualifiers were added to several API routines in version 1.3 of
+the OpenSHMEM specification; however, they were later found to be unnecessary.
+Thus, the \VAR{volatile} qualifier was removed from the \VAR{ivar} arguments to
+\FUNC{shmem\_wait} routines and the \VAR{lock} arguments in the lock API.
+
+\end{itemize}
 
 \section{Version 1.3}
 This section summarizes the changes from the \openshmem specification Version

--- a/content/shmem_lock.tex
+++ b/content/shmem_lock.tex
@@ -4,9 +4,9 @@
 \begin{apidefinition}
 
 \begin{Csynopsis}
-void shmem_clear_lock(volatile long *lock);
-void shmem_set_lock(volatile long *lock);
-int shmem_test_lock(volatile long *lock);
+void shmem_clear_lock(long *lock);
+void shmem_set_lock(long *lock);
+int shmem_test_lock(long *lock);
 \end{Csynopsis}
 
 \begin{Fsynopsis}

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -5,16 +5,16 @@
 \begin{apidefinition}
 
 \begin{Csynopsis}
-void shmem_short_wait(volatile short *ivar, short cmp_value);
-void shmem_short_wait_until(volatile short *ivar, int cmp, short cmp_value);
-void shmem_int_wait(volatile int *ivar, int cmp_value);
-void shmem_int_wait_until(volatile int *ivar, int cmp, int cmp_value);
-void shmem_long_wait(volatile long *ivar, long cmp_value);
-void shmem_long_wait_until(volatile long *ivar, int cmp, long cmp_value);
-void shmem_longlong_wait(volatile long long *ivar, long long cmp_value);
-void shmem_longlong_wait_until(volatile long long *ivar, int cmp, long long cmp_value);
-void shmem_wait(volatile long *ivar, long cmp_value);
-void shmem_wait_until(volatile long *ivar, int cmp, long cmp_value);
+void shmem_short_wait(short *ivar, short cmp_value);
+void shmem_short_wait_until(short *ivar, int cmp, short cmp_value);
+void shmem_int_wait(int *ivar, int cmp_value);
+void shmem_int_wait_until(int *ivar, int cmp, int cmp_value);
+void shmem_long_wait(long *ivar, long cmp_value);
+void shmem_long_wait_until(long *ivar, int cmp, long cmp_value);
+void shmem_longlong_wait(long long *ivar, long long cmp_value);
+void shmem_longlong_wait_until(long long *ivar, int cmp, long long cmp_value);
+void shmem_wait(long *ivar, long cmp_value);
+void shmem_wait_until(long *ivar, int cmp, long cmp_value);
 \end{Csynopsis}
 
 \begin{Fsynopsis}


### PR DESCRIPTION
Ref: redmine ticket 211 (http://www.openshmem.org/redmine/issues/211)