### PR TITLE
Rename SMA-prefixed env-vars to use SHMEM prefix

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -340,7 +340,9 @@ specification.
     \FUNC{SHMEM\_PUT} & 1.2 & Yes & \FUNC{SHMEM\_PUT8} or \FUNC{SHMEM\_PUT64} \\ \hline
     \FUNC{SHMEM\_CACHE} & 1.3 & Yes & (none) \\ \hline
     \_SHMEM\_* constants & 1.3 & Yes & SHMEM\_* \\ \hline
-    \hline
+%\newtext{
+    SMA\_* environment variables & 1.4 & Yes & SHMEM\_* \\ \hline
+%}
     \end{tabular}
 \end{center}
 
@@ -357,6 +359,10 @@ specification.
 
 \item The \VAR{SHMEM\_SYNC\_SIZE} constant was added.
 \\See Section \ref{subsec:library_constants}.
+%
+\item \newtext{The \texttt{SMA\_}* environment variables were deprecated
+and replaced with \texttt{SHMEM\_}* environment variables.
+\\ See Section \ref{subsec:environment_variables}.}
 
 \end{itemize}
 

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -340,9 +340,7 @@ specification.
     \FUNC{SHMEM\_PUT} & 1.2 & Yes & \FUNC{SHMEM\_PUT8} or \FUNC{SHMEM\_PUT64} \\ \hline
     \FUNC{SHMEM\_CACHE} & 1.3 & Yes & (none) \\ \hline
     \_SHMEM\_* constants & 1.3 & Yes & SHMEM\_* \\ \hline
-%\newtext{
     SMA\_* environment variables & 1.4 & Yes & SHMEM\_* \\ \hline
-%}
     \end{tabular}
 \end{center}
 
@@ -360,9 +358,9 @@ specification.
 \item The \VAR{SHMEM\_SYNC\_SIZE} constant was added.
 \\See Section \ref{subsec:library_constants}.
 %
-\item \newtext{The \texttt{SMA\_}* environment variables were deprecated
-and replaced with \texttt{SHMEM\_}* environment variables.
-\\ See Section \ref{subsec:environment_variables}.}
+\item The \VAR{SMA\_}* environment variables were deprecated and replaced
+      with \VAR{SHMEM\_}* environment variables.
+\\ See Section \ref{subsec:environment_variables}.
 
 \end{itemize}
 

--- a/content/environment_variables.tex
+++ b/content/environment_variables.tex
@@ -3,6 +3,8 @@ users to configure the \openshmem implementation, and receive information about
 the implementation. The implementations of the specification are free to define
 additional variables. Currently, the specification defines four environment
 variables.
+\newtext{All environment variables that start with SMA\_* are deprecated, but
+currently supported for backwards compatibility.}
 
 \medskip{}
 
@@ -11,16 +13,16 @@ variables.
 Variable & Value & Purpose\tabularnewline
 \hline 
 \hline 
-\texttt{SMA\_VERSION} & any & print the library version at
+\texttt{\oldtext{SMA}\newtext{SHMEM}\_VERSION} & any & print the library version at
 start-up\tabularnewline
 \hline 
-\texttt{SMA\_INFO} & any & print helpful text about all these environment
+\texttt{\oldtext{SMA}\newtext{SHMEM}\_INFO} & any & print helpful text about all these environment
 variables\tabularnewline
 \hline 
-\texttt{SMA\_SYMMETRIC\_SIZE} & non-negative integer & number of bytes to
+\texttt{\oldtext{SMA}\newtext{SHMEM}\_SYMMETRIC\_SIZE} & non-negative integer & number of bytes to
 allocate for symmetric heap\tabularnewline
 \hline 
-\texttt{SMA\_DEBUG} & any & enable debugging messages\tabularnewline
+\texttt{\oldtext{SMA}\newtext{SHMEM}\_DEBUG} & any & enable debugging messages\tabularnewline
 \hline 
 \end{tabular}
 

--- a/content/environment_variables.tex
+++ b/content/environment_variables.tex
@@ -2,9 +2,8 @@ The \openshmem specification provides a set of environment variables that allows
 users to configure the \openshmem implementation, and receive information about
 the implementation. The implementations of the specification are free to define
 additional variables. Currently, the specification defines four environment
-variables.
-\newtext{All environment variables that start with SMA\_* are deprecated, but
-currently supported for backwards compatibility.}
+variables. All environment variables that start with \VAR{SMA\_*} are
+deprecated, but currently supported for backwards compatibility.
 
 \medskip{}
 
@@ -13,16 +12,16 @@ currently supported for backwards compatibility.}
 Variable & Value & Purpose\tabularnewline
 \hline 
 \hline 
-\texttt{\oldtext{SMA}\newtext{SHMEM}\_VERSION} & any & print the library version at
+\texttt{SHMEM\_VERSION} & any & print the library version at
 start-up\tabularnewline
 \hline 
-\texttt{\oldtext{SMA}\newtext{SHMEM}\_INFO} & any & print helpful text about all these environment
+\texttt{SHMEM\_INFO} & any & print helpful text about all these environment
 variables\tabularnewline
 \hline 
-\texttt{\oldtext{SMA}\newtext{SHMEM}\_SYMMETRIC\_SIZE} & non-negative integer & number of bytes to
+\texttt{SHMEM\_SYMMETRIC\_SIZE} & non-negative integer & number of bytes to
 allocate for symmetric heap\tabularnewline
 \hline 
-\texttt{\oldtext{SMA}\newtext{SHMEM}\_DEBUG} & any & enable debugging messages\tabularnewline
+\texttt{SHMEM\_DEBUG} & any & enable debugging messages\tabularnewline
 \hline 
 \end{tabular}
 

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -77,7 +77,7 @@ void *shmem_align(size_t alignment, size_t size);
     remains unchanged from the deprecated versions.
     					 
     The total size of the symmetric heap is determined at job startup.  One can
-    adjust the size of the heap using the \CONST{SMA\_SYMMETRIC\_SIZE} environment
+    adjust the size of the heap using the \CONST{\oldtext{SMA}\newtext{SHMEM}\_SYMMETRIC\_SIZE} environment
     variable (where available).	
     
     The \FUNC{shmem\_malloc}, \FUNC{shmem\_free}, and \FUNC{shmem\_realloc} routines

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -77,7 +77,7 @@ void *shmem_align(size_t alignment, size_t size);
     remains unchanged from the deprecated versions.
     					 
     The total size of the symmetric heap is determined at job startup.  One can
-    adjust the size of the heap using the \CONST{\oldtext{SMA}\newtext{SHMEM}\_SYMMETRIC\_SIZE} environment
+    adjust the size of the heap using the \CONST{SHMEM\_SYMMETRIC\_SIZE} environment
     variable (where available).	
     
     The \FUNC{shmem\_malloc}, \FUNC{shmem\_free}, and \FUNC{shmem\_realloc} routines

--- a/content/shpalloc.tex
+++ b/content/shpalloc.tex
@@ -38,7 +38,7 @@ CALL SHPALLOC(addr, length, errcode, abort)
 
 \apinotes{  
     The total size of the symmetric heap is determined at job startup.  One may
-    adjust the size of the heap using the \CONST{SMA\_SYMMETRIC\_SIZE} environment
+    adjust the size of the heap using the \CONST{\oldtext{SMA}\newtext{SHMEM}\_SYMMETRIC\_SIZE} environment
     variable (if available).	
 }
 

--- a/content/shpalloc.tex
+++ b/content/shpalloc.tex
@@ -38,7 +38,7 @@ CALL SHPALLOC(addr, length, errcode, abort)
 
 \apinotes{  
     The total size of the symmetric heap is determined at job startup.  One may
-    adjust the size of the heap using the \CONST{\oldtext{SMA}\newtext{SHMEM}\_SYMMETRIC\_SIZE} environment
+    adjust the size of the heap using the \CONST{SHMEM\_SYMMETRIC\_SIZE} environment
     variable (if available).	
 }
 


### PR DESCRIPTION
This PR renames SMA-prefixed environment variables to use the SHMEM prefix.

This is Redmine ticket 222. This ticket had a formal reading at the August 2016 meeting, but this PR includes subsequent changes to note the deprecated env-vars and update the deprecation and change-log annexes. Merge is pending special ballot and formal ballot.