### PR TITLE
Add _Noreturn specifier to shmem_global_exit

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -358,8 +358,8 @@ specification.
 \item The \VAR{SHMEM\_SYNC\_SIZE} constant was added.
 \\See Section \ref{subsec:library_constants}.
 %
-\item \newtext{The C11 \textbf{\_Noreturn} function specifier and the C++11
-\textbf{noreturn} attribute were added to \FUNC{shmem\_global\_exit}.
+\item \newtext{The C11 \textbf{\_Noreturn} function specifier was added to
+  \FUNC{shmem\_global\_exit}.
 \\ See Section \ref{subsec:shmem_global_exit}.}
 
 \end{itemize}

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -358,9 +358,9 @@ specification.
 \item The \VAR{SHMEM\_SYNC\_SIZE} constant was added.
 \\See Section \ref{subsec:library_constants}.
 %
-\item \newtext{The C11 \textbf{\_Noreturn} function specifier was added to
-  \FUNC{shmem\_global\_exit}.
-\\ See Section \ref{subsec:shmem_global_exit}.}
+\item The C11 \textbf{\_Noreturn} function specifier was added to
+      \FUNC{shmem\_global\_exit}.
+\\ See Section \ref{subsec:shmem_global_exit}.
 
 \end{itemize}
 

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -357,6 +357,10 @@ specification.
 
 \item The \VAR{SHMEM\_SYNC\_SIZE} constant was added.
 \\See Section \ref{subsec:library_constants}.
+%
+\item \newtext{The C11 \textbf{\_Noreturn} function specifier and the C++11
+\textbf{noreturn} attribute were added to \FUNC{shmem\_global\_exit}.
+\\ See Section \ref{subsec:shmem_global_exit}.}
 
 \end{itemize}
 

--- a/content/shmem_global_exit.tex
+++ b/content/shmem_global_exit.tex
@@ -4,6 +4,14 @@
 
 \begin{apidefinition}
 
+\begin{Cpp11synopsis}
+[[noreturn]] void shmem_global_exit(int status);
+\end{Cpp11synopsis}
+
+\begin{C11synopsis}
+_Noreturn void shmem_global_exit(int status);
+\end{C11synopsis}
+
 \begin{Csynopsis}
 void shmem_global_exit(int status);
 \end{Csynopsis}

--- a/content/shmem_global_exit.tex
+++ b/content/shmem_global_exit.tex
@@ -4,10 +4,6 @@
 
 \begin{apidefinition}
 
-\begin{Cpp11synopsis}
-[[noreturn]] void shmem_global_exit(int status);
-\end{Cpp11synopsis}
-
 \begin{C11synopsis}
 _Noreturn void shmem_global_exit(int status);
 \end{C11synopsis}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -320,11 +320,17 @@ minus .2ex}{-1em}{\normalsize\sf}}
 \end{description}
 }
 
+\lstnewenvironment{Cpp11synopsis}
+{
+  \textbf{C++11:}
+  \lstset{language={C++}, backgroundcolor=\color{gray}, lineskip=2pt,
+  morekeywords={size_t, TYPE, noreturn}, aboveskip=0pt, belowskip=0pt}}{}
+
 \lstnewenvironment{C11synopsis}
 { 
   \textbf{C11:} 
-  \lstset{language={C++}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, TYPE}, aboveskip=0pt, belowskip=0pt,}}{}
+  \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
+  morekeywords={size_t, TYPE, _Noreturn}, aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
 { 


### PR DESCRIPTION
This PR adds the `_Noreturn` function specifier (C11) and `noreturn` attribute (C++11) to `shmem_global_exit`.

This is Redmine ticket 223. This ticket had a formal reading at the August 2016 meeting, but this PR includes subsequent changes to add C++11 support (as well as change highlighting). Merge is pending special ballot and formal ballot.