### PR TITLE
Generic shmem_wait interfaces

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -358,10 +358,8 @@ specification.
 \item The \VAR{SHMEM\_SYNC\_SIZE} constant was added.
 \\See Section \ref{subsec:library_constants}.
 %
-\newtext{%
 \item Added type-generic interfaces for \FUNC{SHMEM\_WAIT}.
-\\See Section \ref{subsec:shmem_wait}.
-}
+\\ See Section \ref{subsec:shmem_wait}.
 
 \end{itemize}
 

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -357,6 +357,11 @@ specification.
 
 \item The \VAR{SHMEM\_SYNC\_SIZE} constant was added.
 \\See Section \ref{subsec:library_constants}.
+%
+\newtext{%
+\item Added type-generic interfaces for \FUNC{SHMEM\_WAIT}.
+\\See Section \ref{subsec:shmem_wait}.
+}
 
 \end{itemize}
 

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -5,15 +5,15 @@
 \begin{apidefinition}
 
 \begin{C11synopsis}
-void shmem_wait(volatile TYPE *ivar, TYPE cmp_value);
-void shmem_wait_until(volatile TYPE *ivar, int cmp, TYPE cmp_value);
+void shmem_wait(TYPE *ivar, TYPE cmp_value);
+void shmem_wait_until(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{C11synopsis}
 where \TYPE{} is one of the point-to-point synchronization types specified by
 Table \ref{p2psynctypes}.
 
 \begin{Csynopsis}
-void shmem_<TYPENAME>_wait(volatile TYPE *ivar, TYPE cmp_value);
-void shmem_<TYPENAME>_wait_until(volatile TYPE *ivar, int cmp, TYPE cmp_value);
+void shmem_<TYPENAME>_wait(TYPE *ivar, TYPE cmp_value);
+void shmem_<TYPENAME>_wait_until(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the point-to-point synchronization types and has a
 corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -108,7 +108,7 @@ CALL SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)
 \begin{apiexamples}
 
 \apifexample
-{ The following call returns when variable ivar is not equal to 100:}
+{ The following call returns when variable \VAR{ivar} is not equal to 100:}
 {./example_code/shmem_wait1_example.f90}
 {}
 
@@ -119,7 +119,8 @@ call to \FUNC{SHMEM\_INT8\_WAIT} in example 1:}
 {}
 
 \apicexample
-{The following \CorCpp{} call waits until the sign bit in ivar is set by a
+{The following \CorCpp{} call waits until the \oldtext{sign bit}
+\newtext{value} in \VAR{ivar} is set \newtext{to be less than zero} by a
 transfer from a remote PE:}
 {./example_code/shmem_wait3_example.f90}
 {}

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -111,9 +111,8 @@ call to \FUNC{SHMEM\_INT8\_WAIT} in example 1:}
 {}
 
 \apicexample
-{The following \CorCpp{} call waits until the \oldtext{sign bit}
-\newtext{value} in \VAR{ivar} is set \newtext{to be less than zero} by a
-transfer from a remote PE:}
+{The following \CorCpp{} call waits until the value in \VAR{ivar} is set to
+be less than zero by a transfer from a remote PE:}
 {./example_code/shmem_wait3_example.f90}
 {}
 

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -4,18 +4,19 @@
 
 \begin{apidefinition}
 
+\begin{C11synopsis}
+void shmem_wait(volatile TYPE *ivar, TYPE cmp_value);
+void shmem_wait_until(volatile TYPE *ivar, int cmp, TYPE cmp_value);
+\end{C11synopsis}
+where \TYPE{} is one of the point-to-point synchronization types specified by
+Table \ref{p2psynctypes}.
+
 \begin{Csynopsis}
-void shmem_short_wait(volatile short *ivar, short cmp_value);
-void shmem_short_wait_until(volatile short *ivar, int cmp, short cmp_value);
-void shmem_int_wait(volatile int *ivar, int cmp_value);
-void shmem_int_wait_until(volatile int *ivar, int cmp, int cmp_value);
-void shmem_long_wait(volatile long *ivar, long cmp_value);
-void shmem_long_wait_until(volatile long *ivar, int cmp, long cmp_value);
-void shmem_longlong_wait(volatile long long *ivar, long long cmp_value);
-void shmem_longlong_wait_until(volatile long long *ivar, int cmp, long long cmp_value);
-void shmem_wait(volatile long *ivar, long cmp_value);
-void shmem_wait_until(volatile long *ivar, int cmp, long cmp_value);
+void shmem_<TYPENAME>_wait(volatile TYPE *ivar, TYPE cmp_value);
+void shmem_<TYPENAME>_wait_until(volatile TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
+where \TYPE{} is one of the point-to-point synchronization types and has a
+corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
 
 \begin{Fsynopsis}
 CALL SHMEM_INT4_WAIT(ivar, cmp_value)

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -73,15 +73,7 @@ CALL SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)
     The following \VAR{cmp} values are supported:
 }{CMP Value}{Comparison}
 
-\CorCpp:\\
-\apitablerow{SHMEM\_CMP\_EQ }{  Equal}
-\apitablerow{SHMEM\_CMP\_NE}{Not equal}
-\apitablerow{SHMEM\_CMP\_GT}{Greater than}
-\apitablerow{SHMEM\_CMP\_LE}{Less than or equal to}
-\apitablerow{SHMEM\_CMP\_LT}{Less than}
-\apitablerow{SHMEM\_CMP\_GE}{Greater than or equal to}
-\\
-\Fortran:\\
+\CorCppFor:\\
 \apitablerow{SHMEM\_CMP\_EQ }{  Equal}
 \apitablerow{SHMEM\_CMP\_NE}{Not equal}
 \apitablerow{SHMEM\_CMP\_GT}{Greater than}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -200,6 +200,31 @@ The following section discusses \openshmem \ac{API}s that provides a mechanism
 for synchronization between two \ac{PE}s based on the value of a symmetric data
 object. 
 
+\newtext{%
+Where appropriate compiler support is available, \openshmem provides
+type-generic point-to-point synchronization interfaces via \Celev{} generic
+selection. Such type-generic routines are supported for the
+``point-to-point synchronization types'' identified in
+Table~\ref{p2psynctypes}. Implementations may optionally support additional
+types.%
+}
+
+\begin{table}[h]
+  \begin{center}
+    \begin{tabular}{|l|l|}
+      \hline
+      \TYPE     & \TYPENAME \\ \hline
+      short     & short     \\ \hline
+      int       & int       \\ \hline
+      long      & long      \\ \hline
+      long long & longlong  \\ \hline
+    \end{tabular}
+    \caption{Point-to-Point Synchronization Types and Names}
+    \label{p2psynctypes}
+  \end{center}
+\end{table}
+
+
 \subsubsection{\textbf{SHMEM\_WAIT}}\label{subsec:shmem_wait}
 \input{content/shmem_wait.tex}
 

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -200,14 +200,12 @@ The following section discusses \openshmem \ac{API}s that provides a mechanism
 for synchronization between two \ac{PE}s based on the value of a symmetric data
 object. 
 
-\newtext{%
 Where appropriate compiler support is available, \openshmem provides
 type-generic point-to-point synchronization interfaces via \Celev{} generic
 selection. Such type-generic routines are supported for the
 ``point-to-point synchronization types'' identified in
 Table~\ref{p2psynctypes}. Implementations may optionally support additional
-types.%
-}
+types.
 
 \begin{table}[h]
   \begin{center}


### PR DESCRIPTION
This PR adds generic interfaces for `shmem_wait` and `shmem_wait_until`.

This is Redmine ticket 216. This ticket had a formal reading at the August 2016 meeting, but this PR has a mostly-cosmetic cleanup in `shmem_wait` to condense redundant tables for C/C++ and Fortran. Merge is pending special ballot and formal ballot.

This ticket has a dependence on PR #6.