### PR TITLE
Correct active set indexing in a2a

### DIFF
--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -57,8 +57,10 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     an element (32 bits or 64 bits) times \VAR{PE\_size}.
     The \VAR{source} object contains \VAR{PE\_size} blocks of data (the size of each
     block defined by \VAR{nelems}) and each block of data is sent to a different \ac{PE}. 
-    \ac{PE} \VAR{i} sends the \jth block of its \VAR{source} object to
-    \ac{PE} \VAR{j} and that block of data is placed in the \ith block of
+    Given a \ac{PE} \VAR{i} that is the \kth PE in the active set and a \ac{PE}
+    \VAR{j} that is the \lth \ac{PE} in the active set,
+    \ac{PE} \VAR{i} sends the \lth block of its \VAR{source} object to
+    \ac{PE} \VAR{j} and that block of data is placed in the \kth block of
     the \VAR{dest} object of \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, this routine assumes

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -60,7 +60,7 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     Given a \ac{PE} \VAR{i} that is the \kth PE in the active set and a \ac{PE}
     \VAR{j} that is the \lth \ac{PE} in the active set,
     \ac{PE} \VAR{i} sends the \lth block of its \VAR{source} object to
-    \ac{PE} \VAR{j} and that block of data is placed in the \kth block of
+    the \kth block of
     the \VAR{dest} object of \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, this routine assumes

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -63,8 +63,11 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     in the \activeset{} exchanges \VAR{nelems} strided data elements of size
     32 bits (for \FUNC{shmem\_alltoalls32}) or 64 bits (for \FUNC{shmem\_alltoalls64})
     with all other \acp{PE} in the set. Both strides, \VAR{dst} and \VAR{sst}, must be greater
-    than or equal to \CONST{1}. The \VAR{sst}*\jth block sent from \ac{PE} \VAR{i} to
-    \ac{PE} \VAR{j} is placed in the \VAR{dst}*\ith block of the \VAR{dest} data object on
+    than or equal to \CONST{1}.
+    Given a \ac{PE} \VAR{i} that is the \kth PE in the active set and a \ac{PE}
+    \VAR{j} that is the \lth \ac{PE} in the active set,
+    the \VAR{sst}*\lth block sent from \ac{PE} \VAR{i} to
+    \ac{PE} \VAR{j} is placed in the \VAR{dst}*\kth block of the \VAR{dest} data object on
     \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, these routines assume

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -66,8 +66,8 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     than or equal to \CONST{1}.
     Given a \ac{PE} \VAR{i} that is the \kth PE in the active set and a \ac{PE}
     \VAR{j} that is the \lth \ac{PE} in the active set,
-    the \VAR{sst}*\lth block sent from \ac{PE} \VAR{i} to
-    \ac{PE} \VAR{j} is placed in the \VAR{dst}*\kth block of the \VAR{dest} data object on
+    \ac{PE} \VAR{i} sends the \VAR{sst}*\lth block of the \VAR{source} data object to
+    the \VAR{dst}*\kth block of the \VAR{dest} data object on
     \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, these routines assume

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -65,6 +65,8 @@
 \newcommand{\shmemprefixC}{\textit{\_SHMEM\_}}
 \newcommand{\ith}{${\textit{i}^{\text{\tiny th}}}$}
 \newcommand{\jth}{${\textit{j}^{\text{\tiny th}}}$}
+\newcommand{\kth}{${\textit{k}^{\text{\tiny th}}}$}
+\newcommand{\lth}{${\textit{l}^{\text{\tiny th}}}$}
 
 \begin{acronym}
 \acro{RMA}{\emph{Remote Memory Access}}


### PR DESCRIPTION
Buffer indexing in all-to-all collectives was incorrect for active sets
that contain a subset of PEs.

Ref: redmine ticket 208 (http://www.openshmem.org/redmine/issues/208).
