### PR TITLE
Add Makefile for examples

### DIFF
--- a/example_code/Makefile
+++ b/example_code/Makefile
@@ -1,0 +1,30 @@
+CC       = oshcc
+CFLAGS   = -Wall -O3
+
+FC       = oshfort
+FFLAGS   = -Wall -O3
+
+RUNCMD   = oshrun
+RUNOPT   = -np 2
+
+C_TESTS  = $(wildcard *.c)
+C_BINS   = $(C_TESTS:.c=.cx)
+
+F_TESTS  = $(wildcard *.f90)
+F_BINS   = $(F_TESTS:.f90=.fx)
+
+.PHONY: all run clean
+
+all: $(C_BINS) $(F_BINS)
+
+%.cx: %.c
+	$(CC) $(CFLAGS) -o $@ $+
+
+%.fx: %.f90
+	$(FC) $(FFLAGS) -o $@ $+
+
+run: $(C_BINS) $(F_BINS)
+	for bin in $+; do $(RUNCMD) $(RUNOPT) ./$$bin; done
+
+clean:
+	rm -f $(C_BINS) $(F_BINS)

--- a/example_code/Makefile
+++ b/example_code/Makefile
@@ -24,7 +24,7 @@ all: $(C_BINS) $(F_BINS)
 	$(FC) $(FFLAGS) -o $@ $+
 
 run: $(C_BINS) $(F_BINS)
-	for bin in $+; do $(RUNCMD) $(RUNOPT) ./$$bin; done
+	for bin in $+; do $(RUNCMD) $(RUNOPT) ./$$bin || exit $$?; done
 
 clean:
 	rm -f $(C_BINS) $(F_BINS)

--- a/example_code/Makefile
+++ b/example_code/Makefile
@@ -5,7 +5,7 @@ FC       = oshfort
 FFLAGS   = -Wall -O3
 
 RUNCMD   = oshrun
-RUNOPT   = -np 2
+RUNOPT   = -np 4
 
 C_TESTS  = $(wildcard *.c)
 C_BINS   = $(C_TESTS:.c=.cx)

--- a/example_code/Makefile
+++ b/example_code/Makefile
@@ -1,8 +1,8 @@
 CC       = oshcc
-CFLAGS   = -Wall -O3
+CFLAGS  ?= -Wall -Wextra
 
 FC       = oshfort
-FFLAGS   = -Wall -O3
+FFLAGS  ?= -Wall -Wextra
 
 RUNCMD   = oshrun
 RUNOPT   = -np 4

--- a/example_code/Makefile
+++ b/example_code/Makefile
@@ -23,8 +23,11 @@ all: $(C_BINS) $(F_BINS)
 %.fx: %.f90
 	$(FC) $(FFLAGS) -o $@ $+
 
-run: $(C_BINS) $(F_BINS)
-	for bin in $+; do $(RUNCMD) $(RUNOPT) ./$$bin || exit $$?; done
+run: $(C_BINS)
+	@for bin in $+; do				\
+	    echo --$$bin------------------------------;	\
+	    $(RUNCMD) $(RUNOPT) ./$$bin || exit $$?;	\
+	done
 
 clean:
 	rm -f $(C_BINS) $(F_BINS)


### PR DESCRIPTION
This PR only adds the makefile for automating building and running the examples.  It's not perfect, but it should be a reasonable start for us to build on.

Note: the Fortran tests are not even compiling right now, so they are omitted from the ```run``` target.

Needs two reviews to merge: @dkhaldi @shamisp or others, please help