### PR TITLE
Fix bugs in the C examples

### DIFF
--- a/example_code/hello-openshmem.c
+++ b/example_code/hello-openshmem.c
@@ -10,5 +10,6 @@ main (int argc, char *argv[])
   nprocs = shmem_n_pes ();
   me = shmem_my_pe ();
   printf ("Hello from %d of %d\n", me, nprocs);
+  shmem_finalize();
   return 0;
 }

--- a/example_code/shmem_add_example.c
+++ b/example_code/shmem_add_example.c
@@ -18,5 +18,6 @@ int main(void)
    }
    shmem_barrier_all();
    printf("%d: old = %d, dst = %d\n", me, old, dst);
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_add_example.c
+++ b/example_code/shmem_add_example.c
@@ -14,7 +14,7 @@ int main(void)
    shmem_barrier_all();
 
    if (me == 1){
-      old = shmem_int_fadd(&dst, 44, 0);
+      old = shmem_fadd(&dst, 44, 0);
    }
    shmem_barrier_all();
    printf("%d: old = %d, dst = %d\n", me, old, dst);

--- a/example_code/shmem_add_example.c
+++ b/example_code/shmem_add_example.c
@@ -14,7 +14,7 @@ int main(void)
    shmem_barrier_all();
 
    if (me == 1){
-      old = shmem_add(&dst, 44, 0);
+      old = shmem_int_fadd(&dst, 44, 0);
    }
    shmem_barrier_all();
    printf("%d: old = %d, dst = %d\n", me, old, dst);

--- a/example_code/shmem_add_example.c
+++ b/example_code/shmem_add_example.c
@@ -3,21 +3,20 @@
 
 int main(void) 
 {
-   int me, old;
+   int me;
    static int dst;
 
    shmem_init();
    me = shmem_my_pe();
 
-   old = -1;
    dst = 22;
    shmem_barrier_all();
 
    if (me == 1){
-      old = shmem_fadd(&dst, 44, 0);
+      shmem_add(&dst, 44, 0);
    }
    shmem_barrier_all();
-   printf("%d: old = %d, dst = %d\n", me, old, dst);
+   printf("%d: dst = %d\n", me, dst);
    shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_alltoall_example.c
+++ b/example_code/shmem_alltoall_example.c
@@ -1,5 +1,6 @@
-#include <shmem.h>
 #include <stdio.h>
+#include <inttypes.h>
+#include <shmem.h>
 
 long pSync[SHMEM_ALLTOALL_SYNC_SIZE];
 
@@ -35,7 +36,7 @@ int main(void)
     for (pe=0; pe<shmem_n_pes(); pe++) {
        for (i=0; i<count; i++){
           if (dest[(pe*count)+i] != shmem_my_pe() + pe) {
-          printf("[%d] ERROR: dest[%d]=%ld, should be %d\n",
+          printf("[%d] ERROR: dest[%d]=%" PRId64 ", should be %d\n",
                   shmem_my_pe(),(pe*count)+i,dest[(pe*count)+i],
                   shmem_n_pes() + pe);
             }

--- a/example_code/shmem_alltoalls_example.c
+++ b/example_code/shmem_alltoalls_example.c
@@ -1,5 +1,6 @@
-#include <shmem.h>
 #include <stdio.h>
+#include <inttypes.h>
+#include <shmem.h>
 
 long pSync[SHMEM_ALLTOALLS_SYNC_SIZE];
 
@@ -35,7 +36,7 @@ int main(void)
     for (pe=0; pe<shmem_n_pes(); pe++) {
        for (i=0; i<count; i++){
           if (dest[(pe*count)+i] != shmem_my_pe() + pe) {
-          printf("[%d] ERROR: dest[%d]=%ld, should be %d\n",
+          printf("[%d] ERROR: dest[%d]=%" PRId64 ", should be %d\n",
                   shmem_my_pe(),(pe*count)+i,dest[(pe*count)+i],
                   shmem_n_pes() + pe);
             }

--- a/example_code/shmem_barrier_example.c
+++ b/example_code/shmem_barrier_example.c
@@ -24,5 +24,6 @@ int main(void)
       shmem_barrier(0, 1, (npes/2 + npes%2), pSync);
    }
    printf("%d: x = %d\n", me, x);
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_barrierall_example.c
+++ b/example_code/shmem_barrierall_example.c
@@ -17,5 +17,6 @@ int main(void)
    shmem_barrier_all();
 
    printf("%d: x = %d\n", me, x);
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_broadcast_example.c
+++ b/example_code/shmem_broadcast_example.c
@@ -27,5 +27,6 @@ int main(void)
    for (i = 1; i < NUM_ELEMS; i++)
       printf(", %ld", dest[i]);
    printf("\n");
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_collect_example.c
+++ b/example_code/shmem_collect_example.c
@@ -27,5 +27,6 @@ int main(void)
    for (i = 1; i < npes * 2; i++)
       printf(", %d", dest[i]);
    printf("\n");
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_cswap_example.c
+++ b/example_code/shmem_cswap_example.c
@@ -9,4 +9,5 @@ int main(void)
    oldval = shmem_cswap(&race_winner, -1, shmem_my_pe(), 0);
    if(oldval == -1) printf("pe %d was first\n",shmem_my_pe());
    shmem_finalize();
+   return 0;
 }

--- a/example_code/shmem_cswap_example.c
+++ b/example_code/shmem_cswap_example.c
@@ -8,5 +8,5 @@ int main(void)
    shmem_init();
    oldval = shmem_cswap(&race_winner, -1, shmem_my_pe(), 0);
    if(oldval == -1) printf("pe %d was first\n",shmem_my_pe());
-   return 1;
+   shmem_finalize();
 }

--- a/example_code/shmem_fadd_example.c
+++ b/example_code/shmem_fadd_example.c
@@ -18,5 +18,6 @@ int main(void)
    }
    shmem_barrier_all();
    printf("%d: old = %d, dst = %d\n", me, old, dst);
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_fence_example.c
+++ b/example_code/shmem_fence_example.c
@@ -18,5 +18,6 @@ int main(void)
   }
   shmem_barrier_all();  /* sync sender and receiver */
   printf("dest[0] on PE %d is %ld\n", shmem_my_pe(), dest[0]);
-  return 1;
+  shmem_finalize();
+  return 0;
 }

--- a/example_code/shmem_finc_example.c
+++ b/example_code/shmem_finc_example.c
@@ -20,5 +20,6 @@ int main(void)
 
    shmem_barrier_all();
    printf("%d: old = %d, dst = %d\n", me, old, dst);
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_g_example.c
+++ b/example_code/shmem_g_example.c
@@ -17,5 +17,6 @@ int main(void)
 
    printf("%d: y = %ld\n", me, y);
 
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_global_exit_example.c
+++ b/example_code/shmem_global_exit_example.c
@@ -5,12 +5,11 @@
 int
 main(void)
 {
-  int me, npes; 
+  int me;
 
   shmem_init();
 
   me = shmem_my_pe();
-  npes = shmem_n_pes();
 
   if (me == 0) {
     FILE *fp = fopen("input.txt", "r"); 

--- a/example_code/shmem_global_exit_example.c
+++ b/example_code/shmem_global_exit_example.c
@@ -24,5 +24,6 @@ main(void)
     fclose(fp);
   }
 
+  shmem_finalize();
   return 0;
 }

--- a/example_code/shmem_inc_example.c
+++ b/example_code/shmem_inc_example.c
@@ -18,5 +18,6 @@ int main(void)
    shmem_barrier_all();
 
    printf("%d: dst = %d\n", me, dst);
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_iput_example.c
+++ b/example_code/shmem_iput_example.c
@@ -17,6 +17,6 @@ int main(void)
       (int)dest[0], (int)dest[1], (int)dest[2],
       (int)dest[3], (int)dest[4] );
    }
-   shmem_finalize();   /* sync before exiting */
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_iput_example.c
+++ b/example_code/shmem_iput_example.c
@@ -17,6 +17,6 @@ int main(void)
       (int)dest[0], (int)dest[1], (int)dest[2],
       (int)dest[3], (int)dest[4] );
    }
-   shmem_barrier_all();   /* sync before exiting */
+   shmem_finalize();   /* sync before exiting */
    return 0;
 }

--- a/example_code/shmem_lock_example.c
+++ b/example_code/shmem_lock_example.c
@@ -17,6 +17,6 @@ int main(int argc, char **argv)
    sleep(slp);
    printf("%d: sleeping...done\n", me);
    shmem_clear_lock(&L);
-   shmem_barrier_all();
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_mype_example.c
+++ b/example_code/shmem_mype_example.c
@@ -9,5 +9,6 @@ int main(void)
   me = shmem_my_pe();
   printf("My PE id is: %d\n", me);
 
+  shmem_finalize();
   return 0;
 }

--- a/example_code/shmem_npes_example.c
+++ b/example_code/shmem_npes_example.c
@@ -13,5 +13,6 @@ int main(void)
     printf("Number of PEs executing this program is: %d\n", npes);
   }
 
+  shmem_finalize();
   return 0;
 }

--- a/example_code/shmem_p_example.c
+++ b/example_code/shmem_p_example.c
@@ -23,5 +23,6 @@ int main(void)
    if (me == 1)
       printf("%s\n", (fabs (*f - e) < epsilon) ? "OK" : "FAIL");
 
+   shmem_finalize();
    return 0;
 }

--- a/example_code/shmem_ptr_example.c
+++ b/example_code/shmem_ptr_example.c
@@ -27,5 +27,6 @@ int main(void)
          printf(" %d\n",bigd[i]);
       printf("\n");
    }
-  return 1;
+   shmem_finalize();
+   return 0;
 }

--- a/example_code/shmem_put_example.c
+++ b/example_code/shmem_put_example.c
@@ -13,6 +13,7 @@ int main(void)
    }
    shmem_barrier_all();  /* sync sender and receiver */
    printf("dest[0] on PE %d is %ld\n", shmem_my_pe(), dest[0]);
+   shmem_finalize();
    return 0;
 }
 

--- a/example_code/shmem_quiet_example.c
+++ b/example_code/shmem_quiet_example.c
@@ -26,7 +26,6 @@ int main(void)
     shmem_int_put(&targ, &src, 1, 1);  /*put3*/
     shmem_int_put(&targ, &src, 1, 2);  /*put4*/
   }
-  shmem_barrier_all();  /* sync sender and receiver */
   shmem_finalize();
   return 0;
 }

--- a/example_code/shmem_quiet_example.c
+++ b/example_code/shmem_quiet_example.c
@@ -27,6 +27,7 @@ int main(void)
     shmem_int_put(&targ, &src, 1, 2);  /*put4*/
   }
   shmem_barrier_all();  /* sync sender and receiver */
+  shmem_finalize();
   return 0;
 }
 

--- a/example_code/shmem_swap_example.c
+++ b/example_code/shmem_swap_example.c
@@ -19,5 +19,6 @@ int main(void)
       printf("%d: dest = %ld, swapped = %ld\n", me, *dest, swapped_val);
    }
    shmem_free(dest);
+   shmem_finalize();
    return 0;
 }


### PR DESCRIPTION
Bugs fixed:
- Add missing calls to `shmem_finalize()`
- Ensure tests exit with code 0 on success
- shmem_add_example.c: replace `shmem_add` with `shmem_fadd` (transcription error in preview version of the spec)
