### PR TITLE
Verbiage cleanup of Annex G ("Changes to this Document")

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -355,23 +355,25 @@ specification.
 
 \begin{itemize}
 %
-\item The \VAR{SHMEM\_SYNC\_SIZE} constant was added.
+\item Added the \VAR{SHMEM\_SYNC\_SIZE} constant.
 \\See Section \ref{subsec:library_constants}.
 %
 \item Added type-generic interfaces for \FUNC{SHMEM\_WAIT}.
 \\ See Section \ref{subsec:shmem_wait}.
 %
-\item Volatile qualifiers were added to several API routines in version 1.3 of
-the OpenSHMEM specification; however, they were later found to be unnecessary.
-Thus, the \VAR{volatile} qualifier was removed from the \VAR{ivar} arguments to
+\item Removed the \VAR{volatile} qualifiers from the \VAR{ivar} arguments to
 \FUNC{shmem\_wait} routines and the \VAR{lock} arguments in the lock API.
+\emph{Rationale: Volatile qualifiers were added to several API routines in
+version 1.3 of the OpenSHMEM specification; however, they were later found
+to be unnecessary.}
+\\ See Sections \ref{subsec:shmem_wait} and \ref{subsec:shmem_lock}.
 %
-\item The \VAR{SMA\_}* environment variables were deprecated and replaced
-      with \VAR{SHMEM\_}* environment variables.
+\item Deprecated the \VAR{SMA\_}* environment variables and added equivalent
+\VAR{SHMEM\_}* environment variables.
 \\ See Section \ref{subsec:environment_variables}.
 %
-\item The C11 \textbf{\_Noreturn} function specifier was added to
-      \FUNC{shmem\_global\_exit}.
+\item Added the C11 \textbf{\_Noreturn} function specifier to
+\FUNC{shmem\_global\_exit}.
 \\ See Section \ref{subsec:shmem_global_exit}.
 
 \end{itemize}


### PR DESCRIPTION
At the specification meeting when #14, #15, and #16 were ratified, I took the action to clean up the verbiage for Annex G. This PR updates the change log for "1.5".