### PR TITLE
Improve shmemx.h portability

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -373,6 +373,10 @@ Thus, the \VAR{volatile} qualifier was removed from the \VAR{ivar} arguments to
 \item The C11 \textbf{\_Noreturn} function specifier was added to
       \FUNC{shmem\_global\_exit}.
 \\ See Section \ref{subsec:shmem_global_exit}.
+%
+\item Added the \VAR{SHMEM\_PROVIDES\_SHMEMX\_H} constant and clarification
+      that the \FUNC{shmemx.h} header is optional.
+\\ See Sections \ref{subsec:bindings} and \ref{subsec:library_constants}.
 
 \end{itemize}
 

--- a/content/language_bindings_and_conformance.tex
+++ b/content/language_bindings_and_conformance.tex
@@ -17,3 +17,5 @@ variables, or identifiers with the prefix \shmemprefix (for \Clang{} and
 All \openshmem extension \ac{API}s that are not part of this specification must
 be defined in the \FUNC{shmemx.h} include file. These extensions shall use the
 \FUNC{shmemx\_} prefix for all routine, variable, and constant names.
+The existence of the \FUNC{shmemx.h} header is optional, but indicated through
+a compile-time constant (Section~\ref{subsec:library_constants}).

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -132,6 +132,14 @@ String representing the vendor name of length less than
 and whitespace padded.  It can also be equal in length to \const{SHMEM\_MAX\_NAME\_LEN} 
 since Fortran does not NULL terminate strings. \tabularnewline
 \hline
+\vspace{3mm}
+\vtop{\hbox{\CorCppFor:}
+\hbox{\hspace*{12mm} \const{SHMEM\_PROVIDES\_SHMEMX\_H}}}
+&
+An integer constant expression indicating whether a \FUNC{shmemx.h} header is
+provided. A non-zero value shall indicate that a \FUNC{shmemx.h} header is
+available for inclusion; otherwise, the value shall be zero. \tabularnewline
+\hline
 
 \end{tabular}
 \color{black}


### PR DESCRIPTION
This PR adds `SHMEM_PROVIDES_SHMEMX_H` constant and identifies `shmemx.h` as an optional header.

See Redmine [Issue 219](http://www.openshmem.org/redmine/issues/219).