### PR TITLE
Update SHMEM_SYNC_SIZE constant listing

### DIFF
--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -11,10 +11,9 @@ All constants that start with
 \hline 
 \hline
 %new
-\vtop{\hbox{\CorCpp:}
-\hbox{\hspace*{12mm} \const{SHMEM\_SYNC\_SIZE}} 
-\hbox{\strut \Fortran:} 
-\hbox{\hspace*{12mm} \const{SHMEM\_SYNC\_SIZE}}} 
+\vspace{3mm}
+\vtop{\hbox{\CorCppFor:}
+\hbox{\hspace*{12mm} \const{SHMEM\_SYNC\_SIZE}}}
 & Length of a work array that can be used with any SHMEM collective
 communication operation. The value of this constant is implementation
 specific. Refer to the individual \hyperref[subsec:coll]{Collective Routines} for more information


### PR DESCRIPTION
List the constant once for all language bindings, instead of listing the
same thing twice for C/C++ and Fortran.