### PR TITLE
Add Fortran MY_PE and NUM_PES routines

### DIFF
--- a/content/shmem_my_pe.tex
+++ b/content/shmem_my_pe.tex
@@ -11,6 +11,7 @@ int shmem_my_pe(void);
 \begin{Fsynopsis}
 INTEGER SHMEM_MY_PE, ME
 ME = SHMEM_MY_PE()
+ME = MY_PE()
 \end{Fsynopsis}
 
 \begin{apiarguments}

--- a/content/shmem_n_pes.tex
+++ b/content/shmem_n_pes.tex
@@ -11,6 +11,7 @@ int shmem_n_pes(void);
 \begin{Fsynopsis}
 INTEGER SHMEM_N_PES, N_PES
 N_PES = SHMEM_N_PES()
+N_PES = NUM_PES()
 \end{Fsynopsis}
 
 \begin{apiarguments}


### PR DESCRIPTION
These routines were removed in error between v1.1 and v1.2.
Technically, they should be deprecated since the corresponding C
routines _my_pe() and _num_pes() were deprecated.

Signed-off-by: James Dinan <james.dinan@intel.com>