### PR TITLE
Annex F: Expand SMA entry

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -368,7 +368,10 @@ specification.
     \_SHMEM\_MINOR\_VERSION & 1.3 & Current & \hyperref[subsec:library_constants]{SHMEM\_MINOR\_VERSION} \\ \hline
     \_SHMEM\_MAX\_NAME\_LEN & 1.3 & Current & \hyperref[subsec:library_constants]{SHMEM\_MAX\_NAME\_LEN} \\ \hline
     \_SHMEM\_VENDOR\_STRING & 1.3 & Current & \hyperref[subsec:library_constants]{SHMEM\_VENDOR\_STRING} \\ \hline
-    SMA\_* environment variables & 1.4 & Current & SHMEM\_* \\ \hline
+    SMA\_VERSION         & 1.4 & Current & \hyperref[subsec:environment_variables]{SHMEM\_VERSION} \\ \hline
+    SMA\_INFO            & 1.4 & Current & \hyperref[subsec:environment_variables]{SHMEM\_INFO} \\ \hline
+    SMA\_SYMMETRIC\_SIZE & 1.4 & Current & \hyperref[subsec:environment_variables]{SHMEM\_SYMMETRIC\_SIZE} \\ \hline
+    SMA\_DEBUG           & 1.4 & Current & \hyperref[subsec:environment_variables]{SHMEM\_DEBUG} \\ \hline
     \end{tabular}
 \end{center}
 
@@ -413,7 +416,7 @@ was originally implemented for systems with cache management instructions.
 This API has largely gone unused on cache-coherent system architectures.
 \FUNC{SHMEM\_CACHE} has been deprecated.
 
-\subsection{\_SHMEM\_* constants}
+\subsection{\_SHMEM\_* Library Constants}
 The library constants
 \begin{center}
 \begin{tabular}{ll}
@@ -422,12 +425,25 @@ The library constants
     \_SHMEM\_BCAST\_SYNC\_SIZE & \_SHMEM\_MINOR\_VERSION \\
     \_SHMEM\_COLLECT\_SYNC\_SIZE & \_SHMEM\_MAX\_NAME\_LEN \\
     \_SHMEM\_REDUCE\_SYNC\_SIZE & \_SHMEM\_VENDOR\_STRING \\
-    \end{tabular}
+\end{tabular}
 \end{center}
 do not adhere to the \Clang{} standard's reserved identifiers and the \Cpp{}
 standard's reserved names.  These constants have been deprecated and replaced
 with corresponding constants of prefix \shmemprefix{} that adhere to \CorCpp{}
 and \Fortran{} naming conventions.
+
+\subsection{SMA\_* Environment Variables}
+The environment variables
+\begin{center}
+\begin{tabular}{ll}
+    SMA\_VERSION \\
+    SMA\_INFO \\
+    SMA\_SYMMETRIC\_SIZE \\
+    SMA\_DEBUG \\
+\end{tabular}
+\end{center}
+were deprecated in order to normalize the \openshmem \ac{API} to use
+\shmemprefix{} as the standard prefix for all environment variables.
 
 
 


### PR DESCRIPTION
Expands the SMA entry in the deprecation table and adds a deprecation rationale in the same style as the one for _my_pe and friends.