### PR TITLE
Addition of Symmetric Distributed Locking Routines

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -465,6 +465,10 @@ synchronization routines.
 \item Clarified deprecation overview and added deprecation rationale in Annex F.
 \\See Section \ref{sec:dep_api}.
 %
+\item Added the locking routines \FUNC{shmem\_clear\_lock\_pe},
+\FUNC{shmem\_test\_lock\_pe}, and \FUNC{shmem\_set\_lock\_pe}.
+\\See Section \ref{sec:shmem_lock_pe}.
+%
 \end{itemize}
 
 \section{Version 1.3}

--- a/content/shmem_lock_pe.tex
+++ b/content/shmem_lock_pe.tex
@@ -28,8 +28,8 @@ I = SHMEM_TEST_LOCK_PE(lock, pe)
 \apidescription{
     The \FUNC{shmem\_set\_lock\_pe} routine sets a mutual exclusion lock on a
     specific \ac{PE} after waiting for the lock to be freed by any other \ac{PE}
-    currently holding the lock.  Waiting \ac{PE}s are assured of getting the lock in
-    a first-come, first-served manner. The \FUNC{shmem\_clear\_lock\_pe} routine
+    currently holding the lock.  Waiting \ac{PE}s spin-wait on the lock resource
+    until it is released.  The \FUNC{shmem\_clear\_lock\_pe} routine
     releases a lock on a specific \ac{PE} previously set by
     \FUNC{shmem\_set\_lock\_pe} after ensuring that all local and remote stores
     initiated in the critical region are complete.  The \FUNC{shmem\_test\_lock\_pe}

--- a/content/shmem_lock_pe.tex
+++ b/content/shmem_lock_pe.tex
@@ -1,0 +1,69 @@
+\apisummary{
+    Releases, locks, and tests a mutual exclusion memory lock on a specific \ac{PE}.
+}
+\begin{apidefinition}
+
+\begin{Csynopsis}
+void shmem_clear_lock_pe(volatile long *lock, int pe);
+void shmem_set_lock_pe(volatile long *lock, int pe);
+int shmem_test_lock_pe(volatile long *lock, int pe);
+\end{Csynopsis}
+
+\begin{Fsynopsis}
+INTEGER pe, lock, SHMEM_TEST_LOCK
+CALL SHMEM_CLEAR_LOCK_PE(lock, pe)
+CALL SHMEM_SET_LOCK_PE(lock, pe)
+I = SHMEM_TEST_LOCK_PE(lock, pe)
+\end{Fsynopsis}
+
+\begin{apiarguments}
+\apiargument{IN}{lock}{A symmetric data object that is a scalar variable or an array
+    of  length \CONST{1}.  This data  object  must  be set to \CONST{0} on all
+    \ac{PE}s prior to the first use.  \VAR{lock}  must  be  of type \CONST{long}.
+    If you are using \Fortran, it must be of default kind.}
+\apiargument{IN}{pe}{An integer that indicates the \ac{PE} number upon which lock is
+    to be updated. If you are using Fortran, it must be a default integer value.}
+\end{apiarguments}
+
+\apidescription{
+    The \FUNC{shmem\_set\_lock\_pe} routine sets a mutual exclusion lock on a
+    specific \ac{PE} after waiting for the lock to be freed by any other \ac{PE}
+    currently holding the lock.  Waiting \ac{PE}s are assured of getting the lock in
+    a first-come, first-served manner. The \FUNC{shmem\_clear\_lock\_pe} routine
+    releases a lock on a specific \ac{PE} previously set by
+    \FUNC{shmem\_set\_lock\_pe} after ensuring that all local and remote stores
+    initiated in the critical region are complete.  The \FUNC{shmem\_test\_lock\_pe}
+    routine sets a mutual exclusion lock on a specific \ac{PE} only if it is
+    currently cleared.  By using this routine, a \ac{PE} can avoid blocking on a set
+    lock. If the lock is currently set, the routine returns without waiting. These
+    routines are appropriate for protecting a critical region from simultaneous
+    update by multiple \ac{PE}s at a fine-grain level.
+}
+
+\apireturnvalues{
+    The \FUNC{shmem\_test\_lock} routine returns \CONST{0} if  the lock  was
+    originally cleared and  this  call was  able  to set the lock.  A value of
+    \CONST{1} is returned if the lock had been set and the call returned without
+    waiting to set the lock.
+}
+
+\apinotes{
+    The term symmetric data object is defined in Section \ref{subsec:memory_model}.
+    The lock variable should always be initialized to zero and accessed only by the
+    \openshmem locking \ac{API}.  Changing the value of the lock variable by other
+    means without using the \openshmem \ac{API}, can lead to undefined behavior.
+    Mixing the \FUNC{shmem\_lock} and \FUNC{shmem\_lock\_pe} routines with the same
+    lock can lead to undefined behavior.
+}
+
+\begin{apiexamples}
+
+\apicexample
+    {The following example uses \FUNC{shmem\_set\_lock\_pe} and
+    \FUNC{shmem\_clear\_lock\_pe} in a \Clang{} program.}
+    {./example_code/shmem_lock_pe_example.c}
+    {}
+
+\end{apiexamples}
+
+\end{apidefinition}

--- a/example_code/shmem_lock_pe_example.c
+++ b/example_code/shmem_lock_pe_example.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+   int old = -1;
+   static int dst = 22;
+   static long lock = 0;
+   shmem_init();
+   int me = shmem_my_pe();
+   if (me == 1) {
+      shmem_set_lock_pe(&lock, 0);
+      old = shmem_g(&dst, 0);
+      shmem_p(&dst, old + 44, 0);
+      shmem_clear_lock_pe(&lock, 0);
+   }
+   shmem_barrier_all();
+   printf("%d: old = %d, dst = %d\n", me, old, dst);
+   shmem_finalize();
+   return 0;
+}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -258,6 +258,8 @@ mutual exclusion. Three routines are available for distributed locking,
 \input{content/shmem_lock.tex}
 
 
+\subsubsection{\textbf{SHMEM\_LOCK\_PE}}\label{subsec:shmem_lock_pe}
+\input{content/shmem_lock_pe.tex}
 
 
 


### PR DESCRIPTION
This is related to Redmine extension proposal [#232](http://www.openshmem.org/redmine/issues/232)

**Description**

OpenSHMEM 1.3 Section 8.9 provides Distributed Locking Routines whereby a scalar symmetric data object represents a single global lock that may be acquired/released by any PE. Thus, a scalar symmetric data object is treated semantically as a single object even though the applicable declarations associated with the lock instantiate one scalar per PE. Furthermore, in order to provide fine-grain protection of resources local to a PE, it is necessary to allocate an array of locks as a symmetric data object, and then explicitly associate an element in the lock array with a given PE. This is also semantically inconsistent since a symmetric data object is treated as a single global object by the current Distributed Locking Routines. A consequence is that, with the current specification, the total allocated size allocated for fine-grain lock will scale as O(N^2) whereas logical locks scale as O(N), where `N = shmem_n_pes()`.

The proposed Symmetric Distributed Locking Routines appear similar to the existing distributed locking routines with the addition of a second PE argument so that symmetric scalar locks may be treated consistently with ordinary scalar symmetric data objects and used fine-grain locking of a resources local to a specified PE.

**Benefits as Result of Changes**

Fine-grain inter-process locking reduces the memory footprint and potentially network traffic required for locks, leading to more efficient implementations.

The total memory used to implement fine-grain locking scales with the square of the number of processing elements, prohibiting the operation for some highly scalable architecture with limited memory.

With 1M PEs in the code below, for example, 8 Terabytes of memory in total is allocated. The proposed extension would reduce that to a total of just 8 MB.

**Typical code for existing locking routines**

```c
int npes = shmem_n_pes();
int my_pe = shmem_my_pe();
int nxt_pe = (my_pe + 1) % npes;

// x and lock are declared identically
static long x = my_pe;
static long lock = 0;

// x and lock follow different semantic as data objects
long new_value = my_pe + 100;
shmem_set_lock(&lock);
shmem_p(&x, new_value, nxt_pe);
shmem_clear_lock(&lock);
```

**Typical code for existing fine-grain locking routines**

```c
int npes = shmem_n_pes();
int my_pe = shmem_my_pe();
int nxt_pe = (my_pe + 1) % npes;

// array of locks required for fine-grain locking
static long x = my_pe;
long* locks = (long*)shmem_malloc( npes * sizeof(*locks) );
memset(locks, 0, npes * sizeof(*locks));

long new_value = my_pe + 100;
shmem_set_lock(&locks[nxt_pe]);
shmem_p(&x, new_value, nxt_pe);
shmem_clear_lock(&locks[nxt_pe]);
```

**Proposed extension solution**

```c
int npes = shmem_n_pes();
int my_pe = shmem_my_pe();
int nxt_pe = (my_pe + 1) % npes;

// x and lock are declared identically
static long x = my_pe;
static long lock = 0;

// x and lock follow identical semantic as data objects
long new_value = my_pe + 100;
shmem_set_lock_pe(&lock, nxt_pe);
shmem_p(&x, new_vlaue, nxt_pe);
shmem_clear_lock_pe(&lock, nxt_pe);
```

**SW Impact Assessment**

Three new routines must be written. They are straightforward extensions to the three existing Distributed Locking Routines whereby a second argument is added to specify the PE for the target lock.

**HW Impact Assessment**

This proposal should reduce the asymmetric network congestion for OpenSHMEM implementations that locate the actual locks on a particular PE (say PE 0), and reduce the scaling of storage for fine-grain locks from O(N^2) to O(N).

**Synopsis**

_C/C++:_
```c
void shmem_clear_lock_pe(long *lock, int pe);
void shmem_set_lock_pe(long *lock, int pe);
int shmem_test_lock_pe(long *lock, int pe);
```
**Parameters**

_Arguments:_
_IN lock_: A symmetric data object that is a scalar variable or an array of length 1. This data object must be set to 0 on all PEs prior to the first use. lock must be of type long.

_IN pe_: An integer that indicates the PE number upon which lock is to be updated.

**Return Values:**

The shmem_test_lock_pe routine returns 0 if the lock was originally cleared and this call was able to set the lock. A value of 1 is returned if the lock had been set and the call returned without waiting to set the lock.