### PR TITLE
Fixing Source Buffer Ambiguity in Collective Operations Text (RM #217)

### DIFF
--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -72,8 +72,8 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     needed to ensure this): The \VAR{pSync} array on all \ac{PE}s in the
     \activeset{} is not still in use from a prior call to a broadcast routine.  The
     \dest{} array on all \ac{PE}s in the \activeset{} is ready to accept the
-    broadcast data. 
-       
+    broadcast data.
+    
     Upon return from a broadcast routine, the following are true for the local
     \ac{PE}: If the current \ac{PE} is not the root \ac{PE}, the \dest{} data object
     is updated. The \source{} data object may be safely reused.  

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -72,14 +72,11 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     needed to ensure this): The \VAR{pSync} array on all \ac{PE}s in the
     \activeset{} is not still in use from a prior call to a broadcast routine.  The
     \dest{} array on all \ac{PE}s in the \activeset{} is ready to accept the
-    broadcast data. \newtext{The data in the \source{} array on the root \ac{PE} is ready to be broadcasted.}
-    
-    \newtext{The \source{} and \dest{} arrays may be the same array, but they may not be overlapping arrays. If they 
-    are different, the source array on the non-root \acp{PE} and \dest{} array on the root \ac{PE} is not used by the broadcast routine.}
-    
+    broadcast data. 
+       
     Upon return from a broadcast routine, the following are true for the local
     \ac{PE}: If the current \ac{PE} is not the root \ac{PE}, the \dest{} data object
-    is updated. \newtext{If the current PE is the root PE, the \source{} data object may be safely reused.}  
+    is updated. \newtext{The \source{} data object may be safely reused.}  
     The values in the \VAR{pSync} array are restored to the original values.
 }
 

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -76,7 +76,7 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
        
     Upon return from a broadcast routine, the following are true for the local
     \ac{PE}: If the current \ac{PE} is not the root \ac{PE}, the \dest{} data object
-    is updated. \newtext{The \source{} data object may be safely reused.}  
+    is updated. The \source{} data object may be safely reused.  
     The values in the \VAR{pSync} array are restored to the original values.
 }
 

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -72,11 +72,14 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     needed to ensure this): The \VAR{pSync} array on all \ac{PE}s in the
     \activeset{} is not still in use from a prior call to a broadcast routine.  The
     \dest{} array on all \ac{PE}s in the \activeset{} is ready to accept the
-    broadcast data.
+    broadcast data. \newtext{The data in the \source{} array on the root \ac{PE} is ready to be broadcasted.}
+    
+    \newtext{The \source{} and \dest{} arrays may be the same array, but they may not be overlapping arrays. If they 
+    are different, the source array on the non-root \acp{PE} and \dest{} array on the root \ac{PE} is not used by the broadcast routine.}
     
     Upon return from a broadcast routine, the following are true for the local
     \ac{PE}: If the current \ac{PE} is not the root \ac{PE}, the \dest{} data object
-    is updated\newtext{, and if the current PE is the root PE, the buffer pointed to by source may be safely reused.}  
+    is updated. \newtext{If the current PE is the root PE, the \source{} data object may be safely reused.}  
     The values in the \VAR{pSync} array are restored to the original values.
 }
 

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -76,8 +76,8 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     
     Upon return from a broadcast routine, the following are true for the local
     \ac{PE}: If the current \ac{PE} is not the root \ac{PE}, the \dest{} data object
-    is updated.  The values in the \VAR{pSync} array are restored to the original
-    values.
+    is updated\newtext{, and if the current PE is the root PE, the buffer pointed to by source may be safely reused.}  
+    The values in the \VAR{pSync} array are restored to the original values.
 }
 
 \apidesctable{

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -85,7 +85,7 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     \activeset.
     
     Upon return from a collective routine, the following are true for the local
-    \ac{PE}: The \dest{} array is updated \newtext {and the \source{} array may be safely reused}. 
+    \ac{PE}: The \dest{} array is updated and the \source{} array may be safely reused. 
     The values in the \VAR{pSync} array are
     restored to the original values.
 }

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -85,7 +85,8 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     \activeset.
     
     Upon return from a collective routine, the following are true for the local
-    \ac{PE}: The \dest{} array is updated. The values in the \VAR{pSync} array are
+    \ac{PE}: The \dest{} array is updated \newtext {and the \source{} array may be safely reused}. 
+    The values in the \VAR{pSync} array are
     restored to the original values.
 }
 

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -208,7 +208,8 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     \activeset{} is ready to accept the results of the \OPR{reduction}.
     
     Upon return from a reduction routine, the following are true for the local
-    \ac{PE}: The \dest{} array is updated.  The values in the \VAR{pSync} array are
+    \ac{PE}: The \dest{} array is updated \newtext{and the \source{} array may be safely reused}.  
+    The values in the \VAR{pSync} array are
     restored to the original values.
 }
 

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -208,7 +208,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     \activeset{} is ready to accept the results of the \OPR{reduction}.
     
     Upon return from a reduction routine, the following are true for the local
-    \ac{PE}: The \dest{} array is updated \newtext{and the \source{} array may be safely reused}.  
+    \ac{PE}: The \dest{} array is updated and the \source{} array may be safely reused.  
     The values in the \VAR{pSync} array are
     restored to the original values.
 }


### PR DESCRIPTION
The text describing Broadcast (and other collectives) operation in the current specification 
does not clarify the state of source buffer on root PE (read Page 51, 4-5), after it returns.
One would assume the source buffer is reusable.