### PR TITLE
Clarify shmemx header is required, even when empty

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -440,6 +440,9 @@ and \Fortran{} naming conventions.
 
 \begin{itemize}
 %
+\item Clarified that the \openshmem extensions header files are required, even when empty.
+\\See Section~\ref{subsec:bindings}.
+%
 \item The \VAR{SHMEM\_SYNC\_SIZE} constant was added.
 \\See Section \ref{subsec:library_constants}.
 %

--- a/content/language_bindings_and_conformance.tex
+++ b/content/language_bindings_and_conformance.tex
@@ -17,8 +17,5 @@ variables, or identifiers with the prefix \shmemprefix (for \Clang{} and
 All \openshmem extension \ac{API}s that are not part of this specification must
 be defined in the \FUNC{shmemx.h} and \FUNC{shmemx.fh} include files for
 \Clang{} and \Fortran{} language bindings, respectively.  These header files
-must exist, even if they are empty.  Any extensions shall use the
+must exist, even if no extensions are provided.  Any extensions shall use the
 \FUNC{shmemx\_} prefix for all routine, variable, and constant names.
-\openshmem implementations are encouraged to define macros of the form
-\CONST{SHMEMX\_HAVE\_extension} that can be used to check for the presence of
-a particular extension.

--- a/content/language_bindings_and_conformance.tex
+++ b/content/language_bindings_and_conformance.tex
@@ -15,5 +15,10 @@ variables, or identifiers with the prefix \shmemprefix (for \Clang{} and
 \Fortran), \shmemprefixC (for \Clang) or with \openshmem \ac{API} names.
 
 All \openshmem extension \ac{API}s that are not part of this specification must
-be defined in the \FUNC{shmemx.h} include file. These extensions shall use the
+be defined in the \FUNC{shmemx.h} and \FUNC{shmemx.fh} include files for
+\Clang{} and \Fortran{} language bindings, respectively.  These header files
+must exist, even if they are empty.  Any extensions shall use the
 \FUNC{shmemx\_} prefix for all routine, variable, and constant names.
+\openshmem implementations are encouraged to define macros of the form
+\CONST{SHMEMX\_HAVE\_extension} that can be used to check for the presence of
+a particular extension.


### PR DESCRIPTION
Ref: [Redmine ticket 219](http://www.openshmem.org/redmine/issues/219)