### PR TITLE
Add shmem_calloc function

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -465,6 +465,9 @@ synchronization routines.
 \item Clarified deprecation overview and added deprecation rationale in Annex F.
 \\See Section \ref{sec:dep_api}.
 %
+\item Added the \FUNC{shmem\_calloc} function.
+\\ See Section \ref{subsec:shmem_calloc}.
+%
 \end{itemize}
 
 \section{Version 1.3}

--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -29,8 +29,7 @@ void *shmem_calloc(size_t count, size_t size);
   all \ac{PE}s calling \FUNC{shmem\_calloc}; otherwise, the behavior is
   undefined.
 
-  The \FUNC{shmem\_calloc} routine calls \FUNC{shmem\_barrier\_all} on exit
-  prior to returning.
+  The \FUNC{shmem\_calloc} routine calls \FUNC{shmem\_barrier\_all} on exit.
 }
 
 \apireturnvalues{

--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -20,6 +20,11 @@ void *shmem_calloc(size_t count, size_t size);
   returns a pointer to the lowest byte address of the allocated symmetric
   memory. The space is initialized to all bits zero.
 
+  If the allocation succeeds, the pointer returned shall be suitably
+  aligned so that it may be assigned to a pointer to any type of object.
+  If the allocation does not succeed, or either \VAR{count} or \VAR{size} is
+  \CONST{0}, the return value is a null pointer.
+
   The values for \VAR{count} and \VAR{size} shall each be equal across
   all \ac{PE}s calling \FUNC{shmem\_calloc}; otherwise, the behavior is
   undefined.

--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -1,0 +1,40 @@
+\apisummary{
+  Allocate a zeroed block of symmetric memory.
+}
+
+\begin{apidefinition}
+
+\begin{Csynopsis}
+void *shmem_calloc(size_t nmemb, size_t size);
+\end{Csynopsis}
+
+\begin{apiarguments}
+  \apiargument{IN}{nmemb}{The number of elements to allocate.}
+  \apiargument{IN}{size}{The size in bytes of each element to allocate.}
+\end{apiarguments}
+
+
+\apidescription{
+  The \FUNC{shmem\_calloc} routine allocates a region of remotely-accessible
+  memory for an array of \VAR{nmemb} objects of \VAR{size} bytes each and
+  returns a pointer to the lowest byte address of the allocated symmetric
+  memory. The space is initialized to all bits zero.
+
+  The values for \VAR{nmemb} and \VAR{size} shall each be equal across
+  all \ac{PE}s calling \FUNC{shmem\_calloc}; otherwise, the behavior is
+  undefined.
+
+  The \FUNC{shmem\_calloc} routine calls \FUNC{shmem\_barrier\_all} on exit
+  prior to returning.
+}
+
+\apireturnvalues{
+  The \FUNC{shmem\_calloc} routine returns a pointer to the lowest byte
+  address of the allocated space; otherwise, it returns a null pointer.
+}
+
+\apinotes{
+  None.
+}
+
+\end{apidefinition}

--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -5,22 +5,22 @@
 \begin{apidefinition}
 
 \begin{Csynopsis}
-void *shmem_calloc(size_t nmemb, size_t size);
+void *shmem_calloc(size_t count, size_t size);
 \end{Csynopsis}
 
 \begin{apiarguments}
-  \apiargument{IN}{nmemb}{The number of elements to allocate.}
+  \apiargument{IN}{count}{The number of elements to allocate.}
   \apiargument{IN}{size}{The size in bytes of each element to allocate.}
 \end{apiarguments}
 
 
 \apidescription{
   The \FUNC{shmem\_calloc} routine allocates a region of remotely-accessible
-  memory for an array of \VAR{nmemb} objects of \VAR{size} bytes each and
+  memory for an array of \VAR{count} objects of \VAR{size} bytes each and
   returns a pointer to the lowest byte address of the allocated symmetric
   memory. The space is initialized to all bits zero.
 
-  The values for \VAR{nmemb} and \VAR{size} shall each be equal across
+  The values for \VAR{count} and \VAR{size} shall each be equal across
   all \ac{PE}s calling \FUNC{shmem\_calloc}; otherwise, the behavior is
   undefined.
 

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -91,6 +91,9 @@ symmetric data objects in the symmetric heap, in \Clang{} and \Fortran.
 \subsubsection{\textbf{SHMEM\_MALLOC, SHMEM\_FREE, SHMEM\_REALLOC, SHMEM\_ALIGN}}\label{subsec:shfree}
 \input{content/shmem_malloc.tex}
 
+\subsubsection{\textbf{SHMEM\_CALLOC}}\label{subsec:shmem_calloc}
+\input{content/shmem_calloc.tex}
+
 \subsubsection{\textbf{SHPALLOC}}\label{subsec:shpalloc}
 \input{content/shpalloc.tex}
 


### PR DESCRIPTION
This PR adds the `shmem_calloc` function.

**Special Ballot**: diff ([30e8392..d31f114](https://github.com/openshmem-org/specification/pull/47/files/30e83921293fc384ae2209bd99f775a5508e572f..d31f11466f364711add00743dc8843c065f07302)) and [PDF](https://github.com/openshmem-org/specification/files/838553/proposal-calloc-20170313.pdf)


Note that `shmem_calloc` was added separately from the `shmem_{malloc,realloc,align,free}` block because the argument descriptions would conflict.