### PR TITLE
DocEdit: Added \HEADER command

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -683,7 +683,7 @@ provided.
 \\See Section \ref{subsec:progress}. 
 %
 \item Clarification of naming convention for non-standard interfaces and their
-inclusion in \FUNC{shmemx.h}.
+inclusion in \HEADER{shmemx.h}.
 \\See Section \ref{subsec:bindings}. 
 %
 \item Various fixes to \openshmem code examples across the specification to

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -21,7 +21,7 @@ In this section, we describe how to write a ``Hello World" \openshmem program.
 To write a ``Hello World" \openshmem program we need to: 
 
 \begin{itemize}
-\item Add the include file shmem.h (for \Clang) or shmem.fh (for \Fortran).
+\item Add the include file \HEADER{shmem.h} (for \Clang) or \HEADER{shmem.fh} (for \Fortran).
 \item Add the initialization call \FUNC{shmem\_init}, (line 9).
 \item Use OpenSHMEM calls to query the the total number of PEs (line 10) and PE
     id (line 11).

--- a/content/language_bindings_and_conformance.tex
+++ b/content/language_bindings_and_conformance.tex
@@ -15,5 +15,5 @@ variables, or identifiers with the prefix \shmemprefix (for \Clang{} and
 \Fortran), \shmemprefixC (for \Clang) or with \openshmem \ac{API} names.
 
 All \openshmem extension \ac{API}s that are not part of this specification must
-be defined in the \FUNC{shmemx.h} include file. These extensions shall use the
+be defined in the \HEADER{shmemx.h} include file. These extensions shall use the
 \FUNC{shmemx\_} prefix for all routine, variable, and constant names.

--- a/content/shmem_info_get_name.tex
+++ b/content/shmem_info_get_name.tex
@@ -29,7 +29,7 @@ SHMEM_INFO_GET_NAME(NAME)
     invocations of the routine in an \openshmem{} program always return the
     same string.  For a given library implementation, the major and minor
     version returned by these calls is consistent with the compile-time
-    constants defined in its shmem.h.
+    constants defined in its \HEADER{shmem.h}.
 }
 
 \apireturnvalues{ 

--- a/content/shmem_info_get_version.tex
+++ b/content/shmem_info_get_version.tex
@@ -22,7 +22,7 @@ SHMEM_INFO_GET_VERSION(MAJOR, MINOR)
     This routine returns the major and minor version of the \openshmem{} standard
     in use.  For a given library implementation, the major and minor version
     returned by these calls is consistent with the compile-time constants,
-    SHMEM\_MAJOR\_VERSION and SHMEM\_MINOR\_VERSION, defined in its shmem.h. 
+    SHMEM\_MAJOR\_VERSION and SHMEM\_MINOR\_VERSION, defined in its \HEADER{shmem.h}.
 }
 
 \apireturnvalues{

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -36,7 +36,7 @@
 \newcommand{\FUNC}[1]{\textit{#1}}
 \newcommand{\VAR}[1]{\textit{#1}}
 \newcommand{\CONST}[1]{\textit{#1}}
-\newcommand{\const}[1]{\protect\gb\protect{\textsf{\small #1}}\index{CONST:#1}}
+\newcommand{\const}[1]{\protect\gb\protect{\textsf{\small #1}}\index{CONST:#1}} % Only library_constants.tex table.
 \newcommand{\CorCpp}{\textit{C/C++}\xspace}
 \newcommand{\CorCppFor}{\textit{C/C++/Fortran}\xspace}
 \newcommand{\Fortran}{\textit{Fortran}}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -32,6 +32,7 @@
 \newcommand{\insertDocVersion}{1.4}
 \newcommand{\OSH}{\emph{OpenSHMEM}}
 \newcommand{\openshmem}{{Open\-SHMEM}\xspace}
+\newcommand{\HEADER}[1]{\textit{#1}}
 \newcommand{\FUNC}[1]{\textit{#1}}
 \newcommand{\VAR}[1]{\textit{#1}}
 \newcommand{\CONST}[1]{\textit{#1}}


### PR DESCRIPTION
Added `\HEADER` command. Affects Annex A and API descriptions for `shmem_info_get_{version,name}`.

Also, there's a defs comment for \const{} vs. \CONST{}.