### PR TITLE
Differentiate shmemx and SHMEMX prefixes

### DIFF
--- a/content/language_bindings_and_conformance.tex
+++ b/content/language_bindings_and_conformance.tex
@@ -16,4 +16,5 @@ variables, or identifiers with the prefix \shmemprefix (for \Clang{} and
 
 All \openshmem extension \ac{API}s that are not part of this specification must
 be defined in the \FUNC{shmemx.h} include file. These extensions shall use the
-\FUNC{shmemx\_} prefix for all routine, variable, and constant names.
+\FUNC{shmemx\_} prefix for routine names and variable names and the
+\CONST{SHMEMX\_} prefix for library constants.

--- a/content/language_bindings_and_conformance.tex
+++ b/content/language_bindings_and_conformance.tex
@@ -11,8 +11,8 @@ specification.
 implementing the interfaces using macros is strongly discouraged as this could
 severely limit the use of external profiling tools and high-level compiler
 optimizations. An \openshmem program should avoid defining routine names,
-variables, or identifiers with the prefix \shmemprefix (for \Clang{} and
-\Fortran), \shmemprefixC (for \Clang) or with \openshmem \ac{API} names.
+variable names, or identifiers with the prefix \shmemprefix{} (for \Clang{} and
+\Fortran), \shmemprefixC{} (for \Clang) or with \openshmem \ac{API} names.
 
 All \openshmem extension \ac{API}s that are not part of this specification must
 be defined in the \FUNC{shmemx.h} include file. These extensions shall use the


### PR DESCRIPTION
**[Work in Progress]** The spec is inconsistent with the use of e.g., `shmemx_` for routine names and variable names and `SHMEMX_` for library constants (See almost all uses of `\shmemprefix`). This is made even more apparent with inconsistent application of `\FUNC` vs. `\CONST` for prefix uses. Do we want to address this issue?

Also, note that the text includes variable names. Are these specifically environment variables? (**Edit:** Environment variables should be using `SHMEMX_` instead of `shmemx_`.) What other variables are there if not function-local parameters?