### PR TITLE
Add deprecation markers to start_pes()

### DIFF
--- a/content/start_pes.tex
+++ b/content/start_pes.tex
@@ -7,13 +7,17 @@
 
 \begin{apidefinition}
 
+\begin{DeprecateBlock}
 \begin{Csynopsis}
 void start_pes(int npes);
 \end{Csynopsis}
+\end{DeprecateBlock}
 
+\begin{DeprecateBlock}
 \begin{Fsynopsis}
 CALL START_PES(npes)
 \end{Fsynopsis}
+\end{DeprecateBlock}
 
 \begin{apiarguments}
        \apiargument{npes}{Unused}{ Should be set to \CONST{0}.}


### PR DESCRIPTION
Inspired by #61, this PR adds deprecation markers to `start_pes()`. The rendered output is as follows:

![deprecate_start_pes](https://cloud.githubusercontent.com/assets/2961664/24769564/f5a71e4e-1ad4-11e7-827b-147de39720f1.png)
