### PR TITLE
Relaxed definition of SHMEM_MAX_NAME_LEN

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -501,6 +501,9 @@ synchronization routines.
 \item Added the \FUNC{shmem\_calloc} function.
 \\ See Section \ref{subsec:shmem_calloc}.
 %
+\item Clarified description for \CONST{SHMEM\_MAX\_NAME\_LEN}.
+\\See Section \ref{subsec:library_constants}.
+%
 \end{itemize}
 
 \section{Version 1.3}

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -120,7 +120,7 @@ Integer representing the minor version of \openshmem{} standard in use. \tabular
 \vtop{\hbox{\CorCppFor:} 
 \hbox{\hspace*{12mm} \const{SHMEM\_MAX\_NAME\_LEN}}}
 &
-Integer representing the length of vendor string. \tabularnewline
+Integer representing the maximum length of \const{SHMEM\_VENDOR\_STRING}. \tabularnewline
 \hline
 \vspace{3mm}
 \vtop{\hbox{\CorCppFor:} 


### PR DESCRIPTION
`SHMEM_MAX_NAME_LEN` now represents the maximum string length instead of the actual string length. The original definition has ambiguous implications with whether null/blank characters at the end of the relevant characters were counted or not.

Potentially a DocEdit, but this change technically relaxes the existing semantics even if the original semantics were sometimes not used in practice.