### PR TITLE
Housekeeping

### DIFF
--- a/content/language_bindings_and_conformance.tex
+++ b/content/language_bindings_and_conformance.tex
@@ -8,14 +8,14 @@ clear in its documentation. The \openshmem header files \HEADER{shmem.h} for
 \Fortran must contain only the interfaces and constant names defined in this
 specification.
 
-\openshmem \ac{API}s can be implemented as either routines or macros. However,
+\openshmem \acp{API} can be implemented as either routines or macros. However,
 implementing the interfaces using macros is strongly discouraged as this could
 severely limit the use of external profiling tools and high-level compiler
 optimizations. An \openshmem program should avoid defining routine names,
 variables, or identifiers with the prefix \shmemprefix (for \Cstd and
 \Fortran), \shmemprefixC (for \Cstd) or with \openshmem \ac{API} names.
 
-All \openshmem extension \ac{API}s that are not part of this specification must
+All \openshmem extension \acp{API} that are not part of this specification must
 be defined in the \HEADER{shmemx.h} and \HEADER{shmemx.fh} include files for
 \Cstd and \Fortran language bindings, respectively.  These header files
 must exist, even if no extensions are provided.  Any extensions shall use the

--- a/content/p2p_sync_intro.tex
+++ b/content/p2p_sync_intro.tex
@@ -1,5 +1,5 @@
-The following section discusses \openshmem \ac{API}s that provides a mechanism
-for synchronization between two \ac{PE}s based on the value of a symmetric data
+The following section discusses \openshmem \acp{API} that provides a mechanism
+for synchronization between two \acp{PE} based on the value of a symmetric data
 object.
 The point-to-point synchronization routines can be used to portably ensure
 that memory access operations observe remote updates in the order enforced by

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -56,7 +56,7 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
 
 \apinotes{
     As of \openshmem[1.4], \FUNC{shmem\_add} has been deprecated.
-    Its behavior and call signature is identical to the replacement
+    Its behavior and call signature are identical to the replacement
     interface, \FUNC{shmem\_atomic\_add}.
 }
 

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -62,7 +62,7 @@ ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
 
 \apinotes{
     As of \openshmem[1.4], \FUNC{shmem\_cswap} has been deprecated.
-    Its behavior and call signature is identical to the replacement
+    Its behavior and call signature are identical to the replacement
     interface, \FUNC{shmem\_atomic\_compare\_swap}.
 }
 

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -50,7 +50,7 @@ res_r8 = SHMEM_REAL8_FETCH(dest, pe)
 
 \apinotes{
     As of \openshmem[1.4], \FUNC{shmem\_fetch} has been deprecated.
-    Its behavior and call signature is identical to the replacement
+    Its behavior and call signature are identical to the replacement
     interface, \FUNC{shmem\_atomic\_fetch}.
 }
 

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -62,7 +62,7 @@ ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
 
 \apinotes{
     As of \openshmem[1.4], \FUNC{shmem\_fadd} has been deprecated.
-    Its behavior and call signature is identical to the replacement
+    Its behavior and call signature are identical to the replacement
     interface, \FUNC{shmem\_atomic\_fetch\_add}.
 }
 

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -57,7 +57,7 @@ ires_i8 = SHMEM_INT8_FINC(dest, pe)
 
 \apinotes{
     As of \openshmem[1.4], \FUNC{shmem\_finc} has been deprecated.
-    Its behavior and call signature is identical to the replacement
+    Its behavior and call signature are identical to the replacement
     interface, \FUNC{shmem\_atomic\_fetch\_inc}.
 }
 

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -52,7 +52,7 @@ CALL SHMEM_INT8_INC(dest, pe)
 
 \apinotes{
     As of \openshmem[1.4], \FUNC{shmem\_inc} has been deprecated.
-    Its behavior and call signature is identical to the replacement
+    Its behavior and call signature are identical to the replacement
     interface, \FUNC{shmem\_atomic\_inc}.
 }
 

--- a/content/shmem_atomic_set.tex
+++ b/content/shmem_atomic_set.tex
@@ -49,7 +49,7 @@ CALL SHMEM_REAL8_SET(dest, value_r8, pe)
 
 \apinotes{
     As of \openshmem[1.4], \FUNC{shmem\_set} has been deprecated.
-    Its behavior and call signature is identical to the replacement
+    Its behavior and call signature are identical to the replacement
     interface, \FUNC{shmem\_atomic\_set}.
 }
 

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -61,7 +61,7 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
 
 \apinotes{
     As of \openshmem[1.4], \FUNC{shmem\_swap} has been deprecated.
-    Its behavior and call signature is identical to the replacement
+    Its behavior and call signature are identical to the replacement
     interface, \FUNC{shmem\_atomic\_swap}.
 }
 

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -44,7 +44,7 @@ void *shmem_align(size_t alignment, size_t size);
     be allocated, the block to which \VAR{ptr} points is unchanged.
     
     The \FUNC{shmem\_malloc}, \FUNC{shmem\_align}, \FUNC{shmem\_free}, and \FUNC{shmem\_realloc} routines
-    are provided  so that multiple \ac{PE}s in a program can allocate symmetric,
+    are provided  so that multiple \acp{PE} in a program can allocate symmetric,
     remotely accessible memory blocks.  These memory blocks can then be used with
     \openshmem communication routines.  Each of these routines include at least one
     call to a procedure that is semantically equivalent to \FUNC{shmem\_barrier\_all}:
@@ -53,8 +53,8 @@ void *shmem_align(size_t alignment, size_t size);
     \FUNC{shmem\_realloc} may call barriers on both entry and exit, depending on
     whether an existing allocation is modified and whether new memory is allocated.
     This ensures that all
-    \ac{PE}s participate in the memory allocation, and that the memory on other
-    \ac{PE}s can be used as  soon as the local \ac{PE} returns.  The user is
+    \acp{PE} participate in the memory allocation, and that the memory on other
+    \acp{PE} can be used as  soon as the local \ac{PE} returns.  The user is
     responsible for calling these routines with identical argument(s) on all
     \acp{PE}; if differing \VAR{size} arguments are used, the behavior of the call
     and any subsequent \openshmem calls becomes undefined.


### PR DESCRIPTION
* Fix verb tense in atomics text
* Update plural acronyms to use \acp{} macro