### PR TITLE
Removing 'you' from Spec

### DIFF
--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -103,7 +103,7 @@ constraints, which are as follows:
     This routine restores \VAR{pSync} to its original contents.  Multiple calls
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
-    Ensure that the \VAR{pSync} array is not being updated by any
+    The user must ensure that the \VAR{pSync} array is not being updated by any
     \ac{PE} in the \activeset{} while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoall} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -26,21 +26,21 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     elements of data for each \ac{PE} in the \activeset{}, ordered according to
     destination \ac{PE}.}
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
-    \VAR{nelems} must be of type size\_t for \CorCpp.  If you are using
+    \VAR{nelems} must be of type size\_t for \CorCpp.  When using
     \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
-    \acp{PE}.  \VAR{PE\_start} must be of type integer.  If you are using \Fortran,
+    \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between
     consecutive \ac{PE} numbers in the \activeset.  \VAR{logPE\_stride} must be of
-    type integer.  If you are using \Fortran, it must be a default integer value.}
+    type integer.  When using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the \activeset.
-    \VAR{PE\_size} must be of type integer.  If you are using \Fortran, it must
+    \VAR{PE\_size} must be of type integer.  When using \Fortran, it must
     be a default integer value.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be
     of type long and size \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}. In \Fortran,
     \VAR{pSync} must be of type integer and size
-    \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}.  If you are using \Fortran, it must be a
+    \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}.  When using \Fortran, it must be a
     default integer value. Every element of this array must be initialized with
     the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
     \activeset{} enter the routine.}
@@ -103,7 +103,7 @@ constraints, which are as follows:
     This routine restores \VAR{pSync} to its original contents.  Multiple calls
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
-    You must ensure that the \VAR{pSync} array is not being updated by any
+    Ensure that the \VAR{pSync} array is not being updated by any
     \ac{PE} in the \activeset{} while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoall} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -110,7 +110,7 @@ constraints, which are as follows:
     This routine restores \VAR{pSync} to its original contents.  Multiple calls
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
-    Ensure that the \VAR{pSync} array is not being updated by any
+    The user must ensure that the \VAR{pSync} array is not being updated by any
     \ac{PE} in the \activeset{} while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoalls} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -110,7 +110,7 @@ constraints, which are as follows:
     This routine restores \VAR{pSync} to its original contents.  Multiple calls
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
-    Ensure the that the \VAR{pSync} array is not being updated by any
+    Ensure that the \VAR{pSync} array is not being updated by any
     \ac{PE} in the \activeset{} while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoalls} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -29,29 +29,29 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
 \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
     data object.  The stride is scaled by the element size.  A
     value of \CONST{1} indicates contiguous data.  \VAR{dst} must be of type
-    \textit{ptrdiff\_t}.  If you are using \Fortran, it must be a default integer
+    \textit{ptrdiff\_t}.  When using \Fortran, it must be a default integer
     value.}
 \apiargument{IN}{sst}{The  stride between consecutive elements of the
     \source{} data object.  The stride is scaled by the element size.
     A value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-    of type \textit{ptrdiff\_t}.  If you are using \Fortran, it must be a
+    of type \textit{ptrdiff\_t}.  When using \Fortran, it must be a
     default integer value.}
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
-    \VAR{nelems} must be of type size\_t for \CorCpp.  If you are using
+    \VAR{nelems} must be of type size\_t for \CorCpp.  When using
     \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
-    \acp{PE}.  \VAR{PE\_start} must be of type integer.  If you are using \Fortran,
+    \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between
     consecutive \ac{PE} numbers in the \activeset.  \VAR{logPE\_stride} must be of
-    type integer.  If you are using \Fortran, it must be a default integer value.}
+    type integer.  When using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the \activeset.
-    \VAR{PE\_size} must be of type integer.  If you are using \Fortran, it must
+    \VAR{PE\_size} must be of type integer.  When using \Fortran, it must
     be a default integer value.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be
     of type long and size \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}. In \Fortran,
     \VAR{pSync} must be of type integer and size
-    \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}.  If you are using \Fortran, it must be a
+    \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}.  When using \Fortran, it must be a
     default integer value. Every element of this array must be initialized with
     the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
     \activeset{} enter the routine.}
@@ -110,7 +110,7 @@ constraints, which are as follows:
     This routine restores \VAR{pSync} to its original contents.  Multiple calls
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
-    You must ensure the that the \VAR{pSync} array is not being updated by any
+    Ensure the that the \VAR{pSync} array is not being updated by any
     \ac{PE} in the \activeset{} while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoalls} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -43,7 +43,7 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
  }
 
 \apidesctable{
-    When \Fortran, \VAR{dest} must be of the following type:
+    When using \Fortran, \VAR{dest} must be of the following type:
 }{Routine}{Data type of \VAR{dest}}
 
 \apitablerow{SHMEM\_INT4\_ADD}{\CONST{4}-byte integer}

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -26,14 +26,13 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
 
 \begin{apiarguments}
     \apiargument{OUT}{dest}{The remotely accessible integer data object to be
-        updated  on the remote \ac{PE}.  If you are using \CorCpp, the type of
+        updated  on the remote \ac{PE}.  When using \CorCpp, the type of
         \dest{} should match that implied in the SYNOPSIS section.}
-    \apiargument{IN}{value}{The value to be atomically added to \dest. If you
-        are using \CorCpp, the type of \VAR{value} should match that  implied  in
-        the SYNOPSIS  section.  If you are using \Fortran, it must be of type
+    \apiargument{IN}{value}{The value to be atomically added to \dest. When using \CorCpp, the type of \VAR{value} should match that  implied  in
+        the SYNOPSIS  section.  When using \Fortran, it must be of type
         integer with an element size of \dest.}
     \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number upon which
-        \dest{} is to be updated.  If you are using \Fortran, it must be a default
+        \dest{} is to be updated.  When using \Fortran, it must be a default
         integer value.}
 \end{apiarguments}
 
@@ -44,7 +43,7 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
  }
 
 \apidesctable{
-    If you are using \Fortran, \VAR{dest} must be of the following type:
+    When \Fortran, \VAR{dest} must be of the following type:
 }{Routine}{Data type of \VAR{dest}}
 
 \apitablerow{SHMEM\_INT4\_ADD}{\CONST{4}-byte integer}

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -36,7 +36,7 @@ ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
     \apiargument{IN}{value}{The value to be atomically written to the remote
         \ac{PE}. \VAR{value} must be the same data type as \VAR{dest}.}
     \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number upon which
-        \VAR{dest} is to be updated. If you are using \Fortran, it must be a default
+        \VAR{dest} is to be updated. When using \Fortran, it must be a default
         integer value.}
 \end{apiarguments}
 

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -32,7 +32,7 @@ ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
 \apiargument{IN}{value}{The value to be atomically added to \VAR{dest}.  The
     type of \VAR{value} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number on which
-    \VAR{dest} is to be updated.  If you are using \Fortran, it must be a default
+    \VAR{dest} is to be updated.  When using \Fortran, it must be a default
     integer value.}
 
 \end{apiarguments}
@@ -47,7 +47,7 @@ ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
 }
 
 \apidesctable{
-    If you are using \Fortran, \VAR{dest} must be of the following type:
+    When using \Fortran, \VAR{dest} must be of the following type:
 }{Routine}{Data type of \VAR{dest} and \VAR{source}}
 
 \apitablerow{SHMEM\_INT4\_FADD}{\CONST{4}-byte integer}

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -31,7 +31,7 @@ ires_i8 = SHMEM_INT8_FINC(dest, pe)
     on the remote \ac{PE}. The type of \dest{} should match that implied in the
     SYNOPSIS section.}
 \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number on which
-    \dest{} is to be updated.  If you are using \Fortran, it must be a default
+    \dest{} is to be updated.  When using \Fortran, it must be a default
     integer value.}
 
 \end{apiarguments}
@@ -44,7 +44,7 @@ ires_i8 = SHMEM_INT8_FINC(dest, pe)
 }
 
 \apidesctable{
-    If you are using \Fortran, \VAR{dest} must be of the following type:
+    When using \Fortran, \VAR{dest} must be of the following type:
 }{Routine}{Data type of \VAR{dest} and \VAR{source}}
 
 \apitablerow{SHMEM\_INT4\_FINC}{\CONST{4}-byte integer}

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -28,7 +28,7 @@ CALL SHMEM_INT8_INC(dest, pe)
     on the remote \ac{PE}. The type of \dest{} should match that implied in the
     SYNOPSIS section.}
 \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number on which
-    \dest{} is to be  updated. If you are using \Fortran, it must be a default
+    \dest{} is to be  updated. When using \Fortran, it must be a default
     integer value.}
 
 \end{apiarguments}
@@ -40,7 +40,7 @@ CALL SHMEM_INT8_INC(dest, pe)
 
 
 \apidesctable{
-    If you are using \Fortran, \VAR{dest} must be of the following type:
+    When using \Fortran, \VAR{dest} must be of the following type:
 }{Routine}{Data type of \VAR{dest} and \VAR{source}}
 
 \apitablerow{SHMEM\_INT4\_INC}{\CONST{4}-byte integer}

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -29,12 +29,12 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
 
 \begin{apiarguments}
     \apiargument{OUT}{dest}{The  remotely accessible integer data object to be
-        updated on the remote \ac{PE}.	 If you are using \CorCpp, the type of
+        updated on the remote \ac{PE}.	 When using \CorCpp, the type of
         \dest{} should match that  implied in the SYNOPSIS section.}
     \apiargument{IN}{value}{The value to be atomically written to the remote
         \ac{PE}. \VAR{value}  is the same type as \dest.}
     \apiargument{IN}{pe}{ An integer that indicates the \ac{PE} number on which
-        \dest{} is to be updated. If you are using \Fortran, it must be a default
+        \dest{} is to be updated. When using \Fortran, it must be a default
         integer value.}
 \end{apiarguments}
 
@@ -45,7 +45,7 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
 }
 
 \apidesctable{
-    If you are using \Fortran, \VAR{dest} must be of the following type:
+    When using \Fortran, \VAR{dest} must be of the following type:
 }{Routine}{Data type of \VAR{dest} and \VAR{source}}
 
 \apitablerow{SHMEM\_SWAP}{Integer of default kind}

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -18,18 +18,18 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
 \begin{apiarguments}
 
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset of \acp{PE}.
-    \VAR{PE\_start} must be of type integer.  If you are using \Fortran, it must be
+    \VAR{PE\_start} must be of type integer.  When using \Fortran, it must be
     a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between consecutive
     \ac{PE} numbers in the \activeset.  \VAR{logPE\_stride} must be of type integer.
-    If you are using \Fortran, it must be a default integer value.}
+    When using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_size}{The number of  \acp{PE} in the \activeset.  \VAR{PE\_size}
-    must be of type integer.  If you are  using  \Fortran, it must be a default
+    must be of type integer.  When using  \Fortran, it must be a default
     integer value.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must
     be of type long and size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.  In \Fortran,
     \VAR{pSync} must be of type integer and size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.
-    If you are using \Fortran, it must  be a default  integer type.  Every element
+    When using \Fortran, it must  be a default  integer type.  Every element
     of this array must be initialized to \CONST{SHMEM\_SYNC\_VALUE} before any of
     the \acp{PE} in the \activeset enter \FUNC{shmem\_barrier} the first time.}
 

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -26,20 +26,19 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     that is permissible for the \dest{} argument.}
 \apiargument{IN}{nelems}{The number of elements in \source.  For
     \FUNC{shmem\_broadcast32} and \FUNC{shmem\_broadcast4}, this is the number of
-    32-bit halfwords.  nelems must be of type \VAR{size\_t} in \Cstd.  If you are
+    32-bit halfwords.  nelems must be of type \VAR{size\_t} in \Cstd.  When
     using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_root}{Zero-based ordinal of the \ac{PE}, with respect to
     the \activeset,	from which the data is copied. Must be greater than or equal to
-    0 and less than \VAR{PE\_size}. \VAR{PE\_root} must be of type integer.  If you
-    are using \Fortran, it must be a default integer value.}
+    0 and less than \VAR{PE\_size}. \VAR{PE\_root} must be of type integer.  When using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
-    \acp{PE}.  \VAR{PE\_start} must be of type integer.  If you are using \Fortran,
+    \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{ The log (base 2) of the stride between
     consecutive \ac{PE} numbers in the \activeset. \VAR{log\_PE\_stride} must be of
-    type integer.  If you are using \Fortran, it must be a default integer value.}
+    type integer.  When using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_size}{ The number of \acp{PE} in the \activeset.
-    \VAR{PE\_size} must be of type integer.  If you are using \Fortran, it must be a
+    \VAR{PE\_size} must be of type integer.  When using \Fortran, it must be a
     default integer value.}
 \apiargument{IN}{pSync}{ A symmetric work array.  In \CorCpp, \VAR{pSync} must
     be of type long and size \CONST{SHMEM\_BCAST\_SYNC\_SIZE}. In \Fortran,
@@ -67,8 +66,8 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     \dest{} and \source{} data objects and the same \VAR{pSync} work array must be
     passed to all \acp{PE} in the \activeset.
     
-    Before any \ac{PE} calls a broadcast routine, you must ensure that the following
-    conditions exist (synchronization via a barrier or some other method is often
+    Before any \ac{PE} calls a broadcast routine, the following
+    conditions must be met: (synchronization via a barrier or some other method is often
     needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
     \activeset{} is not still in use from a prior call to a broadcast routine.  The
     \dest{} array on all \acp{PE} in the \activeset{} is ready to accept the
@@ -101,7 +100,7 @@ constraints, which are as follows:
     Multiple calls to \openshmem routines that use the same \VAR{pSync} array do not
     require that \VAR{pSync} be reinitialized after the first call.
     
-    You must ensure the that the \VAR{pSync} array is not being updated by any
+    Ensure that the \VAR{pSync} array is not being updated by any
     \ac{PE} in the \activeset{} while any of the \acp{PE} participates in processing
     of an \openshmem broadcast routine. Be careful to avoid these situations: If the
     \VAR{pSync} array is initialized at run time, some type of synchronization is

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -100,7 +100,7 @@ constraints, which are as follows:
     Multiple calls to \openshmem routines that use the same \VAR{pSync} array do not
     require that \VAR{pSync} be reinitialized after the first call.
     
-    Ensure that the \VAR{pSync} array is not being updated by any
+    The user must ensure that the \VAR{pSync} array is not being updated by any
     \ac{PE} in the \activeset{} while any of the \acp{PE} participates in processing
     of an \openshmem broadcast routine. Be careful to avoid these situations: If the
     \VAR{pSync} array is initialized at run time, some type of synchronization is

--- a/content/shmem_cache.tex
+++ b/content/shmem_cache.tex
@@ -28,7 +28,7 @@ CALL SHMEM_UDCFLUSH_LINE(dest)
 \begin{apiarguments}
 
 \apiargument{IN}{dest}{A data object that is local to the \ac{PE}.  \VAR{dest}
-    can be of any noncharacter type. If you are using \Fortran, it can be of any
+    can be of any noncharacter type. When using \Fortran, it can be of any
     kind.}
 
 \end{apiarguments}

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -40,21 +40,21 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \apiargument{IN}{source}{A symmetric data object that can be of any type permissible
     for the \dest{} argument.}
 \apiargument{IN}{nelems}{The number of elements in the \source{} array. \VAR{nelems}
-    must be of type \VAR{size\_t} for \Cstd. If you are using \Fortran, it must be
+    must be of type \VAR{size\_t} for \Cstd. When using \Fortran, it must be
     a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
-    \acp{PE}.  \VAR{PE\_start} must be of type integer.  If you are using \Fortran,
+    \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base \CONST{2}) of the stride between
     consecutive \ac{PE} numbers in the \activeset. \VAR{logPE\_stride} must be of
-    type integer.  If you are using \Fortran, it must be a default integer value.}
+    type integer.  When using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the \activeset. \VAR{PE\_size}
-    must be of type integer.  If you are using  \Fortran, it must be a default
+    must be of type integer.  When using  \Fortran, it must be a default
     integer value.}
 \apiargument{IN}{pSync}{A symmetric  work array.  In \CorCpp, \VAR{pSync} must be of
     type long and size \CONST{SHMEM\_COLLECT\_SYNC\_SIZE}.  In \Fortran,
     \VAR{pSync} must be of type integer and size \CONST{SHMEM\_COLLECT\_SYNC\_SIZE}.
-    If you are using \Fortran, it must be a default integer value.  Every element of
+    When using \Fortran, it must be a default integer value.  Every element of
     this array must be initialized with the value \CONST{SHMEM\_SYNC\_VALUE} in
     \CorCpp{} or \CONST{SHMEM\_SYNC\_VALUE} in \Fortran before any of the \acp{PE}
     in the \activeset{} enter \FUNC{shmem\_collect} or \FUNC{shmem\_fcollect}.}
@@ -99,7 +99,7 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     return, so a particular \VAR{pSync} buffer need only be initialized the first
     time it is used.
     
-    You  must ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
+    Ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
     in the \activeset{} while any of the \acp{PE} participate in processing of an
     \openshmem collective routine.  Be careful to avoid these situations: If the
     \VAR{pSync} array is initialized at run time, some type of synchronization is

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -99,7 +99,7 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     return, so a particular \VAR{pSync} buffer need only be initialized the first
     time it is used.
     
-    Ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
+    The user must ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
     in the \activeset{} while any of the \acp{PE} participate in processing of an
     \openshmem collective routine.  Be careful to avoid these situations: If the
     \VAR{pSync} array is initialized at run time, some type of synchronization is

--- a/content/shmem_get.tex
+++ b/content/shmem_get.tex
@@ -45,11 +45,11 @@ CALL SHMEM_REAL_GET(dest, source, nelems, pe)
         that contains the data to be copied.  This data object must be remotely
         accessible.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
-        arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. If you are
+        arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When
         using \Fortran, it must be a constant, variable, or array element of default
         integer type.}
     \apiargument{IN}{pe}{\ac{PE}  number of the remote \ac{PE}.  \VAR{pe} must
-        be of type integer. If you are using \Fortran, it must be a constant,
+        be of type integer. When using \Fortran, it must be a constant,
         variable, or array element of default integer type.}
 \end{apiarguments}
 
@@ -94,7 +94,7 @@ CALL SHMEM_REAL_GET(dest, source, nelems, pe)
 \apinotes{
     See Section \ref{subsec:memory_model} for a definition of the term
     remotely accessible.
-    If you are using \Fortran, data types must be of default size.  For example, a real
+    When using \Fortran, data types must be of default size.  For example, a real
     variable must be declared as \CONST{REAL}, \CONST{REAL*4},  or
     \CONST{REAL(KIND=KIND(1.0))}.
 }

--- a/content/shmem_get_nbi.tex
+++ b/content/shmem_get_nbi.tex
@@ -46,11 +46,11 @@ CALL SHMEM_REAL_GET_NBI(dest, source, nelems, pe)
         that contains the data to be copied.  This data object must be remotely
         accessible.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
-        arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. If you are
+        arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When
         using \Fortran, it must be a constant, variable, or array element of default
         integer type.}
     \apiargument{IN}{pe}{\ac{PE}  number of the remote \ac{PE}.  \VAR{pe} must
-        be of type integer. If you are using \Fortran, it must be a constant,
+        be of type integer. When using \Fortran, it must be a constant,
         variable, or array element of default integer type.}
 \end{apiarguments}
 
@@ -97,7 +97,7 @@ CALL SHMEM_REAL_GET_NBI(dest, source, nelems, pe)
 \apinotes{
     See Section \ref{subsec:memory_model} for a definition of the term
     remotely accessible.
-    If you are using \Fortran, data types must be of default size.  For example, a real
+    When using \Fortran, data types must be of default size.  For example, a real
     variable must be declared as \CONST{REAL}, \CONST{REAL*4},  or
     \CONST{REAL(KIND=KIND(1.0))}.
 }

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -39,12 +39,12 @@ CALL SHMEM_REAL_IGET(dest, source, dst, sst, nelems, pe)
     \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
         array.  The stride is scaled by the element size of the \dest{} array.
         A  value of \CONST{1} indicates contiguous data. \VAR{dst} must be of
-        type \textit{ptrdiff\_t}.  When calling  from  \Fortran,  it  must
+        type \textit{ptrdiff\_t}.  When using  \Fortran,  it  must
         be a default integer value.}
     \apiargument{IN}{sst}{The stride between consecutive elements of the
         \source{} array.  The stride is scaled by the element size of the \source{}
         array.  A  value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-        of type \textit{ptrdiff\_t}.  When calling  from  \Fortran,  it  must
+        of type \textit{ptrdiff\_t}.  When using  \Fortran,  it  must
         be a default integer value.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
         arrays.  \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -39,19 +39,19 @@ CALL SHMEM_REAL_IGET(dest, source, dst, sst, nelems, pe)
     \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
         array.  The stride is scaled by the element size of the \dest{} array.
         A  value of \CONST{1} indicates contiguous data. \VAR{dst} must be of
-        type \textit{ptrdiff\_t}.  If you are calling  from  \Fortran,  it  must
+        type \textit{ptrdiff\_t}.  When calling  from  \Fortran,  it  must
         be a default integer value.}
     \apiargument{IN}{sst}{The stride between consecutive elements of the
         \source{} array.  The stride is scaled by the element size of the \source{}
         array.  A  value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-        of type \textit{ptrdiff\_t}.  If you are calling  from  \Fortran,  it  must
+        of type \textit{ptrdiff\_t}.  When calling  from  \Fortran,  it  must
         be a default integer value.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
-        arrays.  \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. If you are
+        arrays.  \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When
         using \Fortran, it must be  a constant, variable, or array element of
         default integer type.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.  \VAR{pe} must be
-        of type integer. If you  are  using  \Fortran, it must be a constant,
+        of type integer. When using  \Fortran, it must be a constant,
         variable, or array element of default integer type.}
 \end{apiarguments}
 
@@ -87,7 +87,7 @@ CALL SHMEM_REAL_IGET(dest, source, dst, sst, nelems, pe)
 }
 
 \apinotes{
-    If you are using \Fortran, data types must be of default size. For example, a
+    When using \Fortran, data types must be of default size. For example, a
     real variable must be declared as \CONST{REAL}, \CONST{REAL*4}, or
     \CONST{REAL(KIND=KIND(1.0))}. 
 }

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -40,18 +40,18 @@ CALL SHMEM_REAL_IPUT(dest, source, dst, sst, nelems, pe)
     \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
         array.  The stride is scaled by the element size of the \dest{} array.  A
         value of \CONST{1} indicates contiguous data.  \VAR{dst} must be of type
-        \textit{ptrdiff\_t}.  If you are using \Fortran, it must be a default integer value.}
+        \textit{ptrdiff\_t}.  When using \Fortran, it must be a default integer value.}
     \apiargument{IN}{sst}{The  stride between consecutive elements of the
         \source{} array.  The stride is scaled by the element size of the \source{}
         array.  A  value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-        of type \textit{ptrdiff\_t}.  If you are using \Fortran, it must be a
+        of type \textit{ptrdiff\_t}.  When using \Fortran, it must be a
         default integer value.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
-        arrays.  \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.  If you are
+        arrays.  \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.  When
         using \Fortran, it must be  a constant, variable, or array element of
         default integer type.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.  \VAR{pe} must be
-        of type integer.   If you  are  using  \Fortran, it must be a constant,
+        of type integer.   When  \Fortran, it must be a constant,
         variable, or array element of default integer type.}
 \end{apiarguments}
 
@@ -91,7 +91,7 @@ CALL SHMEM_REAL_IPUT(dest, source, dst, sst, nelems, pe)
 }
 
 \apinotes{
-    If you are using \Fortran, data types must be of default size.  For example, a
+    When using \Fortran, data types must be of default size.  For example, a
     real variable must be declared as  \CONST{REAL}, \CONST{REAL*4} or
     \CONST{REAL(KIND=KIND(1.0))}.
     See Section \ref{subsec:memory_model} for a definition of the term

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -51,7 +51,7 @@ CALL SHMEM_REAL_IPUT(dest, source, dst, sst, nelems, pe)
         using \Fortran, it must be  a constant, variable, or array element of
         default integer type.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.  \VAR{pe} must be
-        of type integer.   When  \Fortran, it must be a constant,
+        of type integer.   When using  \Fortran, it must be a constant,
         variable, or array element of default integer type.}
 \end{apiarguments}
 

--- a/content/shmem_lock.tex
+++ b/content/shmem_lock.tex
@@ -20,7 +20,7 @@ I = SHMEM_TEST_LOCK(lock)
 \apiargument{IN}{lock}{A symmetric data object that is a scalar variable or an array
     of  length \CONST{1}.  This data  object  must  be set to \CONST{0} on all
     \acp{PE} prior to the first use.  \VAR{lock}  must  be  of type \CONST{long}.
-    If you are using \Fortran, it must be of default kind.}
+    When using \Fortran, it must be of default kind.}
 \end{apiarguments}
 
 \apidescription{

--- a/content/shmem_ptr.tex
+++ b/content/shmem_ptr.tex
@@ -18,7 +18,7 @@ PTR = SHMEM_PTR(dest, pe)
 \begin{apiarguments}
 \apiargument{IN}{dest}{The symmetric data object to be referenced.}
 \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number on which \dest{} is to
-		 be accessed.  If you are using \Fortran, it must be a  default
+		 be accessed.  When using \Fortran, it must be a  default
 		 integer value.}
 \end{apiarguments}
 

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -44,11 +44,11 @@ CALL SHMEM_REAL_PUT(dest, source, nelems, pe)
     data object must be remotely accessible.}
     \apiargument{OUT}{source}{Data object containing the data to be copied.}
     \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
-    arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. If you are using
+    arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When using
     \Fortran, it must be a constant, variable, or array element of default
     integer type.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}. \VAR{pe} must be
-    of type integer. If you are using \Fortran, it must be a constant, variable,
+    of type integer. When using \Fortran, it must be a constant, variable,
     or array element of default integer type.}
 \end{apiarguments}
 
@@ -89,7 +89,7 @@ CALL SHMEM_REAL_PUT(dest, source, nelems, pe)
     None.
 }
 \apinotes{
-    If you are using \Fortran, data types must be of default size.  For example,
+    When using \Fortran, data types must be of default size.  For example,
     a real variable must be declared as \CONST{REAL},  \CONST{REAL*4},  or
     \CONST{REAL(KIND=KIND(1.0))}. The Fortran API routine \FUNC{SHMEM\_PUT} has
     been deprecated, and either \FUNC{SHMEM\_PUT8} or \FUNC{SHMEM\_PUT64} should

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -44,11 +44,11 @@ CALL SHMEM_REAL_PUT_NBI(dest, source, nelems, pe)
     data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}
     \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
-    arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. If you are using
+    arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When using
     \Fortran, it must be a constant, variable, or array element of default
     integer type.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}. \VAR{pe} must be
-    of type integer. If you are using \Fortran, it must be a constant, variable,
+    of type integer. When using \Fortran, it must be a constant, variable,
     or array element of default integer type.}
 \end{apiarguments}
 

--- a/content/shmem_quiet.tex
+++ b/content/shmem_quiet.tex
@@ -36,7 +36,7 @@ CALL SHMEM_QUIET
     \FUNC{shmem\_quiet} is most useful as a way of ensuring completion of
     several \PUT{}, \acp{AMO}, memory store, and non-blocking \PUT{}
     and \GET{} routines to symmetric data objects initiated by the calling
-    \ac{PE}.  For example, you might use \FUNC{shmem\_quiet} to await delivery
+    \ac{PE}.  For example, one might use \FUNC{shmem\_quiet} to await delivery
     of a block of data before issuing another \PUT{} or non-blocking
     \PUT{} routine, which sets a completion flag on another \ac{PE}.
      \FUNC{shmem\_quiet} is not usually needed if

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -201,7 +201,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     be passed to all \acp{PE} in the \activeset.
     
     Before any \ac{PE} calls a reduction routine, the
-    following conditions must be met FIXME (synchronization via a \OPR{barrier} or some other
+    following conditions must be met (synchronization via a \OPR{barrier} or some other
     method is often needed to ensure this): The \VAR{pWrk} and \VAR{pSync} arrays
     on all \acp{PE} in the \activeset{} are not still in use from a prior call to a
     collective \openshmem{} routine.  The \dest{} array on all \acp{PE} in the

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -199,7 +199,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     \VAR{PE\_size} must be equal on all \acp{PE} in the \activeset. The same \dest{}
     and \source{} arrays, and the same \VAR{pWrk} and \VAR{pSync} work arrays, must
     be passed to all \acp{PE} in the \activeset.
-    
+    %FIXME: Reword 'the following conditions must be met.'
     Before any \ac{PE} calls a reduction routine, the
     following conditions must be met (synchronization via a \OPR{barrier} or some other
     method is often needed to ensure this): The \VAR{pWrk} and \VAR{pSync} arrays

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -201,7 +201,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     be passed to all \acp{PE} in the \activeset.
     
     Before any \ac{PE} calls a reduction routine, the
-    following conditions must be met (synchronization via a \OPR{barrier} or some other
+    following conditions must be met FIXME (synchronization via a \OPR{barrier} or some other
     method is often needed to ensure this): The \VAR{pWrk} and \VAR{pSync} arrays
     on all \acp{PE} in the \activeset{} are not still in use from a prior call to a
     collective \openshmem{} routine.  The \dest{} array on all \acp{PE} in the

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -254,7 +254,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \apinotes{  
     All \openshmem{} reduction routines reset the values in \VAR{pSync} before they
     return, so a particular \VAR{pSync} buffer need only be initialized the first
-    time it is used. Ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
+    time it is used. The user must ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
     in the \activeset{} while any of the \acp{PE} participate in processing of an
     \openshmem{} reduction routine. Be careful to avoid the following situations: If
     the \VAR{pSync} array is initialized at run time, some type of synchronization

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -150,16 +150,16 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     contains one element for each separate reduction routine.  The \source{}
     argument must have the same data type as \dest.}
 \apiargument{IN}{\VAR{nreduce}}{The number of elements in the \dest{} and \source{}
-    arrays.  \VAR{nreduce} must be of type integer.  If you are using \Fortran, it
+    arrays.  \VAR{nreduce} must be of type integer.  When using \Fortran, it
     must be a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
-    \acp{PE}.  \VAR{PE\_start} must be of type integer.  If you are using \Fortran,
+    \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between consecutive
     \ac{PE} numbers in the \activeset.  \VAR{logPE\_stride} must be of type integer.
-    If you are using \Fortran, it must be a default integer value.}
+    When using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the \activeset.
-    \VAR{PE\_size} must be of type integer.  If you are using \Fortran, it must be a
+    \VAR{PE\_size} must be of type integer.  When using \Fortran, it must be a
     default integer value.}
 \apiargument{IN}{pWrk}{A symmetric work array. The \VAR{pWrk} argument must have the
     same data type as \dest. In \CorCpp, this contains max(\VAR{nreduce}/2 + 1,
@@ -168,7 +168,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     elements.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be of
     type long and size \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}. In \Fortran, \VAR{pSync}
-    must be of type integer and size \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}.  If you are
+    must be of type integer and size \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}.  When
     using \Fortran, it must be a default integer value. Every element of this array
     must be initialized with the value \CONST{SHMEM\_SYNC\_VALUE} (in \CorCpp) or
     \CONST{SHMEM\_SYNC\_VALUE} (in \Fortran) before any of the \acp{PE} in the
@@ -200,8 +200,8 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     and \source{} arrays, and the same \VAR{pWrk} and \VAR{pSync} work arrays, must
     be passed to all \acp{PE} in the \activeset.
     
-    Before any \ac{PE} calls a reduction routine, you must ensure that the
-    following conditions exist (synchronization via a \OPR{barrier} or some other
+    Before any \ac{PE} calls a reduction routine, the
+    following conditions must be met (synchronization via a \OPR{barrier} or some other
     method is often needed to ensure this): The \VAR{pWrk} and \VAR{pSync} arrays
     on all \acp{PE} in the \activeset{} are not still in use from a prior call to a
     collective \openshmem{} routine.  The \dest{} array on all \acp{PE} in the
@@ -254,7 +254,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \apinotes{  
     All \openshmem{} reduction routines reset the values in \VAR{pSync} before they
     return, so a particular \VAR{pSync} buffer need only be initialized the first
-    time it is used. You must ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
+    time it is used. Ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
     in the \activeset{} while any of the \acp{PE} participate in processing of an
     \openshmem{} reduction routine. Be careful to avoid the following situations: If
     the \VAR{pSync} array is initialized at run time, some type of synchronization

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -38,14 +38,14 @@ CALL SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)
 \begin{apiarguments}
 
 \apiargument{OUT}{ivar}{A remotely accessible integer variable that is being updated
-    by another \ac{PE}.  If you are using \CorCpp, the type of \VAR{ivar} should
+    by another \ac{PE}.  When using \CorCpp, the type of \VAR{ivar} should
     match that implied in the SYNOPSIS section.} 
 \apiargument{IN}{cmp}{The compare operator that compares \VAR{ivar} with
-  \VAR{cmp\_value}.  If you are using \Fortran, it must  be of default kind.
-  If you are using \CorCpp, it must be of type \CTYPE{shmem\_cmp\_t}.}
-\apiargument{IN}{cmp\_value}{\VAR{cmp\_value} must be of type integer.  If you are
+  \VAR{cmp\_value}.  When using \Fortran, it must  be of default kind.
+  When using \CorCpp, it must be of type \CTYPE{shmem\_cmp\_t}.}
+\apiargument{IN}{cmp\_value}{\VAR{cmp\_value} must be of type integer.  When
     using \CorCpp, the type of \VAR{cmp\_value} should match that implied in the
-    SYNOPSIS section.  If  you are using \Fortran, cmp\_value must be an integer of
+    SYNOPSIS section.  When using \Fortran, cmp\_value must be an integer of
     the same size and kind as \VAR{ivar}.}
 
 \end{apiarguments}
@@ -68,7 +68,7 @@ CALL SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)
 
 
 \apidesctable{
-    If you are using \Fortran, \VAR{ivar} must be a specific sized integer type
+    When using \Fortran, \VAR{ivar} must be a specific sized integer type
     according to the routine being called, as follows:
 }{Routine}{Data type}
 

--- a/content/shpalloc.tex
+++ b/content/shpalloc.tex
@@ -25,7 +25,8 @@ CALL SHPALLOC(addr, length, errcode, abort)
     consistency, all \acp{PE} in an program must call \FUNC{SHPALLOC} with the same
     value of length; if any  \acp{PE} are missing, the program will hang.
     
-    By using the \Fortran \CONST{POINTER} mechanism in the following manner, array \VAR{A} can be used to refer to the block allocated by \FUNC{SHPALLOC}:
+    By using the \Fortran \CONST{POINTER} mechanism in the following manner, 
+    array \VAR{A} can be used to refer to the block allocated by \FUNC{SHPALLOC}:
     \CONST{POINTER} (\VAR{addr}, \VAR{A}())
 }
 

--- a/content/shpalloc.tex
+++ b/content/shpalloc.tex
@@ -25,8 +25,7 @@ CALL SHPALLOC(addr, length, errcode, abort)
     consistency, all \acp{PE} in an program must call \FUNC{SHPALLOC} with the same
     value of length; if any  \acp{PE} are missing, the program will hang.
     
-    By using the \Fortran \CONST{POINTER} mechanism in the following manner, you
-    can use array \VAR{A} to refer to the block allocated by \FUNC{SHPALLOC}:
+    By using the \Fortran \CONST{POINTER} mechanism in the following manner, array \VAR{A} can be used to refer to the block allocated by \FUNC{SHPALLOC}:
     \CONST{POINTER} (\VAR{addr}, \VAR{A}())
 }
 


### PR DESCRIPTION
Removed use of 'you' from document and replaced with impersonal expressions.

Signed-off-by: Michael Culhane <j.mike.culhane@gmail.com>