### PR TITLE
Punctuation fixes up to pg. 7.

### DIFF
--- a/content/execution_model.tex
+++ b/content/execution_model.tex
@@ -1,18 +1,18 @@
 An \openshmem program consists of a set of \openshmem processes called \acp{PE}
-that execute in a \ac{SPMD}-like model where each \ac{PE} can take a different
+that execute in a \ac{SPMD}-like model, where each \ac{PE} can take a different
 execution path. For example, a \ac{PE} can be implemented using an OS
 process.  The \acp{PE} progress asynchronously, and can communicate/synchronize
 via the \openshmem interfaces.  All \acp{PE} in an \openshmem program should
 start by calling the initialization routine  \FUNC{shmem\_init}
 \footnote{\textbf{start\_pes} has been deprecated as of Specification 1.2}
 before using any of the other \openshmem library routines.  An \openshmem
-program finishes execution by returning from the main routine or when any PE
+program finishes execution by returning from the main routine, or when any PE
 calls \FUNC{shmem\_global\_exit}. When returning from main, \openshmem must
 complete all pending communication and release all the resources associated to
 the library using an implicit collective synchronization across PEs. The user
 has the option to call \FUNC{shmem\_finalize} (before returning from main) to
-complete all pending communication and release all the \openshmem library
-resources without terminating the program. Calling any \openshmem routine after
+complete all pending communication, and release all the \openshmem library
+resources, without terminating the program. Calling any \openshmem routine after
 \FUNC{shmem\_finalize} leads to undefined behavior.
 
 The \acp{PE} of the \openshmem program are identified by unique integers.  The
@@ -45,7 +45,7 @@ that \ac{PE} next engages in an \openshmem call.
       hardware offload capabilities and provide asynchronous one-sided
       communication without software assistance.
   \item Implementations should avoid deferring the execution of one-sided
-      operations until a synchronization point where data is known to be
+      operations until a synchronization point, where data is known to be
       available. High-quality implementations should attempt asynchronous delivery
       whenever possible, for performance reasons. Additionally, the \openshmem
       community discourages releasing \openshmem implementations that do not

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -37,7 +37,7 @@ data objects are symmetric:
 \openshmem dynamic memory allocation routines (\textit{shpalloc} and
 \textit{shmem\_malloc}) allow collective allocation of \emph{Symmetric Data
 Objects} on a special memory region called the \emph{Symmetric Heap}. The
-Symmetric Heap is created during the execution of a program at a memory location
+Symmetric Heap is created, during the execution of a program, at a memory location
 determined by the implementation. The Symmetric Heap may reside in different
 memory regions on different \acp{PE}. Figure~\ref{fig:mem_model} shows how
 \openshmem implements a \ac{PGAS} model using remotely accessible symmetric

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -1,5 +1,5 @@
 \openshmem implements \ac{PGAS} by defining remotely accessible data objects as
-mechanisms to share information among \openshmem processes or \acp{PE} and
+mechanisms to share information among \openshmem processes, or \acp{PE}, and
 private data objects that are accessible by the \ac{PE} itself. The \ac{API}
 allows communication and synchronization operations on both private (local to
 the PE initiating the operation) and remotely accessible data objects. The key
@@ -51,11 +51,11 @@ An overview of the \openshmem routines is described below:
 
 \item \textbf{Remote Memory Access}
 \begin{enumerate}
-    \item \PUT: The local \ac{PE} specifies the \source{} data object (private
-        or symmetric) that is copied to the symmetric data object on the remote
+    \item \PUT: The local \ac{PE} specifies the \source{} data object, private
+        or symmetric, that is copied to the symmetric data object on the remote
         \ac{PE}. 
   \item \GET: The local \ac{PE} specifies the symmetric data object on the remote
-      \ac{PE} that is copied to a data object (private or symmetric) on the local
+      \ac{PE} that is copied to a data object, private or symmetric, on the local
       \ac{PE}. 
 \end{enumerate}
 
@@ -87,7 +87,7 @@ An overview of the \openshmem routines is described below:
       destination \ac{PE}. 
   \item \OPR{Quiet}: The \ac{PE} calling quiet ensures completion of remote access
       operations and stores to symmetric data objects. 
-  \item \OPR{Barrier}: All or some \acp{PE} collectively synchronize and ensure
+  \item \OPR{Barrier}: All, or some \acp{PE}, collectively synchronize and ensure
       completion of all remote and local updates prior to any \ac{PE} returning
       from the call.
 \end{enumerate}


### PR DESCRIPTION
Most of the edits in this PR were made to clarify confusing sentences. For example, on page 3, line 43, the sentence read: 'the symmetric heap is created during the execution of a program at a memory location determined by the implementation.' It nows reads: 'the symmetric heap is created, during the execution of a program, at a memory location determined by the implementation' so as to clarify that it is the heap, and not the program, that is being created at a memory location determined by implementation.