### PR TITLE
Update OpenSHMEM implementations list on Annex-E

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -301,7 +301,7 @@ interconnect, and to a very limited extent, Infiniband based clusters.
   \item SGI \openshmem
   \item University of Houston - \openshmem Reference Implementation
   \item Mellanox ScalableSHMEM
-  \item Portals-SHMEM
+  \item Sandia OpenSHMEM
   \item IBM OpenSHMEM
   \item Cray SHMEM
   \end{itemize}

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -303,6 +303,7 @@ interconnect, and to a very limited extent, Infiniband based clusters.
   \item Mellanox ScalableSHMEM
   \item Portals-SHMEM
   \item IBM OpenSHMEM
+  \item Cray SHMEM
   \end{itemize}
 \end{itemize}
 


### PR DESCRIPTION
Annex:E has list of OpenSHMEM implementations. 

1. Adding Cray SHMEM as part of that OpenSHMEM implementations. 
From version 7.4.0, Cray SHMEM is OpenSHMEM-1.3 compliant .

2. Changing name of Portals-SHMEM to Sandia OpenSHMEM 