### PR TITLE
Update shmem_test() example to be runnable

### DIFF
--- a/example_code/shmem_test_example1.c
+++ b/example_code/shmem_test_example1.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <shmem.h>
 
 int user_wait_any(long *ivar, int count, shmem_cmp_t cmp, long value)
@@ -6,4 +7,24 @@ int user_wait_any(long *ivar, int count, shmem_cmp_t cmp, long value)
   while (!shmem_test(&ivar[idx], cmp, value))
     idx = (idx + 1) % count;
   return idx;
+}
+
+int main(void)
+{
+  shmem_init();
+  const int mype = shmem_my_pe();
+  const int npes = shmem_n_pes();
+
+  long *wait_vars = shmem_calloc(npes, sizeof(long));
+  if (mype == 0)
+  {
+    int who = user_wait_any(wait_vars, npes, SHMEM_CMP_NE, 0);
+    printf("PE %d observed first update from PE %d\n", mype, who);
+  }
+  else
+    shmem_p(&wait_vars[mype], mype, 0);
+
+  shmem_free(wait_vars);
+  shmem_finalize();
+  return 0;
 }


### PR DESCRIPTION
PR #32 was ratified with the expectation that the `shmem_test()` example would be updated to a runnable example and not merely be a function demonstrating the use of `shmem_test()` (see Issue #68). This PR should close out #68.

Here's looking at you, @shamisp.