### PR TITLE
General LaTeX doc-edit cleanups

### DIFF
--- a/content/atomics_intro.tex
+++ b/content/atomics_intro.tex
@@ -2,7 +2,7 @@ An \ac{AMO} is a one-sided communication mechanism that combines memory update
 operations with atomicity guarantees described in Section
 \ref{subsec:amo_guarantees}.  Similar to the \ac{RMA} routines, described in
 Section \ref{sec:rma}, the \acp{AMO} are performed only on symmetric objects.
-\openshmem{} defines the two types of \ac{AMO} routines:
+\openshmem defines the two types of \ac{AMO} routines:
 \begin{itemize}
 \item
 The \textit{fetching} routines return the original value of, and optionally
@@ -19,13 +19,13 @@ atomic operation.  A call to a non-fetching atomic routine issues the atomic
 operation and may return before the operation executes on the remote \ac{PE}.
 To force completion for these non-fetching atomic routines,
 \FUNC{shmem\_quiet}, \FUNC{shmem\_barrier}, or \FUNC{shmem\_barrier\_all} can
-be used by an \openshmem{} program.
+be used by an \openshmem program.
 
 The non-fetching operations include:
 \FUNC{shmem\_atomic\_\{set, inc, add, and, or, xor\}}.
 \end{itemize}
 
-Where appropriate compiler support is available, \openshmem{} provides
+Where appropriate compiler support is available, \openshmem provides
 type-generic \ac{AMO} interfaces via \Cstd[11] generic selection.
 The type-generic support for the \ac{AMO} routines is as follows:
 

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -777,7 +777,7 @@ calls are encountered has been clarified.
 \item Clarification of the size of the symmetric heap and when it is set.
 \\See Section \ref{subsec:shfree}.
 %
-\item Clarification of the integer and real sizes for \Fortran{} \ac{API}.
+\item Clarification of the integer and real sizes for \Fortran \ac{API}.
 \\See Sections \ref{subsec:shmem_atomic_add},
       \ref{subsec:shmem_atomic_compare_swap},
       \ref{subsec:shmem_atomic_swap},

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -14,8 +14,8 @@
 
 
 
-\chapter{Writing \openshmem Programs}
-\section*{Incorporating \openshmem into Programs}\label{sec:writing_programs}
+\chapter{Writing OpenSHMEM Programs}
+\section*{Incorporating OpenSHMEM into Programs}\label{sec:writing_programs}
 
 The following section describes how to write a ``Hello World" \openshmem program.
 To write a ``Hello World" \openshmem program, the user must: 
@@ -110,7 +110,7 @@ Where the $\langle\mbox{compiler options}\rangle$ are options understood by the
 underlying \Cpp compiler called by \textbf{oshCC}.
 
 
-\subsection*{Programs written in \Fortran}
+\subsection*{Programs written in Fortran}
 
 The  \openshmem Reference Implementation provides a wrapper program named
 \textbf{oshfort}, to aid in the compilation of \Fortran programs, the wrapper
@@ -144,7 +144,7 @@ $\langle\mbox{program arguments}\rangle$ & {Flags and other parameters to pass t
 
 
 
-\chapter{Undefined Behavior in \openshmem}\label{sec:undefined}
+\chapter{Undefined Behavior in OpenSHMEM}\label{sec:undefined}
 
 The specification provides guidelines to the expected behavior of
 various library routines.  In cases where routines are improperly used
@@ -257,7 +257,7 @@ non-default memory placement options.
 
 
 
-\chapter{History of \openshmem}\label{sec:openshmem_history}
+\chapter{History of OpenSHMEM}\label{sec:openshmem_history}
 
 SHMEM has a long history as a parallel programming model, having been used
 extensively on a number of products since 1993, including Cray T3D, Cray X1E,
@@ -313,7 +313,7 @@ interconnect, and to a very limited extent, Infiniband based clusters.
 
 
 
-\chapter{\openshmem Specification and Deprecated API}\label{sec:dep_api}
+\chapter{OpenSHMEM Specification and Deprecated API}\label{sec:dep_api}
 
 \section{Overview}\label{subsec:dep_overview}
 For the \openshmem Specification(s), deprecation is the process of identifying
@@ -420,12 +420,12 @@ The \CorCpp routines \FUNC{\_my\_pe}, \FUNC{\_num\_pes}, \FUNC{shmalloc},
 to normalize the \openshmem \ac{API} to use \shmemprefixLC{} as the standard
 prefix for all routines.
 
-\subsection{\Fortran: START\_PES, MY\_PE, NUM\_PES}
+\subsection{Fortran: START\_PES, MY\_PE, NUM\_PES}
 The \Fortran routines \FUNC{START\_PES}, \FUNC{MY\_PE}, and \FUNC{NUM\_PES}
 were deprecated in order to minimize the API differences from the deprecation
 of \CorCpp routines \FUNC{start\_pes}, \FUNC{\_my\_pe}, and \FUNC{\_num\_pes}.
 
-\subsection{\Fortran: SHMEM\_PUT}
+\subsection{Fortran: SHMEM\_PUT}
 The \Fortran function \FUNC{SHMEM\_PUT} is defined only for the \Fortran
 \ac{API} and is semantically identical to \Fortran functions
 \FUNC{SHMEM\_PUT8} and \FUNC{SHMEM\_PUT64}.  Since \FUNC{SHMEM\_PUT8} and
@@ -466,7 +466,7 @@ with corresponding constants of prefix \shmemprefix{} that adhere to \CorCpp{}
 and \Fortran naming conventions.
 
 \subsection{\FUNC{shmem\_fetch}, \FUNC{shmem\_set}, \FUNC{shmem\_cswap},
-  \FUNC{shmem\_swap}, \FUNC{shmem\_finc}, \FUNC{shmem\_inc}, \\
+  \FUNC{shmem\_swap}, \FUNC{shmem\_finc}, \FUNC{shmem\_inc},
   \FUNC{shmem\_fadd}, \FUNC{shmem\_add}}
 
 The \CorCpp interfaces for \FUNC{shmem\_fetch}, \FUNC{shmem\_set},

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -15,7 +15,7 @@
 
 
 \chapter{Writing \openshmem Programs}
-\section*{Incorporating \openshmem{} into Programs}\label{sec:writing_programs}
+\section*{Incorporating \openshmem into Programs}\label{sec:writing_programs}
 
 The following section describes how to write a ``Hello World" \openshmem program.
 To write a ``Hello World" \openshmem program, the user must: 
@@ -78,15 +78,15 @@ active (local) side, the asymmetric \source{} object is handled correctly.
 
 
 \chapter{Compiling and Running Programs}\label{sec:compiling}
-As of this writing, the \openshmem{} specification is silent regarding how
-\openshmem{} programs are compiled, linked and run. This section shows some
-examples of how wrapper programs are utilized in the \openshmem{} Reference
+As of this writing, the \openshmem specification is silent regarding how
+\openshmem programs are compiled, linked and run. This section shows some
+examples of how wrapper programs are utilized in the \openshmem Reference
 Implementation to compile and launch programs.
 
 \section{Compilation}
 \subsection*{Programs written in \Cstd}
 
-The \openshmem{} Reference Implementation provides a wrapper program named
+The \openshmem Reference Implementation provides a wrapper program named
 \textbf{oshcc}, to aid in the compilation of \Cstd programs, the wrapper
 could be called as follows:
 
@@ -99,7 +99,7 @@ underlying \Cstd compiler.
 
 \subsection*{Programs written in \Cpp}
 
-The  \openshmem{} Reference Implementation provides a wrapper program named
+The  \openshmem Reference Implementation provides a wrapper program named
 \textbf{oshCC}, to aid in the compilation of \Cpp programs, the wrapper could
 be called as follows:
 
@@ -112,7 +112,7 @@ underlying \Cpp compiler called by \textbf{oshCC}.
 
 \subsection*{Programs written in \Fortran}
 
-The  \openshmem{} Reference Implementation provides a wrapper program named
+The  \openshmem Reference Implementation provides a wrapper program named
 \textbf{oshfort}, to aid in the compilation of \Fortran programs, the wrapper
 could be called as follows:
 
@@ -124,7 +124,7 @@ underlying \Fortran compiler called by \textbf{oshfort}.
 
 \section{Running Programs}
 
-The  \openshmem{} Reference Implementation provides a wrapper program named
+The  \openshmem Reference Implementation provides a wrapper program named
 \textbf{oshrun}, to launch \openshmem programs, the wrapper could be called as
 follows:
 

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -108,13 +108,13 @@ for more information about the usage of this constant.\tabularnewline
 \vtop{\hbox{\CorCppFor:} 
 \hbox{\hspace*{12mm} \const{SHMEM\_MAJOR\_VERSION}}}
 & 
-Integer representing the major version of \openshmem{} standard in use. \tabularnewline
+Integer representing the major version of \openshmem standard in use. \tabularnewline
 \hline
 \vspace{3mm}
 \vtop{\hbox{\CorCppFor:} 
 \hbox{\hspace*{12mm} \const{SHMEM\_MINOR\_VERSION}}}
 & 
-Integer representing the minor version of \openshmem{} standard in use. \tabularnewline
+Integer representing the minor version of \openshmem standard in use. \tabularnewline
 \hline
 \vspace{3mm}
 \vtop{\hbox{\CorCppFor:} 

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -128,7 +128,7 @@ Integer representing the maximum length of \const{SHMEM\_VENDOR\_STRING}. \tabul
 &
 String representing vendor defined information of size at most
 \const{SHMEM\_MAX\_NAME\_LEN}.
-In \CorCpp{}, the string is terminated by a null character.  In \Fortran{}, the
+In \CorCpp{}, the string is terminated by a null character.  In \Fortran, the
 string of size less than \const{SHMEM\_MAX\_NAME\_LEN} is padded with blank
 characters up to size \const{SHMEM\_MAX\_NAME\_LEN}. \tabularnewline
 \hline

--- a/content/p2p_sync_intro.tex
+++ b/content/p2p_sync_intro.tex
@@ -15,9 +15,9 @@ Table~\ref{p2psynctypes}.
 % Fix the C99 styling here with the macros from PRs #55 and #31, and
 % osh_spec_next for \HEADER{}
 The point-to-point synchronization types include some of the exact-width
-integer types defined in \textit{stdint.h} by \Cstd[99]~\S7.18.1.1 and
+integer types defined in \HEADER{stdint.h} by \Cstd[99]~\S7.18.1.1 and
 \Cstd[11]~\S7.20.1.1. When the \Cstd translation environment
-does not provide exact-width integer types with \textit{stdint.h}, an
+does not provide exact-width integer types with \HEADER{stdint.h}, an
 \openshmem implemementation is not required to provide support for these types.
 
 \begin{table}[h]

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -12,8 +12,8 @@ unstructured, small/medium size data communication patterns. The \openshmem
 library routines have the potential to provide a low-latency, high-bandwidth
 communication \ac{API} for use in highly parallelized scalable programs.  
 
-The \openshmem{} interfaces can be used to implement \ac{SPMD} style programs.
-It provides interfaces to start the \openshmem{} \acp{PE} in parallel, and
+The \openshmem interfaces can be used to implement \ac{SPMD} style programs.
+It provides interfaces to start the \openshmem \acp{PE} in parallel, and
 communication and synchronization interfaces to access remotely accessible data
 objects across \acp{PE}. These interfaces can be leveraged to divide a problem
 into multiple sub-problems that can be solved independently or with coordination

--- a/content/rma_intro.tex
+++ b/content/rma_intro.tex
@@ -1,18 +1,18 @@
 The \ac{RMA} routines described in this section are one-sided communication
-mechanisms of the \openshmem{} \ac{API}. While using these mechanisms, the user
+mechanisms of the \openshmem \ac{API}. While using these mechanisms, the user
 is required to provide parameters only on the calling side. A characteristic of
 one-sided communication is that it decouples communication from the
 synchronization. One-sided communication mechanisms transfer the data but do not
 synchronize the sender of the data with the receiver of the data. 
 
-\openshmem{} \ac{RMA} routines are all performed on the symmetric objects.  The
+\openshmem \ac{RMA} routines are all performed on the symmetric objects.  The
 initiator \ac{PE} of the call is designated as \source{}, and the \ac{PE} in
 which memory is accessed is designated as \dest{}. In the case of the remote
 update routine, \PUT{}, the origin is the \source{} \ac{PE} and the destination
 \ac{PE} is the \dest{} PE. In the case of the remote read routine, \GET{}, the
 origin is the \dest{} \ac{PE} and the destination is the \source{} \ac{PE}.
 
-Where appropriate compiler support is available, \openshmem{} provides type-generic 
+Where appropriate compiler support is available, \openshmem provides type-generic 
 one-sided communication interfaces via \Cstd[11] generic selection
 (\Cstd[11]~\S6.5.1.1\footnote{Formally, the \Cstd[11] specification is ISO/IEC 9899:2011(E).})
 for block, scalar, and block-strided put and get communication. 

--- a/content/rma_intro.tex
+++ b/content/rma_intro.tex
@@ -21,7 +21,7 @@ listed in Table \ref{stdrmatypes}.
 
 The standard \ac{RMA} types include the exact-width integer types defined in
 \HEADER{stdint.h} by \Cstd[99]%
-\footnote{Formally, the \textit{C99} specification is ISO/IEC~9899:1999(E).}%
+\footnote{Formally, the \Cstd[99] specification is ISO/IEC~9899:1999(E).}%
 ~\S7.18.1.1 and \Cstd[11]~\S7.20.1.1. When the \Cstd translation environment
 does not provide exact-width integer types with \HEADER{stdint.h}, an
 \openshmem implemementation is not required to provide support for these types.

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -29,12 +29,12 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
 \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
     data object.  The stride is scaled by the element size.  A
     value of \CONST{1} indicates contiguous data.  \VAR{dst} must be of type
-    \textit{ptrdiff\_t}.  When using \Fortran, it must be a default integer
+    \CTYPE{ptrdiff\_t}.  When using \Fortran, it must be a default integer
     value.}
 \apiargument{IN}{sst}{The  stride between consecutive elements of the
     \source{} data object.  The stride is scaled by the element size.
     A value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-    of type \textit{ptrdiff\_t}.  When using \Fortran, it must be a
+    of type \CTYPE{ptrdiff\_t}.  When using \Fortran, it must be a
     default integer value.}
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
     \VAR{nelems} must be of type size\_t for \CorCpp.  When using

--- a/content/shmem_barrier_all.tex
+++ b/content/shmem_barrier_all.tex
@@ -29,7 +29,7 @@ CALL SHMEM_BARRIER_ALL
 
     Prior to synchronizing with other \acp{PE}, \FUNC{shmem\_barrier\_all}
     ensures completion of all previously issued memory stores and remote memory
-    updates issued via \openshmem{} \acp{AMO} and \ac{RMA} routine calls  such
+    updates issued via \openshmem \acp{AMO} and \ac{RMA} routine calls  such
     as \FUNC{shmem\_int\_add}, \FUNC{shmem\_put32}, 
     \FUNC{shmem\_put\_nbi}, and \FUNC{shmem\_get\_nbi}.
 }

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -62,7 +62,7 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \end{apiarguments}
 
 \apidescription{   
-    \openshmem{} \FUNC{collect} and \FUNC{fcollect} routines concatenate \VAR{nelems}
+    \openshmem \FUNC{collect} and \FUNC{fcollect} routines concatenate \VAR{nelems}
     \CONST{64}-bit or \CONST{32}-bit data items from the \source{} array into the
     \dest{} array, over the set of \acp{PE} defined by \VAR{PE\_start},
     \VAR{log2PE\_stride}, and \VAR{PE\_size}, in processor number order. The

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -39,12 +39,12 @@ CALL SHMEM_REAL_IGET(dest, source, dst, sst, nelems, pe)
     \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
         array.  The stride is scaled by the element size of the \dest{} array.
         A  value of \CONST{1} indicates contiguous data. \VAR{dst} must be of
-        type \textit{ptrdiff\_t}.  When using  \Fortran,  it  must
+        type \CTYPE{ptrdiff\_t}.  When using  \Fortran,  it  must
         be a default integer value.}
     \apiargument{IN}{sst}{The stride between consecutive elements of the
         \source{} array.  The stride is scaled by the element size of the \source{}
         array.  A  value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-        of type \textit{ptrdiff\_t}.  When using  \Fortran,  it  must
+        of type \CTYPE{ptrdiff\_t}.  When using  \Fortran,  it  must
         be a default integer value.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
         arrays.  \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When

--- a/content/shmem_info_get_name.tex
+++ b/content/shmem_info_get_name.tex
@@ -23,7 +23,7 @@ SHMEM_INFO_GET_NAME(NAME)
     this function prepares the \VAR{name} memory buffer of at least size
     \CONST{SHMEM\_MAX\_NAME\_LEN}. The implementation copies the vendor defined
     string of size at most \CONST{SHMEM\_MAX\_NAME\_LEN} to \VAR{name}. In
-    \CorCpp{}, the string is terminated by a null character.  In \Fortran{},
+    \CorCpp{}, the string is terminated by a null character.  In \Fortran,
     the string of size less than \CONST{SHMEM\_MAX\_NAME\_LEN} is padded with
     blank characters up to size \CONST{SHMEM\_MAX\_NAME\_LEN}. If the
     \VAR{name} memory buffer is provided with size less than

--- a/content/shmem_info_get_version.tex
+++ b/content/shmem_info_get_version.tex
@@ -14,12 +14,12 @@ SHMEM_INFO_GET_VERSION(MAJOR, MINOR)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{OUT}{major}{The major version of the \openshmem{} standard in use.}
-    \apiargument{OUT}{minor}{The minor version of the \openshmem{} standard in use.}
+    \apiargument{OUT}{major}{The major version of the \openshmem standard in use.}
+    \apiargument{OUT}{minor}{The minor version of the \openshmem standard in use.}
 \end{apiarguments}
 
 \apidescription{
-    This routine returns the major and minor version of the \openshmem{} standard
+    This routine returns the major and minor version of the \openshmem standard
     in use.  For a given library implementation, the major and minor version
     returned by these calls are consistent with the library constants
     \CONST{SHMEM\_MAJOR\_VERSION} and \CONST{SHMEM\_MINOR\_VERSION}.

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -40,11 +40,11 @@ CALL SHMEM_REAL_IPUT(dest, source, dst, sst, nelems, pe)
     \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
         array.  The stride is scaled by the element size of the \dest{} array.  A
         value of \CONST{1} indicates contiguous data.  \VAR{dst} must be of type
-        \textit{ptrdiff\_t}.  When using \Fortran, it must be a default integer value.}
+        \CTYPE{ptrdiff\_t}.  When using \Fortran, it must be a default integer value.}
     \apiargument{IN}{sst}{The  stride between consecutive elements of the
         \source{} array.  The stride is scaled by the element size of the \source{}
         array.  A  value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-        of type \textit{ptrdiff\_t}.  When using \Fortran, it must be a
+        of type \CTYPE{ptrdiff\_t}.  When using \Fortran, it must be a
         default integer value.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
         arrays.  \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.  When

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -92,7 +92,7 @@ void *shmem_align(size_t alignment, size_t size);
 
 \apiimpnotes{
     The symmetric heap allocation routines always return a pointer to corresponding
-    symmetric objects across all PEs. The \openshmem{} specification does not
+    symmetric objects across all PEs. The \openshmem specification does not
     require that the virtual addresses are equal across all \acp{PE}. Nevertheless,
     the implementation must avoid costly address translation operations in the
     communication path, including order $N$ (where $N$ is the number of \acp{PE})

--- a/content/shmem_ptr.tex
+++ b/content/shmem_ptr.tex
@@ -36,7 +36,7 @@ PTR = SHMEM_PTR(dest, pe)
 
 \apireturnvalues{
     The return value is a non-NULL address of the \dest{} data object when it is 
-    accessible using memory loads and stores in addition to \openshmem{} operations.
+    accessible using memory loads and stores in addition to \openshmem operations.
     Otherwise, a NULL address is returned.
 }
 

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -190,7 +190,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     The \source{} and \dest{} arrays may be the same array, but they may not be
     overlapping arrays.
     
-    As with all \openshmem{} collective routines, each of these routines assumes
+    As with all \openshmem collective routines, each of these routines assumes
     that only \acp{PE} in the \activeset{} call the routine.  If a \ac{PE} not in
     the \activeset{} calls an \openshmem collective routine, undefined behavior
     results.
@@ -204,7 +204,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     following conditions must be met (synchronization via a \OPR{barrier} or some other
     method is often needed to ensure this): The \VAR{pWrk} and \VAR{pSync} arrays
     on all \acp{PE} in the \activeset{} are not still in use from a prior call to a
-    collective \openshmem{} routine.  The \dest{} array on all \acp{PE} in the
+    collective \openshmem routine.  The \dest{} array on all \acp{PE} in the
     \activeset{} is ready to accept the results of the \OPR{reduction}.
     
     Upon return from a reduction routine, the following are true for the local
@@ -252,11 +252,11 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 }
 
 \apinotes{  
-    All \openshmem{} reduction routines reset the values in \VAR{pSync} before they
+    All \openshmem reduction routines reset the values in \VAR{pSync} before they
     return, so a particular \VAR{pSync} buffer need only be initialized the first
     time it is used. The user must ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
     in the \activeset{} while any of the \acp{PE} participate in processing of an
-    \openshmem{} reduction routine. Be careful to avoid the following situations: If
+    \openshmem reduction routine. Be careful to avoid the following situations: If
     the \VAR{pSync} array is initialized at run time, some type of synchronization
     is needed to ensure that all \acp{PE} in the working set have initialized
     \VAR{pSync} before any of them enter an \openshmem routine called with the

--- a/content/shpalloc.tex
+++ b/content/shpalloc.tex
@@ -44,7 +44,7 @@ CALL SHPALLOC(addr, length, errcode, abort)
 
 \apiimpnotes{
     The symmetric heap allocation routines always return a pointer to corresponding
-    symmetric objects across all PEs. The \openshmem{} specification does not
+    symmetric objects across all PEs. The \openshmem specification does not
     require that the virtual addresses are equal across all \acp{PE}. Nevertheless,
     the implementation must avoid costly address translation operations in the
     communication path, including order $N$ (where $N$ is the number of \acp{PE})

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -84,8 +84,8 @@ environment of the \acp{PE}.
 
 
 \subsection{Memory Management Routines}
-\openshmem provides a set of \ac{API}s for managing the symmetric heap. The
-\ac{API}s allow one to dynamically allocate, deallocate, reallocate and align
+\openshmem provides a set of \acp{API} for managing the symmetric heap. The
+\acp{API} allow one to dynamically allocate, deallocate, reallocate and align
 symmetric data objects in the symmetric heap, in \Cstd and \Fortran.
 
 \subsubsection{\textbf{SHMEM\_MALLOC, SHMEM\_FREE, SHMEM\_REALLOC, SHMEM\_ALIGN}}\label{subsec:shfree}
@@ -244,7 +244,7 @@ symmetric data objects in the symmetric heap, in \Cstd and \Fortran.
 
 
 \subsection{Memory Ordering Routines}\label{subsec:memory_order}
-The following section discusses \openshmem \ac{API}s that provide mechanisms to
+The following section discusses \openshmem \acp{API} that provide mechanisms to
 ensure ordering and/or delivery of \OPR{Put}, \ac{AMO}, and memory store
 routines to symmetric data objects. 
 

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -12,7 +12,7 @@
 
 
 
-\section{The \openshmem Effort}\label{subsec:openshmem_effort}
+\section{The OpenSHMEM Effort}\label{subsec:openshmem_effort}
 \input{content/the_openshmem_effort}
 
 \section{Programming Model Overview}\label{subsec:programming_model}
@@ -254,7 +254,7 @@ routines to symmetric data objects.
 \subsubsection{\textbf{SHMEM\_QUIET}}\label{subsec:shmem_quiet}
 \input{content/shmem_quiet.tex}
 
-\subsubsection{Synchronization and Communication Ordering in \openshmem}
+\subsubsection{Synchronization and Communication Ordering in OpenSHMEM}
 \input{content/synchronization_model.tex}
 
 

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -227,6 +227,7 @@ minus .2ex}{-1em}{\normalsize\sf}}
 \lstdefinelanguage{OSH+C}[]{C}{
   classoffset=1,
   morekeywords={
+    size_t, ptrdiff_t,
     SHMEM_BCAST_SYNC_SIZE, SHMEM_SYNC_VALUE,
     start_pes,
     my_pe, _my_pe, shmem_my_pe,
@@ -243,6 +244,7 @@ minus .2ex}{-1em}{\normalsize\sf}}
     shmem_set_lock, shmem_test_lock, shmem_clear_lock,
     shmem_long_sum_to_all,
     shmem_complexd_sum_to_all,
+    shmem_cmp_t
   },
   keywordstyle=\color{black}\textbf,
   classoffset=0,
@@ -359,13 +361,13 @@ minus .2ex}{-1em}{\normalsize\sf}}
 { 
   \textbf{C11:} 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, TYPE, _Noreturn, shmem_cmp},
+  morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_cmp_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
 { 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, TYPE, TYPENAME, SIZE, shmem_cmp},
+  morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_cmp_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 
@@ -373,7 +375,7 @@ minus .2ex}{-1em}{\normalsize\sf}}
 { 
   \textbf{C/C++:} 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, TYPE, TYPENAME, SIZE, shmem_cmp},
+  morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_cmp_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}
@@ -459,7 +461,8 @@ minus .2ex}{-1em}{\normalsize\sf}}
 \newcommand{\apicexample}[3]{
     ##1
     \lstinputlisting[language={C}, tabsize=2,
-    basicstyle=\ttfamily\footnotesize, morekeywords={size_t}]{##2}
+      basicstyle=\ttfamily\footnotesize,
+      morekeywords={size_t, ptrdiff_t, shmem_cmp_t}]{##2}
     ##3 }
 \newcommand{\apifexample}[3]{
     ##1


### PR DESCRIPTION
Currently, this PR includes:
* `\ac{API}s` -> `\acp{API}`
* `\Fortran{}` -> `\Fortran`
* `\openshmem{}` -> `\openshmem`
* `\textit{...}` -> appropriate macro
* Manual fixes for TOC generation (see f9e1887 for details)

This PR would close #66.
