### PR TITLE
Remove expanded type support for the newly-deprecated shmem_wait

### DIFF
--- a/content/p2p_sync_intro.tex
+++ b/content/p2p_sync_intro.tex
@@ -12,8 +12,6 @@ selection. Such type-generic routines are supported for the
 ``point-to-point synchronization types'' identified in
 Table~\ref{p2psynctypes}.
 
-% Fix the C99 styling here with the macros from PRs #55 and #31, and
-% osh_spec_next for \HEADER{}
 The point-to-point synchronization types include some of the exact-width
 integer types defined in \textit{stdint.h} by \Cstd[99]~\S7.18.1.1 and
 \Cstd[11]~\S7.20.1.1. When the \Cstd translation environment

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -7,24 +7,24 @@
 \begin{C11synopsis}
 void shmem_wait_until(TYPE *ivar, shmem_cmp_t cmp, TYPE cmp_value);
 \end{C11synopsis}
-\begin{DeprecateBlock}
-\begin{CsynopsisCol}
-void shmem_wait(TYPE *ivar, TYPE cmp_value);
-\end{CsynopsisCol}
-\end{DeprecateBlock}
 where \TYPE{} is one of the point-to-point synchronization types specified by
 Table \ref{p2psynctypes}.
 
 \begin{Csynopsis}
 void shmem_<TYPENAME>_wait_until(TYPE *ivar, shmem_cmp_t cmp, TYPE cmp_value);
 \end{Csynopsis}
+where \TYPE{} is one of the point-to-point synchronization types and has a
+corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
+
 \begin{DeprecateBlock}
 \begin{CsynopsisCol}
+void shmem_wait(long *ivar, long cmp_value);
 void shmem_<TYPENAME>_wait(TYPE *ivar, TYPE cmp_value);
 \end{CsynopsisCol}
+where \TYPE{} is one of \{\CTYPE{short}, \CTYPE{int}, \CTYPE{long},
+\CTYPE{long long}\} and has a corresponding \TYPENAME{} specified by
+Table~\ref{p2psynctypes}.
 \end{DeprecateBlock}
-where \TYPE{} is one of the point-to-point synchronization types and has a
-corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
 
 \begin{Fsynopsis}
 CALL SHMEM_INT4_WAIT(ivar, cmp_value)


### PR DESCRIPTION
In Issue #84, @jamesaross raised the concern / made the observation that, as written, #32 both deprecated the `shmem_wait` and `shmem_TYPE_wait` routines and expanded the required type support of the API. This PR revises the changes in #32 to deprecate `shmem_wait` _without_ expanding the type support.