### PR TITLE
Consistency Edits from pages 8 to 30.

### DIFF
--- a/content/rma_intro.tex
+++ b/content/rma_intro.tex
@@ -1,5 +1,6 @@
-The \ac{RMA} routines described in this section are one-sided communication
-mechanisms of the \openshmem \ac{API}. While using these mechanisms, the user
+The following section consists of \ac{RMA} routines. The RMAs described 
+in this section are one-sided communication mechanisms of the \openshmem{} 
+\ac{API}. While using these mechanisms, the user
 is required to provide parameters only on the calling side. A characteristic of
 one-sided communication is that it decouples communication from the
 synchronization. One-sided communication mechanisms transfer the data but do not

--- a/content/shmem_addr_accessible.tex
+++ b/content/shmem_addr_accessible.tex
@@ -1,6 +1,6 @@
 \apisummary{
-    Determines whether an address is accessible via OpenSHMEM data transfer
-    routines from the specified  remote \ac{PE}.
+    \FUNC{shmem\_addr\_accessible} is a query routine that determines whether an address 
+    is accessible via OpenSHMEM data transfer routines from the specified  remote \ac{PE}.
 }
 
 \begin{apidefinition}
@@ -21,11 +21,11 @@ LOG = SHMEM_ADDR_ACCESSIBLE(addr, pe)
 \end{apiarguments}
 
 \apidescription{
-    \FUNC{shmem\_addr\_accessible} is a query routine that indicates whether a local
-    address is accessible via \openshmem routines from the specified remote \ac{PE}. 
+    \FUNC{shmem\_addr\_accessible} indicates whether a local address is accessible via 
+    \openshmem routines from the specified remote \ac{PE}. 
     
-    This routine verifies that the data object is symmetric and accessible with
-    respect to a remote \ac{PE} via \openshmem  data  transfer routines.  The
+    \FUNC{shmem\_addr\_accessible}  verifies that the data object is symmetric and 
+    accessible with respect to a remote \ac{PE} via \openshmem  data  transfer routines.  The
     specified address \VAR{addr} is a data object on the local \ac{PE}. 
     
     This routine may be particularly useful for hybrid programming with other

--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -1,5 +1,5 @@
 \apisummary{
-  Allocate a zeroed block of symmetric memory.
+  \FUNC{shmem\_calloc} allocates a zeroed block of symmetric memory.
 }
 
 \begin{apidefinition}
@@ -15,7 +15,7 @@ void *shmem_calloc(size_t count, size_t size);
 
 
 \apidescription{
-  The \FUNC{shmem\_calloc} routine allocates a region of remotely-accessible
+  \FUNC{shmem\_calloc} allocates a region of remotely-accessible
   memory for an array of \VAR{count} objects of \VAR{size} bytes each and
   returns a pointer to the lowest byte address of the allocated symmetric
   memory. The space is initialized to all bits zero.

--- a/content/shmem_finalize.tex
+++ b/content/shmem_finalize.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    A collective operation that releases resources used by the \openshmem
+    \FUNC{shmem\_finalize} is a collective operation that releases resources used by the \openshmem
     library.  This only terminates the \openshmem portion of a program, not the
     entire program.
 }
@@ -19,10 +19,10 @@ CALL SHMEM_FINALIZE()
 \end{apiarguments}
 
 \apidescription{
-    \FUNC{shmem\_finalize} is a collective operation that ends the \openshmem
-    portion of a program previously initialized by \FUNC{shmem\_init} and
-    releases resources used by the \openshmem library. This collective
-    operation requires all \acp{PE} to participate in the call. There is an
+     \FUNC{shmem\_finalize} ends the \openshmem portion of a program
+     previously initialized by \FUNC{shmem\_init} and
+    releases resources used by the \openshmem library. \FUNC{shmem\_finalize} 
+    requires all \acp{PE} to participate in the call. There is an
     implicit global barrier in \FUNC{shmem\_finalize} so that pending
     communications are completed, and no resources can be released until all
     \acp{PE} have entered \FUNC{shmem\_finalize}. \FUNC{shmem\_finalize} must be
@@ -50,7 +50,7 @@ CALL SHMEM_FINALIZE()
 \begin{apiexamples}
 
 \apicexample
-    {The following finalize example is for C11 programs:}
+    {The following \FUNC{shmem\_finalize} example is for C11 programs:}
     {./example_code/shmem_finalize_example.c}
     {}
 

--- a/content/shmem_get.tex
+++ b/content/shmem_get.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies data from a specified \ac{PE}.
+    \FUNC{shmem\_get} copies data from a specified \ac{PE}.
 }
 
 \begin{apidefinition}
@@ -46,15 +46,15 @@ CALL SHMEM_REAL_GET(dest, source, nelems, pe)
         accessible.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
         arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When
-        using \Fortran, it must be a constant, variable, or array element of default
+        using \Fortran, \VAR{nelems} must be a constant, variable, or array element of default
         integer type.}
     \apiargument{IN}{pe}{\ac{PE}  number of the remote \ac{PE}.  \VAR{pe} must
-        be of type integer. When using \Fortran, it must be a constant,
+        be of type integer. When using \Fortran, \VAR{pe} must be a constant,
         variable, or array element of default integer type.}
 \end{apiarguments}
 
 \apidescription{
-   The get routines provide a method for copying a contiguous symmetric data
+   \FUNC{shmem\_get} routines provide a method for copying a contiguous symmetric data
    object from a different \ac{PE} to a contiguous data object on the local
    \ac{PE}.  The routines return after the data has been delivered to the
    \dest{} array on the local \ac{PE}. 
@@ -102,7 +102,7 @@ CALL SHMEM_REAL_GET(dest, source, nelems, pe)
 \begin{apiexamples}
 
 \apifexample
-    {Consider this example for \Fortran.}
+    {The following  \FUNC{shmem\_get} example is for \Fortran programs:}
     {./example_code/shmem_get_example.f90}
     {}
 

--- a/content/shmem_global_exit.tex
+++ b/content/shmem_global_exit.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    A routine that allows any \ac{PE} to force termination of an entire program.
+    \FUNC{shmem\_global\_exit} is a non-collective routine that allows any \ac{PE} to force termination of an entire program.
 }
 
 \begin{apidefinition}
@@ -22,10 +22,10 @@ CALL SHMEM_GLOBAL_EXIT(status)
 \end{apiarguments}
 
 \apidescription{
-    \FUNC{shmem\_global\_exit} is a non-collective routine that allows any one
+    \FUNC{shmem\_global\_exit} allows any one
     \ac{PE} to force termination of an \openshmem program for all \acp{PE},
-    passing an exit status to the execution environment. This routine terminates
-    the entire program, not just the \openshmem portion.  When any \ac{PE} calls
+    passing an exit status to the execution environment. \FUNC{shmem\_global\_exit} 
+    terminates the entire program, not just the \openshmem portion.  When any \ac{PE} calls
     \FUNC{shmem\_global\_exit}, it results in the immediate notification to all
     \acp{PE} to terminate.  \FUNC{shmem\_global\_exit} flushes I/O and releases
     resources in accordance with C/C++/Fortran language requirements for normal

--- a/content/shmem_info_get_name.tex
+++ b/content/shmem_info_get_name.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    This routine returns the vendor defined character string.
+    \FUNC{shmem\_info\_get\_name} returns the vendor defined character string.
 }
 
 \begin{apidefinition}
@@ -18,7 +18,7 @@ SHMEM_INFO_GET_NAME(NAME)
 \end{apiarguments}
 
 \apidescription{
-    This routine returns the vendor defined character string of size defined by
+    \FUNC{shmem\_info\_get\_name} returns the vendor defined character string of size defined by
     the library constant \CONST{SHMEM\_MAX\_NAME\_LEN}. The program calling
     this function prepares the \VAR{name} memory buffer of at least size
     \CONST{SHMEM\_MAX\_NAME\_LEN}. The implementation copies the vendor defined

--- a/content/shmem_info_get_version.tex
+++ b/content/shmem_info_get_version.tex
@@ -1,5 +1,6 @@
 \apisummary{
-    Returns the major and minor version of the library implementation.
+    \FUNC{shmem\_info\_get\_version} returns the major and minor 
+    version of the library implementation.
 }
 
 \begin{apidefinition}
@@ -19,8 +20,8 @@ SHMEM_INFO_GET_VERSION(MAJOR, MINOR)
 \end{apiarguments}
 
 \apidescription{
-    This routine returns the major and minor version of the \openshmem standard
-    in use.  For a given library implementation, the major and minor version
+    \FUNC{shmem\_info\_get\_version} returns the major and minor version of the \openshmem{}
+    standard in use.  For a given library implementation, the major and minor version
     returned by these calls are consistent with the library constants
     \CONST{SHMEM\_MAJOR\_VERSION} and \CONST{SHMEM\_MINOR\_VERSION}.
 }

--- a/content/shmem_init.tex
+++ b/content/shmem_init.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    A collective operation that allocates and initializes the resources used by
+     \FUNC{shmem\_init} is a collective operation that allocates and initializes the resources used by
     the \openshmem library.
 }
 
@@ -20,7 +20,7 @@ CALL SHMEM_INIT()
 
 \apidescription{
     \FUNC{shmem\_init} allocates and initializes resources used by the \openshmem
-    library. It is a collective operation that all \acp{PE} must call before any
+    library. All \acp{PE} must call \FUNC{shmem\_init} before any
     other \openshmem routine may be called. At the end of the \openshmem program
     which it initialized, the call to \FUNC{shmem\_init} must be matched with a
     call to \FUNC{shmem\_finalize}. After the first call to \FUNC{shmem\_init}, a
@@ -46,7 +46,7 @@ CALL SHMEM_INIT()
 \begin{apiexamples}
 
 \apifexample
-    { This is a simple program that calls \FUNC{shmem\_init}: } 
+    { The following example is a simple program that calls \FUNC{shmem\_init}: } 
     { example_code/shmem_init_example.f90 }
     {}
 

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies strided data to a specified \ac{PE}.
+   \FUNC{shmem\_iput} copies strided data to a specified \ac{PE}.
 }
 
 \begin{apidefinition}
@@ -40,24 +40,24 @@ CALL SHMEM_REAL_IPUT(dest, source, dst, sst, nelems, pe)
     \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
         array.  The stride is scaled by the element size of the \dest{} array.  A
         value of \CONST{1} indicates contiguous data.  \VAR{dst} must be of type
-        \CTYPE{ptrdiff\_t}.  When using \Fortran, it must be a default integer value.}
+        \CTYPE{ptrdiff\_t}.  When using \Fortran, \VAR{dst} must be a default integer value.}
     \apiargument{IN}{sst}{The  stride between consecutive elements of the
         \source{} array.  The stride is scaled by the element size of the \source{}
         array.  A  value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-        of type \CTYPE{ptrdiff\_t}.  When using \Fortran, it must be a
+        of type \CTYPE{ptrdiff\_t}.  When using \Fortran, \VAR{sst} must be a
         default integer value.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
         arrays.  \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.  When
-        using \Fortran, it must be  a constant, variable, or array element of
+        using \Fortran, \VAR{nelems} must be  a constant, variable, or array element of
         default integer type.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.  \VAR{pe} must be
-        of type integer.   When using  \Fortran, it must be a constant,
+        of type integer.   When using  \Fortran, \VAR{pe} must be a constant,
         variable, or array element of default integer type.}
 \end{apiarguments}
 
 
 \apidescription{
-    The \FUNC{iput} routines provide a method  for  copying strided data
+     \FUNC{shmem\_iput} routines provide a method  for  copying strided data
     elements (specified by \VAR{sst}) of an array from a \source{} array on the
     local \ac{PE} to locations specified by stride \VAR{dst} on a \dest{} array
     on specified remote \ac{PE}. Both strides, \VAR{dst} and \VAR{sst}, must be
@@ -101,7 +101,7 @@ CALL SHMEM_REAL_IPUT(dest, source, dst, sst, nelems, pe)
 \begin{apiexamples}
 
 \apicexample
-    {Consider the following \FUNC{shmem\_iput}  example  for C11 programs.}
+    {The following \FUNC{shmem\_iput}  example is  for C11 programs:}
     {./example_code/shmem_iput_example.c}
     {}
 \end{apiexamples}

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Symmetric heap memory management routines.
+    \FUNC{shmem\_malloc}, \FUNC{shmem\_free}, \FUNC{shmem\_realloc}, and \FUNC{shmem\_align} are a set of symmetric heap memory management routines.
 }
 
 \begin{apidefinition}
@@ -21,19 +21,19 @@ void *shmem_align(size_t alignment, size_t size);
 
 
 \apidescription{
-    The \FUNC{shmem\_malloc} routine returns a pointer to a block of at least
+    \FUNC{shmem\_malloc} returns a pointer to a block of at least
     \VAR{size} bytes suitably aligned for any use.  This space is allocated from the
     symmetric heap (in contrast to \FUNC{malloc}, which allocates from the private
     heap).
     
-    The \FUNC{shmem\_align} routine allocates a block in the symmetric heap that has
+    \FUNC{shmem\_align} allocates a block in the symmetric heap that has
     a byte alignment specified by the alignment argument.
     
-    The \FUNC{shmem\_free} routine causes the block to which \VAR{ptr} points to be
+    \FUNC{shmem\_free} causes the block to which \VAR{ptr} points to be
     deallocated, that is, made available for further allocation.  If \VAR{ptr} is a
     null pointer, no action occurs. 
            
-    The \FUNC{shmem\_realloc} routine changes the size of the block to which
+    \FUNC{shmem\_realloc} changes the size of the block to which
     \VAR{ptr} points to the size (in bytes) specified by \VAR{size}.  The contents
     of the block are unchanged up to the lesser of the new and old sizes. If the new
     size is larger, the newly allocated portion of the block is

--- a/content/shmem_my_pe.tex
+++ b/content/shmem_my_pe.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Returns the number of the calling \ac{PE}.
+    \FUNC{shmem\_my\_pe} returns the number of the calling \ac{PE}.
 }
 
 \begin{apidefinition}
@@ -18,7 +18,7 @@ ME = SHMEM_MY_PE()
 \end{apiarguments}
 
 \apidescription{
-    This routine returns the \ac{PE} number of the calling \ac{PE}.  It accepts no
+     \FUNC{shmem\_my\_pe} returns the \ac{PE} number of the calling \ac{PE}.  It accepts no
     arguments.  The result is an integer between \CONST{0} and \VAR{npes} -
     \CONST{1}, where \VAR{npes} is the total number of \acp{PE} executing the
     current program.

--- a/content/shmem_n_pes.tex
+++ b/content/shmem_n_pes.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Returns the number of \acp{PE} running in a program.
+    \FUNC{shmem\_n\_pes} returns the number of \acp{PE} running in a program.
 }
 
 \begin{apidefinition}
@@ -18,7 +18,7 @@ N_PES = SHMEM_N_PES()
 \end{apiarguments}
 
 \apidescription{
-    The routine returns the number of \acp{PE} running in the program.
+   This routine returns the number of \acp{PE} running in the program.
 }
 
 \apireturnvalues{

--- a/content/shmem_p.tex
+++ b/content/shmem_p.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies one data item to a remote \ac{PE}.
+    \FUNC{shmem\_p} copies one data item to a remote \ac{PE}.
 }
 
 \begin{apidefinition}
@@ -23,7 +23,7 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
 \end{apiarguments}
 
 \apidescription{
-    These routines provide a very low latency put capability for single elements of
+    \FUNC{shmem\_p} routines provide a very low latency put capability for single elements of
     most basic types.
     
     As with \FUNC{shmem\_put}, these routines start the remote transfer and may
@@ -42,7 +42,7 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
 \begin{apiexamples}
 
     \apicexample
-    {The following example uses \FUNC{shmem\_p} in a \Cstd[11] program.}
+    {The following \FUNC{shmem\_p} example is for \Cstd[11] programs:}
     {./example_code/shmem_p_example.c}
     {}
 

--- a/content/shmem_pe_accessible.tex
+++ b/content/shmem_pe_accessible.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Determines whether a \ac{PE} is accessible via \openshmem's data transfer
+     \FUNC{shmem\_pe\_accessible} is  a  query routine that determines whether a \ac{PE} is accessible via \openshmem's data transfer
     routines.
 }
 
@@ -21,10 +21,9 @@ LOG = SHMEM_PE_ACCESSIBLE(pe)
 \end{apiarguments}
 
 \apidescription{
-    \FUNC{shmem\_pe\_accessible} is  a  query routine  that indicates  whether  a
-    specified \ac{PE} is accessible via \openshmem from the local \ac{PE}. The
-    \FUNC{shmem\_pe\_accessible} routine returns \CONST{TRUE} only if  the  remote
-    \ac{PE} is a process  running from the same executable  file as the local
+    \FUNC{shmem\_pe\_accessible} indicates whether  a specified \ac{PE} is accessible via \openshmem 
+    from the local \ac{PE}. \FUNC{shmem\_pe\_accessible} returns \CONST{TRUE} only if  
+    the  remote \ac{PE} is a process  running from the same executable  file as the local
     \ac{PE}, indicating that full \openshmem support for symmetric data objects
     (that reside in the static memory and symmetric heap) is available, otherwise it
     returns \CONST{FALSE}.  This routine may be particularly useful for hybrid

--- a/content/shmem_ptr.tex
+++ b/content/shmem_ptr.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Returns a pointer to a data object on a specified \ac{PE}.
+    \FUNC{shmem\_ptr} returns a pointer to a data object on a specified \ac{PE}.
 }
 
 \begin{apidefinition}
@@ -18,7 +18,7 @@ PTR = SHMEM_PTR(dest, pe)
 \begin{apiarguments}
 \apiargument{IN}{dest}{The symmetric data object to be referenced.}
 \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number on which \dest{} is to
-		 be accessed.  When using \Fortran, it must be a  default
+		 be accessed.  When using \Fortran, \VAR{pe} must be a  default
 		 integer value.}
 \end{apiarguments}
 
@@ -48,8 +48,7 @@ PTR = SHMEM_PTR(dest, pe)
 \begin{apiexamples}
 
 \apifexample
-    { This  \Fortran  program calls \FUNC{shmem\_ptr} and then \ac{PE} 0 writes to
-    the \VAR{BIGD} array on \ac{PE} 1: }
+    { The following \FUNC{shmem\_ptr} example is for \Fortran  programs. This program calls \FUNC{shmem\_ptr}, and then \ac{PE} 0 writes to the \VAR{BIGD} array on \ac{PE} 1: }
     {./example_code/shmem_ptr_example.f90 }
     {}
     

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    The  put routines  provide  a method for copying data from a contiguous local
+    \FUNC{shmem\_put} copies data from a contiguous local
     data object to a data object on a specified \ac{PE}.
 }
 
@@ -45,15 +45,15 @@ CALL SHMEM_REAL_PUT(dest, source, nelems, pe)
     \apiargument{OUT}{source}{Data object containing the data to be copied.}
     \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
     arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When using
-    \Fortran, it must be a constant, variable, or array element of default
+    \Fortran, \VAR{nelems} must be a constant, variable, or array element of default
     integer type.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}. \VAR{pe} must be
-    of type integer. When using \Fortran, it must be a constant, variable,
+    of type integer. When using \Fortran, \VAR{pe} must be a constant, variable,
     or array element of default integer type.}
 \end{apiarguments}
 
 \apidescription{
-    The routines return after the data has been copied out of the \source{} array
+     \FUNC{shmem\_put} routines return after the data has been copied out of the \source{} array
     on the local \ac{PE}.  The delivery of data words into the data object on the
     destination \ac{PE} may occur in any order.  Furthermore, two successive put
     routines may deliver data out of order unless a call to \FUNC{shmem\_fence} is

--- a/content/shpalloc.tex
+++ b/content/shpalloc.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Allocates a block of memory from the symmetric heap.
+    \FUNC{SHPALLOC} allocates a block of memory from the symmetric heap.
 }
 
 \begin{apidefinition}

--- a/content/shpclmove.tex
+++ b/content/shpclmove.tex
@@ -1,6 +1,5 @@
 \apisummary{
-    Extends  a symmetric heap block or copies the contents of the block into a
-    larger block.
+     \FUNC{SHPCLMOVE} extends a symmetric heap block or copies the contents of the block into a larger block.
 }
 
 \begin{apidefinition}
@@ -24,7 +23,7 @@ CALL SHPCLMOVE (addr, length, status, abort)
 \end{apiarguments}
  
 \apidescription{     
-    The \FUNC{SHPCLMOVE} routine either extends a symmetric heap block if the block
+    \FUNC{SHPCLMOVE} either extends a symmetric heap block if the block
     is followed by a large enough free block or copies the contents of the existing
     block to a larger block and returns a status code indicating that the block was
     moved.  This routine also can reduce the size of a block if the new length is

--- a/content/shpdealloc.tex
+++ b/content/shpdealloc.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Returns a memory block to the symmetric heap.
+    SHPDEALLC returns a memory block to the symmetric heap.
 }
 
 \begin{apidefinition}

--- a/content/start_pes.tex
+++ b/content/start_pes.tex
@@ -1,9 +1,6 @@
 \apisummary{ 
-    Called at the beginning of an \openshmem program to initialize the execution
-    environment. This routine is deprecated and is provided for backwards
-    compatibility. Implementations must include it, and the routine should
-    function properly and may notify the user about deprecation of its use.
-}
+    \FUNC{start\_pes} is a deprecated routine that initializes the execution environment. 
+    }
 
 \begin{apidefinition}
 
@@ -52,7 +49,7 @@ CALL START_PES(npes)
 \begin{apiexamples}
 
 \apicexample
-    { This is a simple program that calls \FUNC{start\_pes}:}
+    { The following example is a simple program that calls \FUNC{start\_pes}:}
     {./example_code/shmem_startpes_example.f90}
     {} 
 

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -43,7 +43,7 @@
 \section{OpenSHMEM Library API}\label{sec:openshmem_library_api}
 
 \subsection{Library Setup, Exit, and Query Routines}
-The library setup and query interfaces that initialize and monitor the parallel
+The following section consists of the library setup and query interfaces that initialize and monitor the parallel
 environment of the \acp{PE}.
 
 \subsubsection{\textbf{SHMEM\_INIT}}\label{subsec:shmem_init}
@@ -93,9 +93,8 @@ environment of the \acp{PE}.
 
 
 \subsection{Memory Management Routines}
-\label{sec:mem_routines}
-\openshmem provides a set of \acp{API} for managing the symmetric heap. The
-\acp{API} allow one to dynamically allocate, deallocate, reallocate and align
+The following section consists of a set of \ac{API}s for managing the symmetric heap. The
+\ac{API}s allow one to dynamically allocate, deallocate, reallocate and align
 symmetric data objects in the symmetric heap, in \Cstd and \Fortran.
 
 \subsubsection{\textbf{SHMEM\_MALLOC, SHMEM\_FREE, SHMEM\_REALLOC, SHMEM\_ALIGN}}\label{subsec:shfree}


### PR DESCRIPTION
This PR is the first part of a series of three. The purpose of the the consis_edits is to make the OpenSHMEM 1.4 specification, specifically the 8.1-8.10 sections, read more consistently. Edits have been made to section intros, routine intros, API descriptions, example sections, and argument lists with the intention of making them read as though they were written by one person. This PR includes consistency edits from pages 8 to 30.