### PR TITLE
Consistency edits from pages 30 to 60.

### DIFF
--- a/content/atomics_intro.tex
+++ b/content/atomics_intro.tex
@@ -1,5 +1,5 @@
-An \ac{AMO} is a one-sided communication mechanism that combines memory update
-operations with atomicity guarantees described in Section
+The following section consists of \ac{AMO} routines. An AMO is a one-sided communication mechanism 
+that combines memory update operations with atomicity guarantees described in Section
 \ref{subsec:amo_guarantees}.  Similar to the \ac{RMA} routines, described in
 Section \ref{sec:rma}, the \acp{AMO} are performed only on symmetric objects.
 \openshmem defines the two types of \ac{AMO} routines:

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Performs an atomic add operation on a remote symmetric data object.
+    \FUNC{shmem\_atomic\_add} performs an atomic add operation on a remote symmetric data object.
 }
 
 \begin{apidefinition}
@@ -29,15 +29,15 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
         updated  on the remote \ac{PE}.  When using \CorCpp, the type of
         \dest{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{value}{The value to be atomically added to \dest. When using \CorCpp, the type of \VAR{value} should match that  implied  in
-        the SYNOPSIS  section.  When using \Fortran, it must be of type
+        the SYNOPSIS  section.  When using \Fortran, \VAR{value} must be of type
         integer with an element size of \dest.}
     \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number upon which
-        \dest{} is to be updated.  When using \Fortran, it must be a default
+        \dest{} is to be updated.  When using \Fortran, \VAR{pe} must be a default
         integer value.}
 \end{apiarguments}
 
 \apidescription{
-    The \FUNC{shmem\_atomic\_add} routine performs an atomic add operation. It adds
+    \FUNC{shmem\_atomic\_add} performs an atomic add operation. It adds
     \VAR{value} to \dest{} on \ac{PE} \VAR{pe} and atomically updates the \dest{}
     without returning the value.
  }
@@ -62,7 +62,7 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
 \begin{apiexamples}
 
 \apicexample
-    {}
+    {The following \FUNC{shmem\_atomic\_add} example is for \Cstd[11] programs:}
     {./example_code/shmem_atomic_add_example.c}
     {}
 

--- a/content/shmem_atomic_and.tex
+++ b/content/shmem_atomic_and.tex
@@ -1,5 +1,5 @@
 \apisummary{
-  Atomically perform a non-fetching bitwise AND operation on a
+  \FUNC{shmem\_atomic\_and} atomically performs a non-fetching bitwise AND operation on a
   remote data object.
 }
 

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Performs an atomic conditional swap on a remote data object.
+    \FUNC{shmem\_atomic\_compare\_swap} performs an atomic conditional swap on a remote data object.
 }
 
 \begin{apidefinition}
@@ -36,12 +36,12 @@ ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
     \apiargument{IN}{value}{The value to be atomically written to the remote
         \ac{PE}. \VAR{value} must be the same data type as \VAR{dest}.}
     \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number upon which
-        \VAR{dest} is to be updated. When using \Fortran, it must be a default
+        \VAR{dest} is to be updated. When using \Fortran, \VAR{pe} must be a default
         integer value.}
 \end{apiarguments}
 
 \apidescription{
-    The conditional swap routines conditionally update a \VAR{dest} data object on
+    \FUNC{shmem\_atomic\_compare\_swap} routines conditionally update a \VAR{dest} data object on
     the specified \ac{PE} and return the prior contents of the data object in one
     atomic operation.
 }
@@ -69,9 +69,10 @@ ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
 \begin{apiexamples}
 
 \apicexample
-    {The following call ensures that the first \ac{PE} to execute the
+    {The following \FUNC{shmem\_atomic\_compare\_swap}  example 
+    ensures that the first \ac{PE} to execute the
     conditional swap will successfully write its \ac{PE} number to
-    \VAR{race\_winner} on \ac{PE} \CONST{0}.}
+    \VAR{race\_winner} on \ac{PE} \CONST{0}:}
     {./example_code/shmem_atomic_compare_swap_example.c}
     {}
 

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Atomically fetches the value of a remote data object.
+     \FUNC{shmem\_atomic\_fetch} atomically fetches the value of a remote data object.
 }
 
 \begin{apidefinition}

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Performs an atomic fetch-and-add operation on a remote data object.
+    \FUNC{shmem\_atomic\_fetch\_add} performs an atomic fetch-and-add operation on a remote data object.
 }
 
 \begin{apidefinition}
@@ -32,7 +32,7 @@ ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
 \apiargument{IN}{value}{The value to be atomically added to \VAR{dest}.  The
     type of \VAR{value} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number on which
-    \VAR{dest} is to be updated.  When using \Fortran, it must be a default
+    \VAR{dest} is to be updated.  When using \Fortran, \VAR{pe} must be a default
     integer value.}
 
 \end{apiarguments}

--- a/content/shmem_atomic_fetch_and.tex
+++ b/content/shmem_atomic_fetch_and.tex
@@ -1,5 +1,5 @@
 \apisummary{
-  Atomically perform a fetching bitwise AND operation on a remote data object.
+  \FUNC{shmem\_atomic\_fetch\_and} atomically performs a fetching bitwise AND operation on a remote data object.
 }
 
 \begin{apidefinition}

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Performs an atomic fetch-and-increment  operation on a remote data object.
+     \FUNC{shmem\_atomic\_fetch\_inc} performs an atomic fetch-and-increment  operation on a remote data object.
 }
 
 \begin{apidefinition}
@@ -31,14 +31,14 @@ ires_i8 = SHMEM_INT8_FINC(dest, pe)
     on the remote \ac{PE}. The type of \dest{} should match that implied in the
     SYNOPSIS section.}
 \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number on which
-    \dest{} is to be updated.  When using \Fortran, it must be a default
+    \dest{} is to be updated.  When using \Fortran, \VAR{pe} must be a default
     integer value.}
 
 \end{apiarguments}
 
 
 \apidescription{
-   These routines perform a fetch-and-increment operation.  The \dest{} on
+   \FUNC{shmem\_atomic\_fetch\_inc} routines perform a fetch-and-increment operation.  The \dest{} on
    \ac{PE} \VAR{pe} is increased by one and the routine returns the previous
    contents of \dest{} as an atomic operation.
 }

--- a/content/shmem_atomic_fetch_or.tex
+++ b/content/shmem_atomic_fetch_or.tex
@@ -1,5 +1,5 @@
 \apisummary{
-  Atomically perform a fetching bitwise OR operation on a remote data object.
+  \FUNC{shmem\_atomic\_fetch\_or} atomically performs a fetching bitwise OR operation on a remote data object.
 }
 
 \begin{apidefinition}

--- a/content/shmem_atomic_fetch_xor.tex
+++ b/content/shmem_atomic_fetch_xor.tex
@@ -1,5 +1,5 @@
 \apisummary{
-  Atomically perform a fetching bitwise exclusive OR (XOR) operation on a
+  \FUNC{shmem\_atomic\_fetch\_xor} atomically performs a fetching bitwise exclusive OR (XOR) operation on a
   remote data object.
 }
 

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Performs an atomic increment operation on a remote data object.
+    \FUNC{shmem\_atomic\_inc} performs an atomic increment operation on a remote data object.
 }
 
 \begin{apidefinition}
@@ -28,13 +28,13 @@ CALL SHMEM_INT8_INC(dest, pe)
     on the remote \ac{PE}. The type of \dest{} should match that implied in the
     SYNOPSIS section.}
 \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number on which
-    \dest{} is to be  updated. When using \Fortran, it must be a default
+    \dest{} is to be  updated. When using \Fortran, \VAR{pe} must be a default
     integer value.}
 
 \end{apiarguments}
 
 \apidescription{
-    These  routines perform  an atomic increment operation on the \VAR{dest} data
+    \FUNC{shmem\_atomic\_inc} routines perform  an atomic increment operation on the \VAR{dest} data
     object on \ac{PE}.
 }
 

--- a/content/shmem_atomic_or.tex
+++ b/content/shmem_atomic_or.tex
@@ -1,5 +1,5 @@
 \apisummary{
-  Atomically perform a non-fetching bitwise OR operation on a
+  \FUNC{shmem\_atomic\_or} atomically performs a non-fetching bitwise OR operation on a
   remote data object.
 }
 

--- a/content/shmem_atomic_set.tex
+++ b/content/shmem_atomic_set.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Atomically sets the value of a remote data object.
+     \FUNC{shmem\_atomic\_set} atomically sets the value of a remote data object.
 }
 
 \begin{apidefinition}

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Performs an atomic swap to a remote data object.
+    \FUNC{shmem\_atomic\_swap} performs an atomic swap to a remote data object.
 }
 
 \begin{apidefinition}
@@ -34,7 +34,7 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
     \apiargument{IN}{value}{The value to be atomically written to the remote
         \ac{PE}. \VAR{value}  is the same type as \dest.}
     \apiargument{IN}{pe}{ An integer that indicates the \ac{PE} number on which
-        \dest{} is to be updated. When using \Fortran, it must be a default
+        \dest{} is to be updated. When using \Fortran, \VAR{pe} must be a default
         integer value.}
 \end{apiarguments}
 
@@ -68,8 +68,9 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
 \begin{apiexamples}
 
 \apicexample
-    {The example below swaps values between odd numbered \acp{PE} and
-    their right (modulo) neighbor and outputs the result of swap.}
+    {The following \FUNC{shmem\_atomic\_swap} example swaps 
+    values between odd numbered \acp{PE} and
+    their right (modulo) neighbor and outputs the result of swap:}
     {./example_code/shmem_atomic_swap_example.c}
     {}
 

--- a/content/shmem_atomic_xor.tex
+++ b/content/shmem_atomic_xor.tex
@@ -1,5 +1,5 @@
 \apisummary{
-  Atomically perform a non-fetching bitwise exclusive OR (XOR) operation on a
+  \FUNC{shmem\_atomic\_xor} atomically performs a non-fetching bitwise exclusive OR (XOR) operation on a
   remote data object.
 }
 

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Performs all operations described in the \FUNC{shmem\_barrier\_all} interface
+    \FUNC{shmem\_barrier} performs all operations described in the \FUNC{shmem\_barrier\_all} interface
     but with respect to a subset of \acp{PE} defined by the active set.
 }
 
@@ -18,18 +18,18 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
 \begin{apiarguments}
 
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of \acp{PE}.
-    \VAR{PE\_start} must be of type integer.  When using \Fortran, it must be
+    \VAR{PE\_start} must be of type integer.  When using \Fortran, \VAR{PE\_start} must be
     a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between consecutive
     \ac{PE} numbers in the active set.  \VAR{logPE\_stride} must be of type integer.
-    When using \Fortran, it must be a default integer value.}
+    When using \Fortran, \VAR{logPE\_stride} must be a default integer value.}
 \apiargument{IN}{PE\_size}{The number of  \acp{PE} in the active set.  \VAR{PE\_size}
-    must be of type integer.  When using  \Fortran, it must be a default
+    must be of type integer.  When using  \Fortran, \VAR{PE\_size} must be a default
     integer value.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must
     be of type long and size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.  In \Fortran,
     \VAR{pSync} must be of type integer and size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.
-    When using \Fortran, it must  be a default  integer type.  Every element
+    When using \Fortran, \VAR{pSync} must  be a default  integer type.  Every element
     of this array must be initialized to \CONST{SHMEM\_SYNC\_VALUE} before any of
     the \acp{PE} in the active set enter \FUNC{shmem\_barrier} the first time.}
 
@@ -78,7 +78,7 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
 \begin{apiexamples}
 
 \apicexample
-	{The following barrier example is for C11 programs:}
+	{The following \FUNC{shmem\_barrier} example is for C11 programs:}
 	{./example_code/shmem_barrier_example.c}
 	{}
 

--- a/content/shmem_barrier_all.tex
+++ b/content/shmem_barrier_all.tex
@@ -1,7 +1,7 @@
 \apisummary{
-    Registers the arrival of a \ac{PE} at a barrier and blocks the \ac{PE}
-    until all other \acp{PE} arrive at the barrier and all local and remote
-    memory updates are completed.
+    \FUNC{shmem\_barrier\_all} registers the arrival of a \ac{PE} at a barrier and suspends \ac{PE} execution
+    until all other \acp{PE} arrive at the barrier and all local and remote memory
+    updates are completed.
 }
 
 \begin{apidefinition}
@@ -21,7 +21,7 @@ CALL SHMEM_BARRIER_ALL
 \end{apiarguments}
 
 \apidescription{   
-    The \FUNC{shmem\_barrier\_all} routine registers the arrival of a \ac{PE} at
+    \FUNC{shmem\_barrier\_all} registers the arrival of a \ac{PE} at
     a barrier. Barriers are a fast mechanism for synchronizing all \acp{PE} at
     once.  This routine blocks the \ac{PE} until all \acp{PE} have called
     \FUNC{shmem\_barrier\_all}. In a multithreaded \openshmem

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Broadcasts a block of data from one \ac{PE} to one or more destination
+    \FUNC{shmem\_broadcast} broadcasts a block of data from one \ac{PE} to one or more destination
     \acp{PE}.
 }
 
@@ -27,18 +27,18 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
 \apiargument{IN}{nelems}{The number of elements in \source.  For
     \FUNC{shmem\_broadcast32} and \FUNC{shmem\_broadcast4}, this is the number of
     32-bit halfwords.  nelems must be of type \VAR{size\_t} in \Cstd.  When
-    using \Fortran, it must be a default integer value.}
+    using \Fortran, \VAR{nelems} must be a default integer value.}
 \apiargument{IN}{PE\_root}{Zero-based ordinal of the \ac{PE}, with respect to
     the active set,	from which the data is copied. Must be greater than or equal to
-    0 and less than \VAR{PE\_size}. \VAR{PE\_root} must be of type integer.  When using \Fortran, it must be a default integer value.}
+    0 and less than \VAR{PE\_root}. \VAR{PE\_root} must be of type integer.  When using \Fortran, \VAR{PE\_size} must be a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
-    it must be a default integer value.}
+    \VAR{PE\_start} must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{ The log (base 2) of the stride between
     consecutive \ac{PE} numbers in the active set. \VAR{log\_PE\_stride} must be of
-    type integer.  When using \Fortran, it must be a default integer value.}
+    type integer.  When using \Fortran, \VAR{logPE\_stride} must be a default integer value.}
 \apiargument{IN}{PE\_size}{ The number of \acp{PE} in the active set.
-    \VAR{PE\_size} must be of type integer.  When using \Fortran, it must be a
+    \VAR{PE\_size} must be of type integer.  When using \Fortran, \VAR{PE\_size} must be a
     default integer value.}
 \apiargument{IN}{pSync}{ A symmetric work array.  In \CorCpp, \VAR{pSync} must
     be of type long and size \CONST{SHMEM\_BCAST\_SYNC\_SIZE}. In \Fortran,
@@ -51,7 +51,7 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
 \end{apiarguments}
 
 \apidescription{   
-    \openshmem broadcast routines are collective routines.  They copy data object
+    \FUNC{shmem\_broadcast} routines are collective routines.  They copy data object
     \source{} on the processor specified by \VAR{PE\_root} and store the values at
     \dest{} on the other \acp{PE} specified by the triplet \VAR{PE\_start},
     \VAR{logPE\_stride}, \VAR{PE\_size}.  The data is not copied to the \dest{} area
@@ -116,8 +116,8 @@ constraints, which are as follows:
 \begin{apiexamples}
 
 \apicexample
-    {In the following examples, the call to \FUNC{shmem\_broadcast64} copies \source{}
-    on \ac{PE} 4 to \dest{} on \acp{PE} 5, 6, and 7. 
+    {The following \FUNC{shmem\_broadcast64} examples copy \source{}
+    on \ac{PE} 4 to \dest{} on \acp{PE} 5, 6, and 7: 
     
     \CorCpp{} example:}
     {./example_code/shmem_broadcast_example.c}

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Concatenates blocks of data from multiple \acp{PE} to an array in every
+    \FUNC{shmem\_collect} and \FUNC{shmem\_fcollect} concatenate blocks of data from multiple \acp{PE} to an array in every
     \ac{PE}.
 }
 
@@ -40,21 +40,21 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \apiargument{IN}{source}{A symmetric data object that can be of any type permissible
     for the \dest{} argument.}
 \apiargument{IN}{nelems}{The number of elements in the \source{} array. \VAR{nelems}
-    must be of type \VAR{size\_t} for \Cstd. When using \Fortran, it must be
+    must be of type \VAR{size\_t} for \Cstd. When using \Fortran, \VAR{nelems} must be
     a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
-    it must be a default integer value.}
+    \VAR{PE\_start} must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base \CONST{2}) of the stride between
     consecutive \ac{PE} numbers in the active set. \VAR{logPE\_stride} must be of
-    type integer.  When using \Fortran, it must be a default integer value.}
+    type integer.  When using \Fortran, \VAR{logPE\_stride} must be a default integer value.}
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set. \VAR{PE\_size}
-    must be of type integer.  When using  \Fortran, it must be a default
+    must be of type integer.  When using  \Fortran, \VAR{PE\_size} must be a default
     integer value.}
 \apiargument{IN}{pSync}{A symmetric  work array.  In \CorCpp, \VAR{pSync} must be of
     type long and size \CONST{SHMEM\_COLLECT\_SYNC\_SIZE}.  In \Fortran,
     \VAR{pSync} must be of type integer and size \CONST{SHMEM\_COLLECT\_SYNC\_SIZE}.
-    When using \Fortran, it must be a default integer value.  Every element of
+    When using \Fortran, \VAR{pSync} must be a default integer value.  Every element of
     this array must be initialized with the value \CONST{SHMEM\_SYNC\_VALUE} in
     \CorCpp{} or \CONST{SHMEM\_SYNC\_VALUE} in \Fortran before any of the \acp{PE}
     in the active set enter \FUNC{shmem\_collect} or \FUNC{shmem\_fcollect}.}
@@ -62,7 +62,7 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \end{apiarguments}
 
 \apidescription{   
-    \openshmem \FUNC{collect} and \FUNC{fcollect} routines concatenate \VAR{nelems}
+    \FUNC{shmem\_collect} and \FUNC{shmem\_fcollect} routines concatenate \VAR{nelems}
     \CONST{64}-bit or \CONST{32}-bit data items from the \source{} array into the
     \dest{} array, over the set of \acp{PE} defined by \VAR{PE\_start},
     \VAR{log2PE\_stride}, and \VAR{PE\_size}, in processor number order. The

--- a/content/shmem_g.tex
+++ b/content/shmem_g.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies one data item from a remote \ac{PE}
+    \FUNC{shmem\_g} copies one data item from a remote \ac{PE}
 }
 
 \begin{apidefinition}
@@ -20,7 +20,7 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
 \end{apiarguments}
 
 \apidescription{
-  These routines provide a very low latency get capability for single elements
+   \FUNC{shmem\_g} routines provide a very low latency get capability for single elements
   of most basic types. 
 }
 

--- a/content/shmem_get_nbi.tex
+++ b/content/shmem_get_nbi.tex
@@ -1,6 +1,7 @@
 \apisummary{
-    The nonblocking get routines provide a method for copying data from a
-    contiguous remote data object on the specified \ac{PE} to the local data object. 
+    \FUNC{shmem\_get\_nbi} nonblocking get routines 
+    provide a method for copying data from a contiguous remote data object on the 
+    specified \ac{PE} to the local data object. 
 }
 
 \begin{apidefinition}
@@ -47,15 +48,15 @@ CALL SHMEM_REAL_GET_NBI(dest, source, nelems, pe)
         accessible.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
         arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When
-        using \Fortran, it must be a constant, variable, or array element of default
+        using \Fortran, \VAR{nelems} must be a constant, variable, or array element of default
         integer type.}
     \apiargument{IN}{pe}{\ac{PE}  number of the remote \ac{PE}.  \VAR{pe} must
-        be of type integer. When using \Fortran, it must be a constant,
+        be of type integer. When using \Fortran, \VAR{pe} must be a constant,
         variable, or array element of default integer type.}
 \end{apiarguments}
 
 \apidescription{
-    The get routines provide a method for copying a contiguous symmetric data
+     \FUNC{shmem\_get\_nbi} routines provide a method for copying a contiguous symmetric data
    object from a different \ac{PE} to a contiguous data object on the local
    \ac{PE}.   The routines return after posting the operation.  The operation is considered 
     complete after a subsequent call to \FUNC{shmem\_quiet}. 

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Copies strided data from a specified \ac{PE}.
+    \FUNC{shmem\_iget} copies strided data from a specified \ac{PE}.
 }
 
 \begin{apidefinition}
@@ -39,24 +39,24 @@ CALL SHMEM_REAL_IGET(dest, source, dst, sst, nelems, pe)
     \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
         array.  The stride is scaled by the element size of the \dest{} array.
         A  value of \CONST{1} indicates contiguous data. \VAR{dst} must be of
-        type \CTYPE{ptrdiff\_t}.  When using  \Fortran,  it  must
+        type \CTYPE{ptrdiff\_t}.  When using  \Fortran,  \VAR{dst}  must
         be a default integer value.}
     \apiargument{IN}{sst}{The stride between consecutive elements of the
         \source{} array.  The stride is scaled by the element size of the \source{}
         array.  A  value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-        of type \CTYPE{ptrdiff\_t}.  When using  \Fortran,  it  must
+        of type \CTYPE{ptrdiff\_t}.  When using  \Fortran,  \VAR{sst}  must
         be a default integer value.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
         arrays.  \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When
-        using \Fortran, it must be  a constant, variable, or array element of
+        using \Fortran, \VAR{nelems} must be  a constant, variable, or array element of
         default integer type.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.  \VAR{pe} must be
-        of type integer. When using  \Fortran, it must be a constant,
+        of type integer. When using  \Fortran, \VAR{pe} must be a constant,
         variable, or array element of default integer type.}
 \end{apiarguments}
 
 \apidescription{
-    The \FUNC{iget} routines provide a method for copying strided data elements from
+    \FUNC{shmem\_iget} routines provide a method for copying strided data elements from
     a symmetric array from a specified remote \ac{PE} to strided locations on a
     local array.  The routines return when the data has been copied into the local
     \VAR{dest} array.
@@ -95,8 +95,8 @@ CALL SHMEM_REAL_IGET(dest, source, dst, sst, nelems, pe)
 \begin{apiexamples}
 
 \apifexample
-    {The following example uses \FUNC{shmem\_logical\_iget}  in a \Fortran
-    program.} 
+    {The following \FUNC{shmem\_logical\_iget} example is for \Fortran
+    programs:} 
     {./example_code/shmem_iget_example.f90}
     {}
 

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -1,6 +1,7 @@
 \apisummary{
-    The nonblocking put routines provide a method for copying data
-    from a contiguous local data object to a data object on a specified \ac{PE}. 
+    \FUNC{shmem\_put\_nbi} nonblocking put routines 
+    provide a method for copying data from a contiguous local data object 
+    to a data object on a specified \ac{PE}. 
 }
 
 \begin{apidefinition}
@@ -45,16 +46,16 @@ CALL SHMEM_REAL_PUT_NBI(dest, source, nelems, pe)
     \apiargument{IN}{source}{Data object containing the data to be copied.}
     \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
     arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When using
-    \Fortran, it must be a constant, variable, or array element of default
+    \Fortran, \VAR{nelems} must be a constant, variable, or array element of default
     integer type.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}. \VAR{pe} must be
-    of type integer. When using \Fortran, it must be a constant, variable,
+    of type integer. When using \Fortran, \VAR{pe} must be a constant, variable,
     or array element of default integer type.}
 \end{apiarguments}
 
 \apidescription{
-    The routines return after posting the operation.  The operation is considered 
-    complete after a subsequent call to \FUNC{shmem\_quiet}. 
+    \FUNC{shmem\_put\_nbi} routines return after posting the operation.  
+    The operation is considered complete after a subsequent call to \FUNC{shmem\_quiet}. 
     At the completion of \FUNC{shmem\_quiet}, the data has been copied into the \dest{} array
     on the destination \ac{PE}.
     The delivery of data words into the data object on the

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Performs arithmetic and logical operations across a set of \acp{PE}.
+    \FUNC{shmem\_reductions} performs arithmetic and logical operations across a set of \acp{PE}.
 }
 
 \begin{apidefinition}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -137,6 +137,8 @@ symmetric data objects in the symmetric heap, in \Cstd and \Fortran.
 
 \subsection{Non-blocking Remote Memory Access Routines}\label{sec:rma_nbi}
 
+The following section consists of nonblocking Remote Memory Access (RMA) routines. 
+
 \subsubsection{\textbf{SHMEM\_PUT\_NBI}}\label{subsec:shmem_put_nbi}
 \input{content/shmem_put_nbi.tex}
 


### PR DESCRIPTION
This PR is the second part of a series of three. The purpose of the consis_edit PRs is to make the OpenSHMEM 1.4 specification, specifically the 8.1-8.10 sections, read more consistently. Edits have been made to section intros, routine intros, API descriptions, example sections, and argument lists with the intention of making them read as though they were written by one person. This PR includes consistency edits from pages 30 to 60.