### PR TITLE
Consistency edits from pages 60 to 85.

### DIFF
--- a/content/p2p_sync_intro.tex
+++ b/content/p2p_sync_intro.tex
@@ -1,4 +1,4 @@
-The following section discusses \openshmem \acp{API} that provides a mechanism
+The following section consists of \openshmem \acp{API} that provides a mechanism
 for synchronization between two \acp{PE} based on the value of a symmetric data
 object.
 The point-to-point synchronization routines can be used to portably ensure

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -30,7 +30,7 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
-    it must be a default integer value.}
+    \VAR{PE\_start} must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between
     consecutive \ac{PE} numbers in the active set.  \VAR{logPE\_stride} must be of
     type integer.  When using \Fortran, it must be a default integer value.}
@@ -40,7 +40,7 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be
     of type long and size \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}. In \Fortran,
     \VAR{pSync} must be of type integer and size
-    \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}.  When using \Fortran, it must be a
+    \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}.  When using \Fortran, \VAR{pSync} must be a
     default integer value. Every element of this array must be initialized with
     the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
     active set enter the routine.}
@@ -48,7 +48,7 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \end{apiarguments}
 
 \apidescription{
-    The \FUNC{shmem\_alltoall} routines are collective routines. Each \ac{PE}
+    \FUNC{shmem\_alltoall} routines are collective routines. Each \ac{PE}
     in the active set exchanges \VAR{nelems} data elements of size
     32 bits (for \FUNC{shmem\_alltoall32}) or 64 bits (for \FUNC{shmem\_alltoall64})
     with all other \acp{PE} in the set. The data being sent and received are
@@ -120,7 +120,7 @@ constraints, which are as follows:
 \begin{apiexamples}
 
 \apicexample
-    {This example shows a \FUNC{shmem\_alltoall64} on two long elements among all
+    {The following example shows a \FUNC{shmem\_alltoall64} on two long elements among all
     \acp{PE}.}
     {./example_code/shmem_alltoall_example.c}
     {}

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -29,29 +29,29 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
 \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
     data object.  The stride is scaled by the element size.  A
     value of \CONST{1} indicates contiguous data.  \VAR{dst} must be of type
-    \CTYPE{ptrdiff\_t}.  When using \Fortran, it must be a default integer
+    \CTYPE{ptrdiff\_t}.  When using \Fortran, \VAR{dst} must be a default integer
     value.}
 \apiargument{IN}{sst}{The  stride between consecutive elements of the
     \source{} data object.  The stride is scaled by the element size.
     A value of \CONST{1} indicates contiguous data.  \VAR{sst} must be
-    of type \CTYPE{ptrdiff\_t}.  When using \Fortran, it must be a
+    of type \CTYPE{ptrdiff\_t}.  When using \Fortran, \VAR{sst} must be a
     default integer value.}
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
     \VAR{nelems} must be of type size\_t for \CorCpp.  When using
     \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
-    it must be a default integer value.}
+    \VAR{PE\_start} must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between
     consecutive \ac{PE} numbers in the active set.  \VAR{logPE\_stride} must be of
-    type integer.  When using \Fortran, it must be a default integer value.}
+    type integer.  When using \Fortran, \VAR{logPE\_stride} must be a default integer value.}
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set.
-    \VAR{PE\_size} must be of type integer.  When using \Fortran, it must
+    \VAR{PE\_size} must be of type integer.  When using \Fortran, \VAR{PE\_size} must
     be a default integer value.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be
     of type long and size \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}. In \Fortran,
     \VAR{pSync} must be of type integer and size
-    \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}.  When using \Fortran, it must be a
+    \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}.  When using \Fortran, \VAR{pSync} must be a
     default integer value. Every element of this array must be initialized with
     the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
     active set enter the routine.}
@@ -59,7 +59,7 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
 \end{apiarguments}
 
 \apidescription{
-    The \FUNC{shmem\_alltoalls} routines are collective routines. Each \ac{PE}
+    \FUNC{shmem\_alltoalls} routines are collective routines. Each \ac{PE}
     in the active set exchanges \VAR{nelems} strided data elements of size
     32 bits (for \FUNC{shmem\_alltoalls32}) or 64 bits (for \FUNC{shmem\_alltoalls64})
     with all other \acp{PE} in the set. Both strides, \VAR{dst} and \VAR{sst}, must be greater
@@ -127,7 +127,7 @@ constraints, which are as follows:
 \begin{apiexamples}
 
 \apicexample
-    {This example shows a \FUNC{shmem\_alltoalls64} on two long elements among
+    {The following example shows a \FUNC{shmem\_alltoalls64} on two long elements among
     all \acp{PE}.}
     {./example_code/shmem_alltoalls_example.c}
     {}

--- a/content/shmem_cache.tex
+++ b/content/shmem_cache.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Controls data cache utilities.
+    \FUNC{shmem\_cache} controls data cache utilities.
 }
 
 \begin{apidefinition}
@@ -28,7 +28,7 @@ CALL SHMEM_UDCFLUSH_LINE(dest)
 \begin{apiarguments}
 
 \apiargument{IN}{dest}{A data object that is local to the \ac{PE}.  \VAR{dest}
-    can be of any noncharacter type. When using \Fortran, it can be of any
+    can be of any noncharacter type. When using \Fortran, \VAR{dest} can be of any
     kind.}
 
 \end{apiarguments}

--- a/content/shmem_fence.tex
+++ b/content/shmem_fence.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Assures ordering of delivery of \PUT{}, \acp{AMO}, and memory store routines
+    \FUNC{shmem\_fence} assures ordering of delivery of \PUT{}, \acp{AMO}, and memory store routines
     to symmetric data objects.
 }
 

--- a/content/shmem_lock.tex
+++ b/content/shmem_lock.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Releases, locks, and tests a mutual exclusion memory lock.
+    \FUNC{shmem\_lock} releases, locks, and tests a mutual exclusion memory lock.
 }
 \begin{apidefinition}
 
@@ -20,17 +20,17 @@ I = SHMEM_TEST_LOCK(lock)
 \apiargument{IN}{lock}{A symmetric data object that is a scalar variable or an array
     of  length \CONST{1}.  This data  object  must  be set to \CONST{0} on all
     \acp{PE} prior to the first use.  \VAR{lock}  must  be  of type \CONST{long}.
-    When using \Fortran, it must be of default kind.}
+    When using \Fortran, \VAR{lock} must be of default kind.}
 \end{apiarguments}
 
 \apidescription{
-    The \FUNC{shmem\_set\_lock} routine sets a mutual exclusion lock after  waiting
+    \FUNC{shmem\_set\_lock} sets a mutual exclusion lock after  waiting
     for  the lock  to be freed by any other \ac{PE} currently holding the lock.
     Waiting \acp{PE} are assured of getting the lock in a first-come, first-served
-    manner.  The \FUNC{shmem\_clear\_lock} routine releases a lock  previously set
+    manner.  \FUNC{shmem\_clear\_lock} releases a lock  previously set
     by \FUNC{shmem\_set\_lock} after ensuring that all local and remote	 stores
-    initiated in the critical region are complete.  The \FUNC{shmem\_test\_lock}
-    routine sets a mutual exclusion lock only if it is currently cleared.  By using
+    initiated in the critical region are complete.  \FUNC{shmem\_test\_lock}
+    sets a mutual exclusion lock only if it is currently cleared.  By using
     this routine, a \ac{PE} can avoid blocking on a set lock.  If the lock is
     currently set, the routine returns without waiting.  These routines are
     appropriate for protecting a critical region from simultaneous update by
@@ -38,7 +38,7 @@ I = SHMEM_TEST_LOCK(lock)
 }
 
 \apireturnvalues{
-    The \FUNC{shmem\_test\_lock} routine returns \CONST{0} if  the lock  was
+    \FUNC{shmem\_test\_lock} returns \CONST{0} if  the lock  was
     originally cleared and  this  call was  able  to set the lock.  A value of
     \CONST{1} is returned if the lock had been set and the call returned without
     waiting to set the lock.
@@ -54,7 +54,7 @@ I = SHMEM_TEST_LOCK(lock)
 \begin{apiexamples}
 
 \apicexample
-    {The following example uses \FUNC{shmem\_lock} in a \Cstd[11] program.}
+    {The following \FUNC{shmem\_lock} example is for \Cstd[11] programs:}
     {./example_code/shmem_lock_example.c}
     {}
 

--- a/content/shmem_quiet.tex
+++ b/content/shmem_quiet.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Waits for completion of all outstanding \PUT{}, \acp{AMO}, memory store,
+    \FUNC{shmem\_quiet} waits for completion of all outstanding \PUT{}, \acp{AMO}, memory store,
     and non-blocking \PUT{} and \GET{} routines to symmetric data
     objects issued by a \ac{PE}.
 }
@@ -19,7 +19,7 @@ CALL SHMEM_QUIET
 \end{apiarguments}
 
 \apidescription{ 
-    The \FUNC{shmem\_quiet} routine ensures completion of \PUT{}, \acp{AMO},
+    \FUNC{shmem\_quiet} ensures completion of \PUT{}, \acp{AMO},
     memory store, and non-blocking \PUT{} and \GET{} routines on
     symmetric data objects issued by the calling \ac{PE}. All \PUT{}, \acp{AMO},
     memory store, and non-blocking \PUT{} and \GET{} routines to
@@ -74,7 +74,7 @@ CALL SHMEM_QUIET
 \begin{apiexamples}
 
 \apicexample
-    {The following example uses  \FUNC{shmem\_quiet}  in a C11 program: }
+    {The following \FUNC{shmem\_quiet}  example is for C11 programs: }
     {./example_code/shmem_quiet_example.c}
     {\VAR{Put1} and \VAR{put2} will be completed and visible before \VAR{put3}
     and \VAR{put4}.}

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -149,17 +149,17 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \apiargument{IN}{source}{ A symmetric array, of length \VAR{nreduce} elements, that
     contains one element for each separate reduction routine.  The \source{}
     argument must have the same data type as \dest.}
-\apiargument{IN}{nreduce}{The number of elements in the \dest{} and \source{}
-    arrays.  \VAR{nreduce} must be of type integer.  When using \Fortran, it
+\apiargument{IN}{\VAR{nreduce}}{The number of elements in the \dest{} and \source{}
+    arrays.  \VAR{nreduce} must be of type integer.  When using \Fortran, \VAR{nreduce}
     must be a default integer value.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
-    it must be a default integer value.}
+    \VAR{PE\_start} must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between consecutive
     \ac{PE} numbers in the active set.  \VAR{logPE\_stride} must be of type integer.
-    When using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set.
-    \VAR{PE\_size} must be of type integer.  When using \Fortran, it must be a
+    When using \Fortran, \VAR{logPE\_stride} must be a default integer value.}
+    \VAR{PE\_size} must be of type integer.  When using \Fortran, \VAR{PE\_size} must be a
     default integer value.}
 \apiargument{IN}{pWrk}{A symmetric work array. The \VAR{pWrk} argument must have the
     same data type as \dest. In \CorCpp, this contains max(\VAR{nreduce}/2 + 1,
@@ -169,7 +169,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be of
     type long and size \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}. In \Fortran, \VAR{pSync}
     must be of type integer and size \CONST{SHMEM\_REDUCE\_SYNC\_SIZE}.  When
-    using \Fortran, it must be a default integer value. Every element of this array
+    using \Fortran, \VAR{pSync} must be a default integer value. Every element of this array
     must be initialized with the value \CONST{SHMEM\_SYNC\_VALUE} (in \CorCpp) or
     \CONST{SHMEM\_SYNC\_VALUE} (in \Fortran) before any of the \acp{PE} in the
     active set enter the reduction routine.}
@@ -177,7 +177,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \end{apiarguments}
 
 \apidescription{
-    \openshmem reduction routines compute one or more reductions across symmetric
+    \FUNC{shmem\_reduction} routines compute one or more reductions across symmetric
     arrays on multiple \acp{PE}.  A reduction performs an associative binary routine
     across a set of values.	 
     
@@ -278,48 +278,48 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \begin{apiexamples}
 
 \apifexample
-    {This \Fortran reduction example statically initializes the \VAR{pSync} array
+    {The following \FUNC{shmem\_reduction} example is for \Fortran programs. This example statically initializes the \VAR{pSync} array
     and finds the logical \OPR{AND} of the integer variable \VAR{FOO} across all
-    even \acp{PE}.}
+    even \acp{PE}:}
     {./example_code/shmem_and_example.f90}
     {}
     
 \apifexample
-    {This \Fortran example statically initializes the \VAR{pSync} array and finds
-    the \OPR{maximum} value of real variable \VAR{FOO} across all even \acp{PE}.}
+    {The following \FUNC{shmem\_reduction} example is for \Fortran programs. This example statically initializes the \VAR{pSync} array and finds
+    the \OPR{maximum} value of real variable \VAR{FOO} across all even \acp{PE}:}
     {./example_code/shmem_max_example.f90}
     {}
 
 \apifexample
-    { This \Fortran example statically initializes the \VAR{pSync} array and finds
+    { The following \FUNC{shmem\_reduction} example is for \Fortran programs. This example statically initializes the \VAR{pSync} array and finds
     the \OPR{minimum} value of real variable \VAR{FOO} across all the even
-    \acp{PE}.}
+    \acp{PE}:}
     {./example_code/shmem_min_example.f90}
     {}
 
 \apifexample
-    {This \Fortran example statically initializes the \VAR{pSync} array and finds
-    the \OPR{sum} of the real variable \VAR{FOO} across all even \acp{PE}.}
+    {The following \FUNC{shmem\_reduction} examples is for \Fortran programs. This example statically initializes the \VAR{pSync} array and finds
+    the \OPR{sum} of the real variable \VAR{FOO} across all even \acp{PE}:}
     {./example_code/shmem_sum_example.f90}
     {}
 
 \apifexample
-    {This \Fortran example statically initializes the \VAR{pSync} array and finds
-    the \OPR{product} of the real variable \VAR{FOO} across all the even \acp{PE}.}
+    {The following \FUNC{shmem\_reduction} example is for \Fortran programs. This example statically initializes the \VAR{pSync} array and finds
+    the \OPR{product} of the real variable \VAR{FOO} across all the even \acp{PE}:}
     {./example_code/shmem_prod_example.f90}
     {}
 
 \apifexample
-    {This \Fortran example statically initializes the \VAR{pSync} array and finds
+    {The following \FUNC{shmem\_reduction} example is for \Fortran programs. This example statically initializes the \VAR{pSync} array and finds
     the logical \OPR{OR} of the integer variable \VAR{FOO} across all even
-    \acp{PE}.}
+    \acp{PE}:}
     {./example_code/shmem_or_example.f90}
     {}
 
 \apifexample
-    {This \Fortran example statically initializes the \VAR{pSync} array and
+    {The following \FUNC{shmem\_reduction} example is for \Fortran programs. This example statically initializes the \VAR{pSync} array and
     computes the exclusive \OPR{XOR} of variable \VAR{FOO} across all even
-    \acp{PE}.}
+    \acp{PE}:}
     {./example_code/shmem_xor_example.f90}
     {} 
 

--- a/content/shmem_test.tex
+++ b/content/shmem_test.tex
@@ -1,5 +1,5 @@
 \apisummary{
-  Test whether a variable on the local \ac{PE} has changed.
+  \FUNC{shmem\_test} tests whether a variable on the local \ac{PE} has changed.
 }
 
 \begin{apidefinition}
@@ -44,7 +44,7 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
 
 \begin{apiexamples}
   \apicexample
-      {The following example demonstrates the use of \FUNC{shmem\_test} to
+      {The following \FUNC{shmem\_test} example demonstrates the use of \FUNC{shmem\_test} to
         wait on an array of symmetric objects and return the index of an
         element that satisfies the specified condition.}
       {./example_code/shmem_test_example1.c}

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -1,5 +1,5 @@
 \apisummary{
-    Wait for a variable on the local \ac{PE} to change.
+    \FUNC{shmem\_wait} waits for a variable on the local \ac{PE} to change.
 }
 
 \begin{apidefinition}
@@ -40,11 +40,11 @@ CALL SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)
 \apiargument{OUT}{ivar}{A remotely accessible integer variable. When using \CorCpp,
     the type of \VAR{ivar} should match that implied in the SYNOPSIS section.} 
 \apiargument{IN}{cmp}{The compare operator that compares \VAR{ivar} with
-  \VAR{cmp\_value}.  When using \Fortran, it must  be of default kind.
-  When using \CorCpp, it must be of type \CTYPE{shmem\_cmp\_t}.}
+  \VAR{cmp\_value}.  When using \Fortran, \VAR{cmp} must  be of default kind.
+  When using \CorCpp, \VAR{cmp} must be of type \CTYPE{shmem\_cmp\_t}.}
 \apiargument{IN}{cmp\_value}{\VAR{cmp\_value} must be of type integer.  When
     using \CorCpp, the type of \VAR{cmp\_value} should match that implied in the
-    SYNOPSIS section.  When using \Fortran, cmp\_value must be an integer of
+    SYNOPSIS section.  When using \Fortran, \VAR{cmp\_value} must be an integer of
     the same size and kind as \VAR{ivar}.}
 
 \end{apiarguments}
@@ -94,24 +94,24 @@ CALL SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)
 \begin{apiexamples}
 
 \apifexample
-{ The following call returns when variable \VAR{ivar} is not equal to 100:}
+{ The following \FUNC{SHMEM\_INT8\_WAIT\_UNTIL} example returns when variable \VAR{ivar} is not equal to 100:}
 {./example_code/shmem_wait1_example.f90}
 {}
 
 \apifexample
-{ The following call to \FUNC{SHMEM\_INT8\_WAIT\_UNTIL} is  equivalent to the
+{ The following \FUNC{SHMEM\_INT8\_WAIT\_UNTIL} example is  equivalent to the
 call to \FUNC{SHMEM\_INT8\_WAIT} in example 1:}
 {./example_code/shmem_wait2_example.f90}
 {}
 
 \apicexample
-{The following \CorCpp{} call waits until the value in \VAR{ivar} is set to
+{The following \FUNC{shmem\_int\_wait\_until} example is for \CorCpp{} program. The call in this example waits until the value in \VAR{ivar} is set to
 be less than zero by a transfer from a remote PE:}
 {./example_code/shmem_wait3_example.f90}
 {}
 
 \apifexample
-{The following \Fortran example is in the context of a subroutine:}
+{The following \FUNC{shmem\_wait} example is a subroutine for  \Fortran programs:}
 {./example_code/shmem_wait4_example.f90}
 {}
 

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -255,7 +255,7 @@ symmetric data objects in the symmetric heap, in \Cstd and \Fortran.
 
 
 \subsection{Memory Ordering Routines}\label{subsec:memory_order}
-The following section discusses \openshmem \acp{API} that provide mechanisms to
+The following section consists of \openshmem \ac{API}s that provide mechanisms to
 ensure ordering and/or delivery of \OPR{Put}, \ac{AMO}, and memory store
 routines to symmetric data objects. 
 
@@ -274,7 +274,7 @@ routines to symmetric data objects.
 
 
 \subsection{Distributed Locking Routines}
-The following section discusses \openshmem locks as a mechanism to provide
+The following section consists of \openshmem locks. These locks provide
 mutual exclusion. Three routines are available for distributed locking,
 \textit{set, test} and \textit{clear}.
 
@@ -286,7 +286,7 @@ mutual exclusion. Three routines are available for distributed locking,
 
 
 \subsection{Cache Management}
-All of these routines are deprecated and are provided for backwards
+The following section consists of deprecated routines. These routines are provided for backwards
 compatibility.  Implementations must include all items in this section, and the
 routines should function properly and may notify the user about deprecation of
 their use.


### PR DESCRIPTION
This PR is the third part of a series of three. The purpose of the consis_edit PRs is to make the OpenSHMEM 1.4 specification, specifically the 8.1-8.10 sections, read more consistently. Edits have been made to section intros, routine intros, API descriptions, example sections, and argument lists with the intention of making them read as though they were written by one person. This PR includes consistency edits from pages 60 to 85.