### PR TITLE
Consistency edits for the term: active set.

### DIFF
--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -1,15 +1,15 @@
-\emph{Collective routines} are defined as communication or synchronization
+\emph{Collective Routines} are defined as communication or synchronization
 operations on a group of \acp{PE} called an \activeset. The collective
-routines require all \acp{PE} in the \activeset to simultaneously call the
-routine.  A \ac{PE} that is not part of the \activeset calling the collective
+routines require all \acp{PE} in the active set to simultaneously call the
+routine.  A \ac{PE} that is not part of the active set calling the collective
 routines results in an undefined behavior.  All collective routines have an
-\activeset as an input parameter except \barrierall. The \barrierall is
+active set as an input parameter except \barrierall. The \barrierall is
 called by all \acp{PE} of the \openshmem program. 
 
-The \activeset is defined by the arguments \VAR{PE\_start}, \VAR{logPE\_stride},
+The active set is defined by the arguments \VAR{PE\_start}, \VAR{logPE\_stride},
 and \VAR{PE\_size}.  \VAR{PE\_start} is the starting \ac{PE} number, a log (base
 2) of \VAR{logPE\_stride} is the stride between \acp{PE}, and \VAR{PE\_size} is
-the number of \acp{PE} participating in the \activeset.  All \acp{PE}
+the number of \acp{PE} participating in the active set.  All \acp{PE}
 participating in the collective routines provide the same values for these
 arguments. 
  
@@ -21,7 +21,7 @@ array if all previous collective routines using the \VAR{pSync} array have been
 completed by all participating \acp{PE}.  One can use a synchronization
 collective routine such as \barrier to ensure completion of previous collective
 routines. The \FUNC{shmem\_barrier} routine allows the same \VAR{pSync} array to
-be used on consecutive calls as long as the \ac{PE} \activeset does not change. 
+be used on consecutive calls as long as the \ac{PE} active set does not change. 
 
 All collective routines defined in the specification are blocking.  The
 collective routines return on completion.  The collective routines defined in

--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -1,5 +1,5 @@
 \emph{Collective Routines} are defined as communication or synchronization
-operations on a group of \acp{PE} called an \activeset. The collective
+operations on a group of \acp{PE} called an active set. The collective
 routines require all \acp{PE} in the active set to simultaneously call the
 routine.  A \ac{PE} that is not part of the active set calling the collective
 routines results in an undefined behavior.  All collective routines have an

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -1,6 +1,6 @@
 \apisummary{
     shmem\_alltoall is a collective routine where each \ac{PE} exchanges a fixed amount of data with all other \acp{PE} in the
-    \activeset.
+    active set.
 }
 
 \begin{apidefinition}
@@ -21,20 +21,20 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 
 \apiargument{OUT}{dest}{A symmetric data object large enough to receive
     the combined total of \VAR{nelems} elements from each \ac{PE} in the
-    \activeset.}
+    active set.}
 \apiargument{IN}{source}{A symmetric data object that contains \VAR{nelems}
-    elements of data for each \ac{PE} in the \activeset{}, ordered according to
+    elements of data for each \ac{PE} in the active set{}, ordered according to
     destination \ac{PE}.}
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
     \VAR{nelems} must be of type size\_t for \CorCpp.  When using
     \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between
-    consecutive \ac{PE} numbers in the \activeset.  \VAR{logPE\_stride} must be of
+    consecutive \ac{PE} numbers in the active set.  \VAR{logPE\_stride} must be of
     type integer.  When using \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_size}{The number of \acp{PE} in the \activeset.
+\apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set.
     \VAR{PE\_size} must be of type integer.  When using \Fortran, it must
     be a default integer value.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be
@@ -43,13 +43,13 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}.  When using \Fortran, it must be a
     default integer value. Every element of this array must be initialized with
     the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
-    \activeset{} enter the routine.}
+    active set{} enter the routine.}
 
 \end{apiarguments}
 
 \apidescription{
     The \FUNC{shmem\_alltoall} routines are collective routines. Each \ac{PE}
-    in the \activeset{} exchanges \VAR{nelems} data elements of size
+    in the active set{} exchanges \VAR{nelems} data elements of size
     32 bits (for \FUNC{shmem\_alltoall32}) or 64 bits (for \FUNC{shmem\_alltoall64})
     with all other \acp{PE} in the set. The data being sent and received are
     stored in a contiguous symmetric data object. The total size of each \acp{PE}
@@ -64,21 +64,21 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     the \VAR{dest} object of \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, this routine assumes
-    that only \acp{PE} in the \activeset{} call the routine.  If a \ac{PE} not
-    in the \activeset{} calls an \openshmem collective routine, undefined
+    that only \acp{PE} in the active set{} call the routine.  If a \ac{PE} not
+    in the active set{} calls an \openshmem collective routine, undefined
     behavior results.
 
     The values of arguments \VAR{nelems}, \VAR{PE\_start}, \VAR{logPE\_stride},
-    and \VAR{PE\_size} must be equal on all \acp{PE} in the \activeset. The same
+    and \VAR{PE\_size} must be equal on all \acp{PE} in the active set. The same
     \VAR{dest} and \VAR{source} data objects, and the same \VAR{pSync} work
-    array must be passed to all \acp{PE} in the \activeset.
+    array must be passed to all \acp{PE} in the active set.
 
     Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine, the following
     conditions must exist (synchronization via a barrier or some other method is
     often needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
-    \activeset{} is not still in use from a prior call to a
+    active set{} is not still in use from a prior call to a
     \FUNC{shmem\_alltoall/s} routine.  The \VAR{dest} data object on
-    all \acp{PE} in the \activeset{} is ready to accept the
+    all \acp{PE} in the active set{} is ready to accept the
     \FUNC{shmem\_alltoall} data.
 
     Upon return from a \FUNC{shmem\_alltoall} routine, the following is true for
@@ -104,15 +104,15 @@ constraints, which are as follows:
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
     The user must ensure that the \VAR{pSync} array is not being updated by any
-    \ac{PE} in the \activeset{} while any of the \acp{PE} participates in
+    \ac{PE} in the active set{} while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoall} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,
     some type of synchronization is needed to ensure that all \acp{PE} in the
-    \activeset{} have initialized \VAR{pSync} before any of them enter an
+    active set{} have initialized \VAR{pSync} before any of them enter an
     \openshmem\ routine called with the \VAR{pSync} synchronization array.  A
     \VAR{pSync} array may be reused on a subsequent \openshmem\
     \FUNC{shmem\_alltoall} routine only if none of the \acp{PE} in the
-    \activeset{} are still processing a prior \openshmem\ \FUNC{shmem\_alltoall}
+    active set{} are still processing a prior \openshmem\ \FUNC{shmem\_alltoall}
     routine call that used the same \VAR{pSync} array.  In general, this can be
     ensured only by doing some type of synchronization.
 }

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -23,12 +23,12 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     the combined total of \VAR{nelems} elements from each \ac{PE} in the
     active set.}
 \apiargument{IN}{source}{A symmetric data object that contains \VAR{nelems}
-    elements of data for each \ac{PE} in the active set{}, ordered according to
+    elements of data for each \ac{PE} in the active set, ordered according to
     destination \ac{PE}.}
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
     \VAR{nelems} must be of type size\_t for \CorCpp.  When using
     \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between
@@ -43,13 +43,13 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     \CONST{SHMEM\_ALLTOALL\_SYNC\_SIZE}.  When using \Fortran, it must be a
     default integer value. Every element of this array must be initialized with
     the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
-    active set{} enter the routine.}
+    active set enter the routine.}
 
 \end{apiarguments}
 
 \apidescription{
     The \FUNC{shmem\_alltoall} routines are collective routines. Each \ac{PE}
-    in the active set{} exchanges \VAR{nelems} data elements of size
+    in the active set exchanges \VAR{nelems} data elements of size
     32 bits (for \FUNC{shmem\_alltoall32}) or 64 bits (for \FUNC{shmem\_alltoall64})
     with all other \acp{PE} in the set. The data being sent and received are
     stored in a contiguous symmetric data object. The total size of each \acp{PE}
@@ -64,8 +64,8 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     the \VAR{dest} object of \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, this routine assumes
-    that only \acp{PE} in the active set{} call the routine.  If a \ac{PE} not
-    in the active set{} calls an \openshmem collective routine, undefined
+    that only \acp{PE} in the active set call the routine.  If a \ac{PE} not
+    in the active set calls an \openshmem collective routine, undefined
     behavior results.
 
     The values of arguments \VAR{nelems}, \VAR{PE\_start}, \VAR{logPE\_stride},
@@ -76,9 +76,9 @@ CALL SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine, the following
     conditions must exist (synchronization via a barrier or some other method is
     often needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
-    active set{} is not still in use from a prior call to a
+    active set is not still in use from a prior call to a
     \FUNC{shmem\_alltoall/s} routine.  The \VAR{dest} data object on
-    all \acp{PE} in the active set{} is ready to accept the
+    all \acp{PE} in the active set is ready to accept the
     \FUNC{shmem\_alltoall} data.
 
     Upon return from a \FUNC{shmem\_alltoall} routine, the following is true for
@@ -104,15 +104,15 @@ constraints, which are as follows:
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
     The user must ensure that the \VAR{pSync} array is not being updated by any
-    \ac{PE} in the active set{} while any of the \acp{PE} participates in
+    \ac{PE} in the active set while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoall} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,
     some type of synchronization is needed to ensure that all \acp{PE} in the
-    active set{} have initialized \VAR{pSync} before any of them enter an
+    active set have initialized \VAR{pSync} before any of them enter an
     \openshmem\ routine called with the \VAR{pSync} synchronization array.  A
     \VAR{pSync} array may be reused on a subsequent \openshmem\
     \FUNC{shmem\_alltoall} routine only if none of the \acp{PE} in the
-    active set{} are still processing a prior \openshmem\ \FUNC{shmem\_alltoall}
+    active set are still processing a prior \openshmem\ \FUNC{shmem\_alltoall}
     routine call that used the same \VAR{pSync} array.  In general, this can be
     ensured only by doing some type of synchronization.
 }

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -1,6 +1,6 @@
 \apisummary{
     shmem\_alltoalls is a collective routine where each \ac{PE} exchanges a fixed amount of strided data with all other
-    \acp{PE} in the \activeset.
+    \acp{PE} in the active set.
 }
 
 \begin{apidefinition}
@@ -22,9 +22,9 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
 
 \apiargument{OUT}{dest}{A symmetric data object large enough to receive 
     the combined total of \VAR{nelems} elements from each \ac{PE} in the
-    \activeset.}
+    active set.}
 \apiargument{IN}{source}{A symmetric data object that contains \VAR{nelems} 
-    elements of data for each \ac{PE} in the \activeset{}, ordered according to 
+    elements of data for each \ac{PE} in the active set{}, ordered according to 
     destination \ac{PE}.}
 \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
     data object.  The stride is scaled by the element size.  A
@@ -39,13 +39,13 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
     \VAR{nelems} must be of type size\_t for \CorCpp.  When using
     \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between
-    consecutive \ac{PE} numbers in the \activeset.  \VAR{logPE\_stride} must be of
+    consecutive \ac{PE} numbers in the active set.  \VAR{logPE\_stride} must be of
     type integer.  When using \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_size}{The number of \acp{PE} in the \activeset.
+\apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set.
     \VAR{PE\_size} must be of type integer.  When using \Fortran, it must
     be a default integer value.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must be
@@ -54,13 +54,13 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}.  When using \Fortran, it must be a
     default integer value. Every element of this array must be initialized with
     the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
-    \activeset{} enter the routine.}
+    active set{} enter the routine.}
     
 \end{apiarguments}
 
 \apidescription{
     The \FUNC{shmem\_alltoalls} routines are collective routines. Each \ac{PE}
-    in the \activeset{} exchanges \VAR{nelems} strided data elements of size
+    in the active set{} exchanges \VAR{nelems} strided data elements of size
     32 bits (for \FUNC{shmem\_alltoalls32}) or 64 bits (for \FUNC{shmem\_alltoalls64})
     with all other \acp{PE} in the set. Both strides, \VAR{dst} and \VAR{sst}, must be greater
     than or equal to \CONST{1}.
@@ -71,21 +71,21 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, these routines assume
-    that only \acp{PE} in the \activeset{} call the routine.  If a \ac{PE} not
-    in the \activeset{} calls an \openshmem collective routine, undefined
+    that only \acp{PE} in the active set{} call the routine.  If a \ac{PE} not
+    in the active set{} calls an \openshmem collective routine, undefined
     behavior results.
 
     The values of arguments \VAR{dst}, \VAR{sst}, \VAR{nelems}, \VAR{PE\_start},
     \VAR{logPE\_stride}, and \VAR{PE\_size} must be equal on all \acp{PE} in the
-    \activeset. The same \VAR{dest} and \VAR{source} data objects, and the same
-    \VAR{pSync} work array must be passed to all \acp{PE} in the \activeset.
+    active set. The same \VAR{dest} and \VAR{source} data objects, and the same
+    \VAR{pSync} work array must be passed to all \acp{PE} in the active set.
     
     Before any \ac{PE} calls to a \FUNC{shmem\_alltoalls} routine, the following
     conditions must exist (synchronization via a barrier or some other method is
     often needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
-    \activeset{} is not still in use from a prior call to a
+    active set{} is not still in use from a prior call to a
     \FUNC{shmem\_alltoalls} routine.  The \VAR{dest} data object on
-    all \acp{PE} in the \activeset{} is ready to accept the
+    all \acp{PE} in the active set{} is ready to accept the
     \FUNC{shmem\_alltoalls} data.
     
     Upon return from a \FUNC{shmem\_alltoalls} routine, the following is true for
@@ -111,15 +111,15 @@ constraints, which are as follows:
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
     The user must ensure that the \VAR{pSync} array is not being updated by any
-    \ac{PE} in the \activeset{} while any of the \acp{PE} participates in
+    \ac{PE} in the active set{} while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoalls} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,
     some type of synchronization is needed to ensure that all \acp{PE} in the
-    \activeset{} have initialized \VAR{pSync} before any of them enter an
+    active set{} have initialized \VAR{pSync} before any of them enter an
     \openshmem\ routine called with the \VAR{pSync} synchronization array.  A
     \VAR{pSync} array may be reused on a subsequent \openshmem\
     \FUNC{shmem\_alltoalls} routine only if none of the \acp{PE} in the
-    \activeset{} are still processing a prior \openshmem\ \FUNC{shmem\_alltoalls}
+    active set{} are still processing a prior \openshmem\ \FUNC{shmem\_alltoalls}
     routine call that used the same \VAR{pSync} array.  In general, this can be
     ensured only by doing some type of synchronization.        
 }

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -24,7 +24,7 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     the combined total of \VAR{nelems} elements from each \ac{PE} in the
     active set.}
 \apiargument{IN}{source}{A symmetric data object that contains \VAR{nelems} 
-    elements of data for each \ac{PE} in the active set{}, ordered according to 
+    elements of data for each \ac{PE} in the active set, ordered according to 
     destination \ac{PE}.}
 \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}
     data object.  The stride is scaled by the element size.  A
@@ -39,7 +39,7 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
 \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.
     \VAR{nelems} must be of type size\_t for \CorCpp.  When using
     \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between
@@ -54,13 +54,13 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     \CONST{SHMEM\_ALLTOALLS\_SYNC\_SIZE}.  When using \Fortran, it must be a
     default integer value. Every element of this array must be initialized with
     the value \CONST{SHMEM\_SYNC\_VALUE} before any of the \acp{PE} in the
-    active set{} enter the routine.}
+    active set enter the routine.}
     
 \end{apiarguments}
 
 \apidescription{
     The \FUNC{shmem\_alltoalls} routines are collective routines. Each \ac{PE}
-    in the active set{} exchanges \VAR{nelems} strided data elements of size
+    in the active set exchanges \VAR{nelems} strided data elements of size
     32 bits (for \FUNC{shmem\_alltoalls32}) or 64 bits (for \FUNC{shmem\_alltoalls64})
     with all other \acp{PE} in the set. Both strides, \VAR{dst} and \VAR{sst}, must be greater
     than or equal to \CONST{1}.
@@ -71,8 +71,8 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     \ac{PE} \VAR{j}.
 
     As with all \openshmem collective routines, these routines assume
-    that only \acp{PE} in the active set{} call the routine.  If a \ac{PE} not
-    in the active set{} calls an \openshmem collective routine, undefined
+    that only \acp{PE} in the active set call the routine.  If a \ac{PE} not
+    in the active set calls an \openshmem collective routine, undefined
     behavior results.
 
     The values of arguments \VAR{dst}, \VAR{sst}, \VAR{nelems}, \VAR{PE\_start},
@@ -83,9 +83,9 @@ CALL SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, P
     Before any \ac{PE} calls to a \FUNC{shmem\_alltoalls} routine, the following
     conditions must exist (synchronization via a barrier or some other method is
     often needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
-    active set{} is not still in use from a prior call to a
+    active set is not still in use from a prior call to a
     \FUNC{shmem\_alltoalls} routine.  The \VAR{dest} data object on
-    all \acp{PE} in the active set{} is ready to accept the
+    all \acp{PE} in the active set is ready to accept the
     \FUNC{shmem\_alltoalls} data.
     
     Upon return from a \FUNC{shmem\_alltoalls} routine, the following is true for
@@ -111,15 +111,15 @@ constraints, which are as follows:
     to \openshmem\ routines that use the same \VAR{pSync} array do not require
     that \VAR{pSync} be reinitialized after the first call.
     The user must ensure that the \VAR{pSync} array is not being updated by any
-    \ac{PE} in the active set{} while any of the \acp{PE} participates in
+    \ac{PE} in the active set while any of the \acp{PE} participates in
     processing of an \openshmem\ \FUNC{shmem\_alltoalls} routine. Be careful to
     avoid these situations: If the \VAR{pSync} array is initialized at run time,
     some type of synchronization is needed to ensure that all \acp{PE} in the
-    active set{} have initialized \VAR{pSync} before any of them enter an
+    active set have initialized \VAR{pSync} before any of them enter an
     \openshmem\ routine called with the \VAR{pSync} synchronization array.  A
     \VAR{pSync} array may be reused on a subsequent \openshmem\
     \FUNC{shmem\_alltoalls} routine only if none of the \acp{PE} in the
-    active set{} are still processing a prior \openshmem\ \FUNC{shmem\_alltoalls}
+    active set are still processing a prior \openshmem\ \FUNC{shmem\_alltoalls}
     routine call that used the same \VAR{pSync} array.  In general, this can be
     ensured only by doing some type of synchronization.        
 }

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -1,6 +1,6 @@
 \apisummary{
     Performs all operations described in the \FUNC{shmem\_barrier\_all} interface
-    but with respect to a subset of \acp{PE} defined by the \activeset.
+    but with respect to a subset of \acp{PE} defined by the active set.
 }
 
 \begin{apidefinition}
@@ -17,13 +17,13 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
 
 \begin{apiarguments}
 
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset of \acp{PE}.
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of \acp{PE}.
     \VAR{PE\_start} must be of type integer.  When using \Fortran, it must be
     a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between consecutive
-    \ac{PE} numbers in the \activeset.  \VAR{logPE\_stride} must be of type integer.
+    \ac{PE} numbers in the active set.  \VAR{logPE\_stride} must be of type integer.
     When using \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_size}{The number of  \acp{PE} in the \activeset.  \VAR{PE\_size}
+\apiargument{IN}{PE\_size}{The number of  \acp{PE} in the active set.  \VAR{PE\_size}
     must be of type integer.  When using  \Fortran, it must be a default
     integer value.}
 \apiargument{IN}{pSync}{A symmetric work array. In \CorCpp, \VAR{pSync} must
@@ -31,27 +31,27 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
     \VAR{pSync} must be of type integer and size \CONST{SHMEM\_BARRIER\_SYNC\_SIZE}.
     When using \Fortran, it must  be a default  integer type.  Every element
     of this array must be initialized to \CONST{SHMEM\_SYNC\_VALUE} before any of
-    the \acp{PE} in the \activeset enter \FUNC{shmem\_barrier} the first time.}
+    the \acp{PE} in the active set enter \FUNC{shmem\_barrier} the first time.}
 
 \end{apiarguments}
 
 \apidescription{
     \FUNC{shmem\_barrier} is a collective synchronization routine over an
-    \activeset.  Control returns from \FUNC{shmem\_barrier} after all \acp{PE} in
-    the \activeset (specified by \VAR{PE\_start}, \VAR{logPE\_stride}, and
+    active set.  Control returns from \FUNC{shmem\_barrier} after all \acp{PE} in
+    the active set (specified by \VAR{PE\_start}, \VAR{logPE\_stride}, and
     \VAR{PE\_size}) have called \FUNC{shmem\_barrier}.
     
     As with all \openshmem collective routines, each of these routines assumes that
-    only \acp{PE} in the \activeset call the routine.  If a \ac{PE} not  in  the
-    \activeset calls an \openshmem collective routine, undefined behavior results.
+    only \acp{PE} in the active set call the routine.  If a \ac{PE} not  in  the
+    active set calls an \openshmem collective routine, undefined behavior results.
     
     The values of arguments \VAR{PE\_start}, \VAR{logPE\_stride}, and \VAR{PE\_size}
-    must be equal on all \acp{PE} in the \activeset.  The same work array must be
-    passed in \VAR{pSync} to all \acp{PE} in the \activeset.
+    must be equal on all \acp{PE} in the active set.  The same work array must be
+    passed in \VAR{pSync} to all \acp{PE} in the active set.
     
     \FUNC{shmem\_barrier} ensures that all previously issued stores and remote
     memory updates, including \acp{AMO} and \ac{RMA} operations, done by any of the
-    \acp{PE} in the \activeset are complete before returning.
+    \acp{PE} in the active set are complete before returning.
     
     The  same  \VAR{pSync} array may be reused on consecutive calls   to
     \FUNC{shmem\_barrier} if the same active \ac{PE} set is used.
@@ -66,7 +66,7 @@ CALL SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)
     synchronization, for example, a call to \FUNC{shmem\_barrier\_all}, before
     calling \FUNC{shmem\_barrier} for the first time.
     
-    If  the \activeset  does not change, \FUNC{shmem\_barrier} can  be called
+    If  the active set  does not change, \FUNC{shmem\_barrier} can  be called
     repeatedly with the same \VAR{pSync} array.  No additional synchronization
     beyond that implied by \FUNC{shmem\_barrier} itself is necessary in this case.
 

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -29,15 +29,15 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     32-bit halfwords.  nelems must be of type \VAR{size\_t} in \Cstd.  When
     using \Fortran, it must be a default integer value.}
 \apiargument{IN}{PE\_root}{Zero-based ordinal of the \ac{PE}, with respect to
-    the \activeset,	from which the data is copied. Must be greater than or equal to
+    the active set,	from which the data is copied. Must be greater than or equal to
     0 and less than \VAR{PE\_size}. \VAR{PE\_root} must be of type integer.  When using \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{ The log (base 2) of the stride between
-    consecutive \ac{PE} numbers in the \activeset. \VAR{log\_PE\_stride} must be of
+    consecutive \ac{PE} numbers in the active set. \VAR{log\_PE\_stride} must be of
     type integer.  When using \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_size}{ The number of \acp{PE} in the \activeset.
+\apiargument{IN}{PE\_size}{ The number of \acp{PE} in the active set.
     \VAR{PE\_size} must be of type integer.  When using \Fortran, it must be a
     default integer value.}
 \apiargument{IN}{pSync}{ A symmetric work array.  In \CorCpp, \VAR{pSync} must
@@ -45,7 +45,7 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     \VAR{pSync} must be of type integer and size \CONST{SHMEM\_BCAST\_SYNC\_SIZE}.
     Every element of this array must be initialized with the value
     \CONST{SHMEM\_SYNC\_VALUE} (in \CorCpp) or \CONST{SHMEM\_SYNC\_VALUE} (in
-    \Fortran) before any of the \acp{PE}  in  the  \activeset{} enter
+    \Fortran) before any of the \acp{PE}  in  the  active set{} enter
     \FUNC{shmem\_broadcast}.}
 
 \end{apiarguments}
@@ -58,19 +58,19 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     on the root \ac{PE}.
     
     As with all \openshmem collective routines, each of these routines assumes that
-    only \acp{PE} in the \activeset{} call the routine.  If a \ac{PE} not in the
-    \activeset{} calls an \openshmem collective routine, undefined behavior results.
+    only \acp{PE} in the active set{} call the routine.  If a \ac{PE} not in the
+    active set{} calls an \openshmem collective routine, undefined behavior results.
     
     The values of arguments \VAR{PE\_root}, \VAR{PE\_start}, \VAR{logPE\_stride},
-    and \VAR{PE\_size} must be equal on all \acp{PE} in the \activeset.  The same
+    and \VAR{PE\_size} must be equal on all \acp{PE} in the active set.  The same
     \dest{} and \source{} data objects and the same \VAR{pSync} work array must be
-    passed to all \acp{PE} in the \activeset.
+    passed to all \acp{PE} in the active set.
     
     Before any \ac{PE} calls a broadcast routine, the following
     conditions must be met: (synchronization via a barrier or some other method is often
     needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
-    \activeset{} is not still in use from a prior call to a broadcast routine.  The
-    \dest{} array on all \acp{PE} in the \activeset{} is ready to accept the
+    active set{} is not still in use from a prior call to a broadcast routine.  The
+    \dest{} array on all \acp{PE} in the active set{} is ready to accept the
     broadcast data.
     
     Upon return from a broadcast routine, the following are true for the local
@@ -101,14 +101,14 @@ constraints, which are as follows:
     require that \VAR{pSync} be reinitialized after the first call.
     
     The user must ensure that the \VAR{pSync} array is not being updated by any
-    \ac{PE} in the \activeset{} while any of the \acp{PE} participates in processing
+    \ac{PE} in the active set{} while any of the \acp{PE} participates in processing
     of an \openshmem broadcast routine. Be careful to avoid these situations: If the
     \VAR{pSync} array is initialized at run time, some type of synchronization is
-    needed to ensure that all \acp{PE} in the \activeset{} have initialized
+    needed to ensure that all \acp{PE} in the active set{} have initialized
     \VAR{pSync} before any of them enter an \openshmem routine called with the
     \VAR{pSync} synchronization array.  A \VAR{pSync} array may be reused on a
     subsequent \openshmem broadcast routine only if none of the \acp{PE} in the
-    \activeset{} are still processing a prior \openshmem broadcast routine call that
+    active set{} are still processing a prior \openshmem broadcast routine call that
     used the same \VAR{pSync} array.  In general, this can be ensured only by doing
     some type of synchronization.        
 }

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -31,7 +31,7 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
 \apiargument{IN}{PE\_root}{Zero-based ordinal of the \ac{PE}, with respect to
     the active set,	from which the data is copied. Must be greater than or equal to
     0 and less than \VAR{PE\_size}. \VAR{PE\_root} must be of type integer.  When using \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{ The log (base 2) of the stride between
@@ -45,7 +45,7 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     \VAR{pSync} must be of type integer and size \CONST{SHMEM\_BCAST\_SYNC\_SIZE}.
     Every element of this array must be initialized with the value
     \CONST{SHMEM\_SYNC\_VALUE} (in \CorCpp) or \CONST{SHMEM\_SYNC\_VALUE} (in
-    \Fortran) before any of the \acp{PE}  in  the  active set{} enter
+    \Fortran) before any of the \acp{PE}  in  the  active set enter
     \FUNC{shmem\_broadcast}.}
 
 \end{apiarguments}
@@ -58,8 +58,8 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     on the root \ac{PE}.
     
     As with all \openshmem collective routines, each of these routines assumes that
-    only \acp{PE} in the active set{} call the routine.  If a \ac{PE} not in the
-    active set{} calls an \openshmem collective routine, undefined behavior results.
+    only \acp{PE} in the active set call the routine.  If a \ac{PE} not in the
+    active set calls an \openshmem collective routine, undefined behavior results.
     
     The values of arguments \VAR{PE\_root}, \VAR{PE\_start}, \VAR{logPE\_stride},
     and \VAR{PE\_size} must be equal on all \acp{PE} in the active set.  The same
@@ -69,8 +69,8 @@ CALL SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE
     Before any \ac{PE} calls a broadcast routine, the following
     conditions must be met: (synchronization via a barrier or some other method is often
     needed to ensure this): The \VAR{pSync} array on all \acp{PE} in the
-    active set{} is not still in use from a prior call to a broadcast routine.  The
-    \dest{} array on all \acp{PE} in the active set{} is ready to accept the
+    active set is not still in use from a prior call to a broadcast routine.  The
+    \dest{} array on all \acp{PE} in the active set is ready to accept the
     broadcast data.
     
     Upon return from a broadcast routine, the following are true for the local
@@ -101,14 +101,14 @@ constraints, which are as follows:
     require that \VAR{pSync} be reinitialized after the first call.
     
     The user must ensure that the \VAR{pSync} array is not being updated by any
-    \ac{PE} in the active set{} while any of the \acp{PE} participates in processing
+    \ac{PE} in the active set while any of the \acp{PE} participates in processing
     of an \openshmem broadcast routine. Be careful to avoid these situations: If the
     \VAR{pSync} array is initialized at run time, some type of synchronization is
-    needed to ensure that all \acp{PE} in the active set{} have initialized
+    needed to ensure that all \acp{PE} in the active set have initialized
     \VAR{pSync} before any of them enter an \openshmem routine called with the
     \VAR{pSync} synchronization array.  A \VAR{pSync} array may be reused on a
     subsequent \openshmem broadcast routine only if none of the \acp{PE} in the
-    active set{} are still processing a prior \openshmem broadcast routine call that
+    active set are still processing a prior \openshmem broadcast routine call that
     used the same \VAR{pSync} array.  In general, this can be ensured only by doing
     some type of synchronization.        
 }

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -42,7 +42,7 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \apiargument{IN}{nelems}{The number of elements in the \source{} array. \VAR{nelems}
     must be of type \VAR{size\_t} for \Cstd. When using \Fortran, it must be
     a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base \CONST{2}) of the stride between
@@ -76,8 +76,8 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     vary from \ac{PE} to \ac{PE}.
     
     As with all \openshmem collective routines, each of these routines assumes that
-    only \acp{PE} in the active set{} call the routine. If a \ac{PE} not in the
-    active set{} and calls this collective routine, the behavior is undefined.
+    only \acp{PE} in the active set call the routine. If a \ac{PE} not in the
+    active set and calls this collective routine, the behavior is undefined.
     
     The values of arguments \VAR{PE\_start}, \VAR{logPE\_stride}, and \VAR{PE\_size}
     must be equal on all \acp{PE} in the active set. The same \dest{} and \source{}
@@ -100,14 +100,14 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     time it is used.
     
     The user must ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
-    in the active set{} while any of the \acp{PE} participate in processing of an
+    in the active set while any of the \acp{PE} participate in processing of an
     \openshmem collective routine.  Be careful to avoid these situations: If the
     \VAR{pSync} array is initialized at run time, some type of synchronization is
     needed to ensure that all \acp{PE} in the working set have initialized
     \VAR{pSync} before any of them  enter an \openshmem routine called with the
     \VAR{pSync} synchronization array.  A \VAR{pSync} array can be reused on a
     subsequent \openshmem collective routine only if none of the \acp{PE} in the
-    active set{}  are still processing a  prior \openshmem collective routine call
+    active set  are still processing a  prior \openshmem collective routine call
     that used the same \VAR{pSync} array.  In general, this may be ensured only by
     doing some type of synchronization.  
     

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -57,7 +57,7 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     When using \Fortran, it must be a default integer value.  Every element of
     this array must be initialized with the value \CONST{SHMEM\_SYNC\_VALUE} in
     \CorCpp{} or \CONST{SHMEM\_SYNC\_VALUE} in \Fortran before any of the \acp{PE}
-    in the \activeset{} enter \FUNC{shmem\_collect} or \FUNC{shmem\_fcollect}.}
+    in the active set enter \FUNC{shmem\_collect} or \FUNC{shmem\_fcollect}.}
 
 \end{apiarguments}
 

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -42,13 +42,13 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
 \apiargument{IN}{nelems}{The number of elements in the \source{} array. \VAR{nelems}
     must be of type \VAR{size\_t} for \Cstd. When using \Fortran, it must be
     a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base \CONST{2}) of the stride between
-    consecutive \ac{PE} numbers in the \activeset. \VAR{logPE\_stride} must be of
+    consecutive \ac{PE} numbers in the active set. \VAR{logPE\_stride} must be of
     type integer.  When using \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_size}{The number of \acp{PE} in the \activeset. \VAR{PE\_size}
+\apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set. \VAR{PE\_size}
     must be of type integer.  When using  \Fortran, it must be a default
     integer value.}
 \apiargument{IN}{pSync}{A symmetric  work array.  In \CorCpp, \VAR{pSync} must be of
@@ -69,20 +69,20 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     resultant \dest{} array contains the contribution from \ac{PE} \VAR{PE\_start}
     first, then the contribution from \ac{PE} \VAR{PE\_start} + \VAR{PE\_stride}
     second, and so on. The collected result is written to the \dest{} array for all
-    \acp{PE} in the \activeset.
+    \acp{PE} in the active set.
     
     The \FUNC{fcollect} routines require that \VAR{nelems} be the same value in all
     participating \acp{PE}, while the \FUNC{collect} routines allow \VAR{nelems} to
     vary from \ac{PE} to \ac{PE}.
     
     As with all \openshmem collective routines, each of these routines assumes that
-    only \acp{PE} in the \activeset{} call the routine. If a \ac{PE} not in the
-    \activeset{} and calls this collective routine, the behavior is undefined.
+    only \acp{PE} in the active set{} call the routine. If a \ac{PE} not in the
+    active set{} and calls this collective routine, the behavior is undefined.
     
     The values of arguments \VAR{PE\_start}, \VAR{logPE\_stride}, and \VAR{PE\_size}
-    must be equal on all \acp{PE} in the \activeset. The same \dest{} and \source{}
+    must be equal on all \acp{PE} in the active set. The same \dest{} and \source{}
     arrays and the same \VAR{pSync} work array must be passed to all \acp{PE} in the
-    \activeset.
+    active set.
     
     Upon return from a collective routine, the following are true for the local
     \ac{PE}: The \dest{} array is updated and the \source{} array may be safely reused. 
@@ -100,14 +100,14 @@ CALL SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSy
     time it is used.
     
     The user must ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
-    in the \activeset{} while any of the \acp{PE} participate in processing of an
+    in the active set{} while any of the \acp{PE} participate in processing of an
     \openshmem collective routine.  Be careful to avoid these situations: If the
     \VAR{pSync} array is initialized at run time, some type of synchronization is
     needed to ensure that all \acp{PE} in the working set have initialized
     \VAR{pSync} before any of them  enter an \openshmem routine called with the
     \VAR{pSync} synchronization array.  A \VAR{pSync} array can be reused on a
     subsequent \openshmem collective routine only if none of the \acp{PE} in the
-    \activeset{}  are still processing a  prior \openshmem collective routine call
+    active set{}  are still processing a  prior \openshmem collective routine call
     that used the same \VAR{pSync} array.  In general, this may be ensured only by
     doing some type of synchronization.  
     

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -152,13 +152,13 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \apiargument{IN}{\VAR{nreduce}}{The number of elements in the \dest{} and \source{}
     arrays.  \VAR{nreduce} must be of type integer.  When using \Fortran, it
     must be a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the \activeset{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between consecutive
-    \ac{PE} numbers in the \activeset.  \VAR{logPE\_stride} must be of type integer.
+    \ac{PE} numbers in the active set.  \VAR{logPE\_stride} must be of type integer.
     When using \Fortran, it must be a default integer value.}
-\apiargument{IN}{PE\_size}{The number of \acp{PE} in the \activeset.
+\apiargument{IN}{PE\_size}{The number of \acp{PE} in the active set.
     \VAR{PE\_size} must be of type integer.  When using \Fortran, it must be a
     default integer value.}
 \apiargument{IN}{pWrk}{A symmetric work array. The \VAR{pWrk} argument must have the
@@ -172,7 +172,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     using \Fortran, it must be a default integer value. Every element of this array
     must be initialized with the value \CONST{SHMEM\_SYNC\_VALUE} (in \CorCpp) or
     \CONST{SHMEM\_SYNC\_VALUE} (in \Fortran) before any of the \acp{PE} in the
-    \activeset{} enter the reduction routine.}
+    active set{} enter the reduction routine.}
     
 \end{apiarguments}
 
@@ -182,30 +182,30 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     across a set of values.	 
     
     The \VAR{nreduce} argument determines the number of separate reductions to
-    perform.  The \source{} array on all \acp{PE} in the \activeset{} provides one
+    perform.  The \source{} array on all \acp{PE} in the active set{} provides one
     element for each reduction.  The results of the reductions are placed in the
-    \dest{} array on all \acp{PE} in the \activeset.  The \activeset{} is defined
+    \dest{} array on all \acp{PE} in the active set.  The active set{} is defined
     by the \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet.
     
     The \source{} and \dest{} arrays may be the same array, but they may not be
     overlapping arrays.
     
     As with all \openshmem{} collective routines, each of these routines assumes
-    that only \acp{PE} in the \activeset{} call the routine.  If a \ac{PE} not in
-    the \activeset{} calls an \openshmem collective routine, undefined behavior
+    that only \acp{PE} in the active set{} call the routine.  If a \ac{PE} not in
+    the active set{} calls an \openshmem collective routine, undefined behavior
     results.
     
     The values of arguments \VAR{nreduce}, \VAR{PE\_start}, \VAR{logPE\_stride}, and
-    \VAR{PE\_size} must be equal on all \acp{PE} in the \activeset. The same \dest{}
+    \VAR{PE\_size} must be equal on all \acp{PE} in the active set. The same \dest{}
     and \source{} arrays, and the same \VAR{pWrk} and \VAR{pSync} work arrays, must
-    be passed to all \acp{PE} in the \activeset.
+    be passed to all \acp{PE} in the active set.
     %FIXME: Reword 'the following conditions must be met.'
     Before any \ac{PE} calls a reduction routine, the
     following conditions must be met (synchronization via a \OPR{barrier} or some other
     method is often needed to ensure this): The \VAR{pWrk} and \VAR{pSync} arrays
-    on all \acp{PE} in the \activeset{} are not still in use from a prior call to a
+    on all \acp{PE} in the active set{} are not still in use from a prior call to a
     collective \openshmem{} routine.  The \dest{} array on all \acp{PE} in the
-    \activeset{} is ready to accept the results of the \OPR{reduction}.
+    active set{} is ready to accept the results of the \OPR{reduction}.
     
     Upon return from a reduction routine, the following are true for the local
     \ac{PE}: The \dest{} array is updated and the \source{} array may be safely reused.  
@@ -263,14 +263,14 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     All \openshmem{} reduction routines reset the values in \VAR{pSync} before they
     return, so a particular \VAR{pSync} buffer need only be initialized the first
     time it is used. The user must ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
-    in the \activeset{} while any of the \acp{PE} participate in processing of an
+    in the active set{} while any of the \acp{PE} participate in processing of an
     \openshmem{} reduction routine. Be careful to avoid the following situations: If
     the \VAR{pSync} array is initialized at run time, some type of synchronization
     is needed to ensure that all \acp{PE} in the working set have initialized
     \VAR{pSync} before any of them enter an \openshmem routine called with the
     \VAR{pSync} synchronization array. A \VAR{pSync} or \VAR{pWrk} array can be
     reused in a subsequent reduction routine call only if none of the \acp{PE} in
-    the \activeset{} are still processing a prior reduction routine call that used
+    the active set{} are still processing a prior reduction routine call that used
     the same \VAR{pSync} or \VAR{pWrk} arrays. In general, this can be assured only
     by doing some type of synchronization. 
 }

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -152,7 +152,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
 \apiargument{IN}{\VAR{nreduce}}{The number of elements in the \dest{} and \source{}
     arrays.  \VAR{nreduce} must be of type integer.  When using \Fortran, it
     must be a default integer value.}
-\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set{} of
+\apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.  \VAR{PE\_start} must be of type integer.  When using \Fortran,
     it must be a default integer value.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between consecutive
@@ -172,7 +172,7 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     using \Fortran, it must be a default integer value. Every element of this array
     must be initialized with the value \CONST{SHMEM\_SYNC\_VALUE} (in \CorCpp) or
     \CONST{SHMEM\_SYNC\_VALUE} (in \Fortran) before any of the \acp{PE} in the
-    active set{} enter the reduction routine.}
+    active set enter the reduction routine.}
     
 \end{apiarguments}
 
@@ -182,17 +182,17 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     across a set of values.	 
     
     The \VAR{nreduce} argument determines the number of separate reductions to
-    perform.  The \source{} array on all \acp{PE} in the active set{} provides one
+    perform.  The \source{} array on all \acp{PE} in the active set provides one
     element for each reduction.  The results of the reductions are placed in the
-    \dest{} array on all \acp{PE} in the active set.  The active set{} is defined
+    \dest{} array on all \acp{PE} in the active set.  The active set is defined
     by the \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet.
     
     The \source{} and \dest{} arrays may be the same array, but they may not be
     overlapping arrays.
     
     As with all \openshmem{} collective routines, each of these routines assumes
-    that only \acp{PE} in the active set{} call the routine.  If a \ac{PE} not in
-    the active set{} calls an \openshmem collective routine, undefined behavior
+    that only \acp{PE} in the active set call the routine.  If a \ac{PE} not in
+    the active set calls an \openshmem collective routine, undefined behavior
     results.
     
     The values of arguments \VAR{nreduce}, \VAR{PE\_start}, \VAR{logPE\_stride}, and
@@ -203,9 +203,9 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     Before any \ac{PE} calls a reduction routine, the
     following conditions must be met (synchronization via a \OPR{barrier} or some other
     method is often needed to ensure this): The \VAR{pWrk} and \VAR{pSync} arrays
-    on all \acp{PE} in the active set{} are not still in use from a prior call to a
+    on all \acp{PE} in the active set are not still in use from a prior call to a
     collective \openshmem{} routine.  The \dest{} array on all \acp{PE} in the
-    active set{} is ready to accept the results of the \OPR{reduction}.
+    active set is ready to accept the results of the \OPR{reduction}.
     
     Upon return from a reduction routine, the following are true for the local
     \ac{PE}: The \dest{} array is updated and the \source{} array may be safely reused.  
@@ -263,14 +263,14 @@ CALL SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_siz
     All \openshmem{} reduction routines reset the values in \VAR{pSync} before they
     return, so a particular \VAR{pSync} buffer need only be initialized the first
     time it is used. The user must ensure that the \VAR{pSync} array is not being updated on any \ac{PE}
-    in the active set{} while any of the \acp{PE} participate in processing of an
+    in the active set while any of the \acp{PE} participate in processing of an
     \openshmem{} reduction routine. Be careful to avoid the following situations: If
     the \VAR{pSync} array is initialized at run time, some type of synchronization
     is needed to ensure that all \acp{PE} in the working set have initialized
     \VAR{pSync} before any of them enter an \openshmem routine called with the
     \VAR{pSync} synchronization array. A \VAR{pSync} or \VAR{pWrk} array can be
     reused in a subsequent reduction routine call only if none of the \acp{PE} in
-    the active set{} are still processing a prior reduction routine call that used
+    the active set are still processing a prior reduction routine call that used
     the same \VAR{pSync} or \VAR{pWrk} arrays. In general, this can be assured only
     by doing some type of synchronization. 
 }

--- a/content/synchronization_model.tex
+++ b/content/synchronization_model.tex
@@ -66,7 +66,7 @@ a local \ac{PE} need to be visible  to all other \acp{PE} before the local
 
 
 \begin{tabular}{p{0.2\textwidth} | p{0.7\textwidth}}
-Collective synchronization over an \activeset \\
+Collective synchronization over an active set \\
 \FUNC{shmem\_barrier}
 &  
 \raisebox{-\totalheight}{\includegraphics[width=0.7\textwidth]{figures/barrier}} 
@@ -76,9 +76,9 @@ Collective synchronization over an \activeset \\
 {}
 &
 {All local and remote memory operations issued by all \acp{PE} within the
-\activeset{} are guaranteed to be completed before any \ac{PE} in the
-\activeset{} returns from the call. Additionally, no \ac{PE} my return from the
-barrier until all \acp{PE} in the \activeset{} have entered the same barrier
+active set{} are guaranteed to be completed before any \ac{PE} in the
+active set{} returns from the call. Additionally, no \ac{PE} my return from the
+barrier until all \acp{PE} in the active set{} have entered the same barrier
 call. This routine should be used when synchronization as well as completion of
 all stores and remote memory updates via \openshmem is required over a sub set
 of the executing \acp{PE}.} \tabularnewline

--- a/content/synchronization_model.tex
+++ b/content/synchronization_model.tex
@@ -76,9 +76,9 @@ Collective synchronization over an active set \\
 {}
 &
 {All local and remote memory operations issued by all \acp{PE} within the
-active set{} are guaranteed to be completed before any \ac{PE} in the
-active set{} returns from the call. Additionally, no \ac{PE} my return from the
-barrier until all \acp{PE} in the active set{} have entered the same barrier
+active set are guaranteed to be completed before any \ac{PE} in the
+active set returns from the call. Additionally, no \ac{PE} my return from the
+barrier until all \acp{PE} in the active set have entered the same barrier
 call. This routine should be used when synchronization as well as completion of
 all stores and remote memory updates via \openshmem is required over a sub set
 of the executing \acp{PE}.} \tabularnewline

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -63,7 +63,7 @@
 \newcommand{\reduction}{\textit{Reduction Operations}}
 \newcommand{\alltoall}{\FUNC{SHMEM\_ALLTOALL}}
 \newcommand{\alltoalls}{\FUNC{SHMEM\_ALLTOALLS}}
-\newcommand{\activeset}{\textit{Active~set}\xspace} % why here and not others?
+\newcommand{\activeset}{\textit{Active~Set}\xspace} % why here and not others?
 \newcommand{\shmemprefix}{\textit{SHMEM\_}}
 \newcommand{\shmemprefixLC}{\textit{shmem\_}}
 \newcommand{\shmemprefixC}{\textit{\_SHMEM\_}}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -63,7 +63,6 @@
 \newcommand{\reduction}{\textit{Reduction Operations}}
 \newcommand{\alltoall}{\FUNC{SHMEM\_ALLTOALL}}
 \newcommand{\alltoalls}{\FUNC{SHMEM\_ALLTOALLS}}
-\newcommand{\activeset}{\textit{Active~Set}\xspace} % why here and not others?
 \newcommand{\shmemprefix}{\textit{SHMEM\_}}
 \newcommand{\shmemprefixLC}{\textit{shmem\_}}
 \newcommand{\shmemprefixC}{\textit{\_SHMEM\_}}


### PR DESCRIPTION
The purpose of this file is to change the formatting of the term ‘active set,’ **and one instance of the term ‘collective routines,’** so that they are consistent with the way other important terms appear in the spec. The following is an explanation justifying the edit:

When an important term is introduced in the spec it is written in italics and every first letter is capitalized. Symmetric data objects, for example, reads as _Symmetric Data Objects_ when first introduced. Every subsequent time an important term appears, all letters are written in the lower case and the term is not italicized. The term ‘active set,’ when it first appears, reads like so: _Active set_. Collective routines, when it first appears, also follows this formatting. Almost every subsequent time ‘active set’ appears in the spec the term is written this way. The a is capitalized and the term itself is written in italics. No other important terms follow this pattern.