### PR TITLE
Add `longtable` to packages

### DIFF
--- a/utils/packages.tex
+++ b/utils/packages.tex
@@ -49,5 +49,6 @@
 \usepackage{draftcopy}
 \usepackage{draftwatermark}
 \usepackage{wrapfig}
+\usepackage{longtable}
 \usepackage{caption}
 \usepackage{subcaption}


### PR DESCRIPTION
Some of these tables are getting pretty big. I need a way to break them across pages without jumping through hoops. This addition affects multiple sections, with intent for tables in: 6 Library Constants, C Undefined Behavior, and F Deprecation.