### PR TITLE
Symmetric Heap: Clarify size and alignment semantics

### DIFF
--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -31,7 +31,7 @@ void *@\FuncDecl{shmem\_calloc}@(size_t count, size_t size);
   undefined.
 
   When \VAR{count} or \VAR{size} is \CONST{0}, the \FUNC{shmem\_calloc} routine
-  is not collective and returns without performing a barrier.  Otherwise, this
+  returns without performing a barrier.  Otherwise, this
   routine calls a procedure that is semantically equivalent to
   \FUNC{shmem\_barrier\_all} on exit.
 }

--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -30,8 +30,10 @@ void *@\FuncDecl{shmem\_calloc}@(size_t count, size_t size);
   all \acp{PE} calling \FUNC{shmem\_calloc}; otherwise, the behavior is
   undefined.
 
-  The \FUNC{shmem\_calloc} routine calls a procedure that is semantically
-  equivalent to \FUNC{shmem\_barrier\_all} on exit.
+  When \VAR{count} or \VAR{size} is \CONST{0}, the \FUNC{shmem\_calloc} routine
+  is not collective and returns without performing a barrier.  Otherwise, this
+  routine calls a procedure that is semantically equivalent to
+  \FUNC{shmem\_barrier\_all} on exit.
 }
 
 \apireturnvalues{

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -57,13 +57,13 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     are provided  so that multiple \acp{PE} in a program can allocate symmetric,
     remotely accessible memory blocks.  These memory blocks can then be used with
     \openshmem communication routines.  When no action is performed, these
-    routines are not collective and return without performing a barrier.
+    routines return without performing a barrier.
     Otherwise, each of these routines includes at least one
     call to a procedure that is semantically equivalent to \FUNC{shmem\_barrier\_all}:
     \FUNC{shmem\_malloc} and \FUNC{shmem\_align} call a
     barrier on exit; \FUNC{shmem\_free} calls a barrier on entry; and
     \FUNC{shmem\_realloc} may call barriers on both entry and exit, depending on
-    whether an existing allocation is modified and whether new memory is allocated.
+    whether an existing allocation is modified and whether new memory is allocated, respectively.
     This ensures that all
     \acp{PE} participate in the memory allocation, and that the memory on other
     \acp{PE} can be used as soon as the local \ac{PE} returns.
@@ -85,7 +85,7 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     The \FUNC{shmem\_free} routine returns no value.
     
     The \FUNC{shmem\_realloc} routine returns a pointer to the allocated space
-    (which may have moved); otherwise, it returns a null pointer.
+    (which may have moved); otherwise, all PEs return a null pointer.
     
     The \FUNC{shmem\_align} routine returns an aligned pointer whose value is a
     multiple of \VAR{alignment}; otherwise, it returns a null pointer.

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -85,7 +85,7 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     The \FUNC{shmem\_free} routine returns no value.
     
     The \FUNC{shmem\_realloc} routine returns a pointer to the allocated space
-    (which may have moved); otherwise, all PEs return a null pointer.
+    (which may have moved); otherwise, all \acp{PE} return a null pointer.
     
     The \FUNC{shmem\_align} routine returns an aligned pointer whose value is a
     multiple of \VAR{alignment}; otherwise, it returns a null pointer.

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -13,8 +13,8 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
 
 \begin{apiarguments}
     \apiargument{IN}{size}{The size, in bytes, of a block to be
-        allocated from the symmetric heap. This argument is of type \VAR{size\_t}}
-    \apiargument{IN}{ptr}{Points to a block within the symmetric heap.}
+        allocated from the symmetric heap. This argument is of type \CTYPE{size\_t}}
+    \apiargument{IN}{ptr}{Pointer to a block within the symmetric heap.}
     \apiargument{IN}{alignment}{Byte alignment of the block allocated from the
         symmetric heap.}
 \end{apiarguments}
@@ -28,14 +28,19 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     The \FUNC{shmem\_malloc} routine returns a pointer to a block of at least
     \VAR{size} bytes suitably aligned for any use.  This space is allocated from the
     symmetric heap (in contrast to \FUNC{malloc}, which allocates from the private
-    heap).
+    heap).  When \VAR{size} is zero, the \FUNC{shmem\_malloc} routine performs
+    no action and returns a null pointer.
     
     The \FUNC{shmem\_align} routine allocates a block in the symmetric heap that has
-    a byte alignment specified by the \VAR{alignment} argument.
+    a byte alignment specified by the \VAR{alignment} argument.  The value of
+    \VAR{alignment} shall be a multiple of \CONST{sizeof(void *)}, that is also
+    a power of two.  Otherwise, the behavior is undefined.  When \VAR{size} is
+    zero, the \FUNC{shmem\_align} routine performs no action and returns a null
+    pointer.
     
     The \FUNC{shmem\_free} routine causes the block to which \VAR{ptr} points to be
     deallocated, that is, made available for further allocation.  If \VAR{ptr} is a
-    null pointer, no action occurs.
+    null pointer, no action is performed.
            
     The \FUNC{shmem\_realloc} routine changes the size of the block to which
     \VAR{ptr} points to the size (in bytes) specified by \VAR{size}.  The contents
@@ -50,7 +55,9 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     The \FUNC{shmem\_malloc}, \FUNC{shmem\_align}, \FUNC{shmem\_free}, and \FUNC{shmem\_realloc} routines
     are provided  so that multiple \acp{PE} in a program can allocate symmetric,
     remotely accessible memory blocks.  These memory blocks can then be used with
-    \openshmem communication routines.  Each of these routines includes at least one
+    \openshmem communication routines.  When no action is performed, these
+    routines are not collective and return without performing a barrier.
+    Otherwise, each of these routines includes at least one
     call to a procedure that is semantically equivalent to \FUNC{shmem\_barrier\_all}:
     \FUNC{shmem\_malloc} and \FUNC{shmem\_align} call a
     barrier on exit; \FUNC{shmem\_free} calls a barrier on entry; and
@@ -79,8 +86,8 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     The \FUNC{shmem\_realloc} routine returns a pointer to the allocated space
     (which may have moved); otherwise, it returns a null pointer.
     
-    The \FUNC{shmem\_align} routine returns an aligned pointer to the allocated
-    space; otherwise, it returns a null pointer.
+    The \FUNC{shmem\_align} routine returns an aligned pointer whose value is a
+    multiple of \VAR{alignment}; otherwise, it returns a null pointer.
 }
 
 \apinotes{ 

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -26,12 +26,11 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     participation by all \acp{PE}.
 
     The \FUNC{shmem\_malloc} routine returns a pointer to a block of at least
-    \VAR{size} bytes, which shall be suitably aligned so this it may be
+    \VAR{size} bytes, which shall be suitably aligned so that it may be
     assigned to a pointer to any type of object.  This space is allocated from
-    the
-    symmetric heap (in contrast to \FUNC{malloc}, which allocates from the private
-    heap).  When \VAR{size} is zero, the \FUNC{shmem\_malloc} routine performs
-    no action and returns a null pointer.
+    the symmetric heap (in contrast to \FUNC{malloc}, which allocates from the
+    private heap).  When \VAR{size} is zero, the \FUNC{shmem\_malloc} routine
+    performs no action and returns a null pointer.
     
     The \FUNC{shmem\_align} routine allocates a block in the symmetric heap that has
     a byte alignment specified by the \VAR{alignment} argument.  The value of

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -26,7 +26,9 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     participation by all \acp{PE}.
 
     The \FUNC{shmem\_malloc} routine returns a pointer to a block of at least
-    \VAR{size} bytes suitably aligned for any use.  This space is allocated from the
+    \VAR{size} bytes, which shall be suitably aligned so this it may be
+    assigned to a pointer to any type of object.  This space is allocated from
+    the
     symmetric heap (in contrast to \FUNC{malloc}, which allocates from the private
     heap).  When \VAR{size} is zero, the \FUNC{shmem\_malloc} routine performs
     no action and returns a null pointer.

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -33,7 +33,7 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     
     The \FUNC{shmem\_align} routine allocates a block in the symmetric heap that has
     a byte alignment specified by the \VAR{alignment} argument.  The value of
-    \VAR{alignment} shall be a multiple of \CONST{sizeof(void *)}, that is also
+    \VAR{alignment} shall be a multiple of \CONST{sizeof(void *)} that is also
     a power of two.  Otherwise, the behavior is undefined.  When \VAR{size} is
     zero, the \FUNC{shmem\_align} routine performs no action and returns a null
     pointer.

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -106,7 +106,12 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
     The \FUNC{shmem\_malloc}, \FUNC{shmem\_free}, and \FUNC{shmem\_realloc} routines
     differ from the private heap allocation routines in that all \acp{PE} in a
     program must call them (a barrier is used to ensure this).
-}		
+
+    When the \VAR{ptr} argument in a call to \FUNC{shmem\_realloc} corresponds
+    to a buffer allocated using \FUNC{shmem\_align}, the buffer returned by
+    \FUNC{shmem\_realloc} is not guaranteed to maintain the alignment requested
+    in the original call to \FUNC{shmem\_align}.
+}
 
 \apiimpnotes{
     The symmetric heap allocation routines always return a pointer to corresponding


### PR DESCRIPTION
In symmetric heap management routines, clarify requirements on size and alignment arguments and resulting behavior.

 * a `size` of zero results in no action and returns a null pointer
 * `alignment` must be a power-of-two multiple of `sizeof(void*)` or behavior is undefined
 * symmetric heap management routines that perform no action also perform no barriers

Closes #76 
Closes #78