### PR TITLE
Update atomic memory model text

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -558,6 +558,8 @@ The following list describes the specific changes in \openshmem[1.5]:
 \item This item is a template for changelist entries and should be deleted
     before this document is published.
     \\See Annex~\ref{sec:changelog}.
+\item Clarified the atomicity guarantees of the \openshmem memory model.
+    \\See Section~\ref{subsec:amo_guarantees}.
 \end{itemize}
 
 \section{Version 1.4}

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -55,19 +55,58 @@ memory section of each \ac{PE}.
 \subsection{Atomicity Guarantees}\label{subsec:amo_guarantees}
 
 \openshmem contains a number of routines that perform atomic operations on
-symmetric data objects (Section \ref{sec:amo}).  These routines guarantee that
-concurrent accesses to the same location by \openshmem atomic operations using
-the same datatype will be exclusive.  However, they do not guarantee
-exclusivity when concurrent accesses to the same location are performed using
-\openshmem atomic operations using different datatypes, when non-atomic
-\openshmem operations are used to access the given location, or when
-non-\openshmem operations are performed on the given location.  The result in
-such scenarios is undefined.
+symmetric data objects, which are defined in Section \ref{sec:amo}.  In
+addition, \openshmem defines routines that are atomic compatible, e.g. the
+point-to-point synchronization routines defined in
+Section~\ref{subsec:p2p_intro}.  The atomic and atomic compatible routines
+guarantee that concurrent accesses by any of these routines to the same
+location and using the same datatype (specified in Tables~\ref{stdamotypes} and
+\ref{extamotypes}) will be exclusive.  Two operations are concurrent when the
+first operation is not completed at the target PE (e.g. by a call to
+\FUNC{shmem\_quiet}) prior to the start of the second operation.
 
-For example: during the execution of an atomic remote integer increment
+\openshmem atomic operations do not guarantee exclusivity in the following
+scenarios, all of which result in undefined behavior.
+\begin{enumerate}
+    \item When concurrent accesses to the same location are performed using
+        \openshmem atomic or atomic compatible operations using different
+        datatypes.
+    \item When atomic and non-atomic \openshmem operations are used to access
+        the same location concurrently.
+    \item When \openshmem atomic operations and non-\openshmem operations (e.g.
+        load and store operations) are used to access the same location
+        concurrently.
+\end{enumerate}
+For example, during the execution of an atomic remote integer increment, i.e. \FUNC{shmem\_atomic\_inc},
 operation on a symmetric variable \VAR{X}, no other \openshmem atomic operation
 may access \VAR{X}.  After the increment, \VAR{X} will have increased its value
 by \CONST{1} on the destination \ac{PE}, at which point other atomic operations
 may then modify that \VAR{X}.  However, access to the symmetric object \VAR{X}
 with non-atomic operations, such as one-sided \OPR{put} or \OPR{get} operations,
 will invalidate the atomicity guarantees.
+
+\cexample
+    {The following \CorCpp example illustrates scenario 1.  In this example,
+    different datatypes are used to access the same location concurrently,
+    resulting in undefined behavior.  The undefined behavior can be resolved by
+    using the same datatype in all concurrent operations.  For example, the
+    32-bit value can be left-shifted and a 64-bit atomic OR operation can be
+    used.}
+    {./example_code/amo_scenario_1.c}
+
+\cexample
+    {The following \CorCpp example illustrates scenario 2.  In this example,
+    atomic increment operations are concurrent with a non-atomic reduction
+    operation, resulting in undefined behavior.  The undefined behavior can be
+    resolved by inserting a barrier operation before the reduction.  The
+    barrier ensures that all local and remote AMOs have completed before the
+    reduction operation accesses $x$.}
+    {./example_code/amo_scenario_2.c}
+
+\cexample
+    {The following \CorCpp example illustrates scenario 3.  In this example, an
+    \openshmem atomic increment operation is concurrent with a local increment
+    operation, resulting in undefined behavior.  The undefined behavior can be
+    resolved by replacing the local increment operation with an \openshmem
+    atomic increment.}
+    {./example_code/amo_scenario_3.c}

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -58,10 +58,12 @@ memory section of each \ac{PE}.
 symmetric data objects, which are defined in Section \ref{sec:amo}.  In
 addition, \openshmem defines routines that are atomic compatible, e.g. the
 point-to-point synchronization routines defined in
-Section~\ref{subsec:p2p_intro}.  The atomic and atomic compatible routines
+Section~\ref{subsec:p2p_intro}.  The atomic routines
 guarantee that concurrent accesses by any of these routines to the same
 location and using the same datatype (specified in Tables~\ref{stdamotypes} and
-\ref{extamotypes}) will be exclusive.  In contrast to atomic operations, atomic
+\ref{extamotypes}) will be exclusive.  Similarly, concurrent accesses by atomic
+and atomic compatible routines to the same location and using the same datatype
+will also be exclusive.  In contrast to atomic operations, atomic
 compatible operations may not be limited by the restrictions specified in this
 section.  Two operations issued by different \acp{PE} to the same destination
 \acp{PE} are concurrent when the first operation is not completed at the

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -61,9 +61,14 @@ point-to-point synchronization routines defined in
 Section~\ref{subsec:p2p_intro}.  The atomic and atomic compatible routines
 guarantee that concurrent accesses by any of these routines to the same
 location and using the same datatype (specified in Tables~\ref{stdamotypes} and
-\ref{extamotypes}) will be exclusive.  Two operations are concurrent when the
-first operation is not completed at the target PE (e.g. by a call to
-\FUNC{shmem\_quiet}) prior to the start of the second operation.
+\ref{extamotypes}) will be exclusive.  In contrast to atomic operations, atomic
+compatible operations may not be limited by the restrictions specified in this
+section.  Two operations issued by different \acp{PE} to the same destination
+\acp{PE} are concurrent when the first operation is not completed at the
+destination \acp{PE} prior to the start of the second operation.  Two
+operations issued by the same \acp{PE} to the same destination \acp{PE} are
+concurrent when the first operation is not ordered prior to the start of the
+second operation.
 
 \openshmem atomic operations do not guarantee exclusivity in the following
 scenarios, all of which result in undefined behavior.

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -55,29 +55,16 @@ memory section of each \ac{PE}.
 \subsection{Atomicity Guarantees}\label{subsec:amo_guarantees}
 
 \openshmem contains a number of routines that perform atomic operations on
-symmetric data objects, which are defined in Section \ref{sec:amo}.  In
-addition, \openshmem defines routines that are atomic compatible, e.g. the
-point-to-point synchronization routines defined in
-Section~\ref{subsec:p2p_intro}.  The atomic routines
+symmetric data objects, which are defined in Section \ref{sec:amo}.
+The atomic routines
 guarantee that concurrent accesses by any of these routines to the same
 location and using the same datatype (specified in Tables~\ref{stdamotypes} and
-\ref{extamotypes}) will be exclusive.  Similarly, concurrent accesses by atomic
-and atomic compatible routines to the same location and using the same datatype
-will also be exclusive.  In contrast to atomic operations, atomic
-compatible operations may not be limited by the restrictions specified in this
-section.  Two operations issued by different \acp{PE} to the same destination
-\acp{PE} are concurrent when the first operation is not completed at the
-destination \acp{PE} prior to the start of the second operation.  Two
-operations issued by the same \acp{PE} to the same destination \acp{PE} are
-concurrent when the first operation is not ordered prior to the start of the
-second operation.
-
+\ref{extamotypes}) will be exclusive.
 \openshmem atomic operations do not guarantee exclusivity in the following
 scenarios, all of which result in undefined behavior.
 \begin{enumerate}
     \item When concurrent accesses to the same location are performed using
-        \openshmem atomic or atomic compatible operations using different
-        datatypes.
+        \openshmem atomic operations using different datatypes.
     \item When atomic and non-atomic \openshmem operations are used to access
         the same location concurrently.
     \item When \openshmem atomic operations and non-\openshmem operations (e.g.

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -54,11 +54,15 @@ memory section of each \ac{PE}.
 
 \subsection{Atomicity Guarantees}\label{subsec:amo_guarantees}
 
-\openshmem contains a number of routines that operate on symmetric data
-atomically (Section \ref{sec:amo}).  These routines guarantee that accesses by
-\openshmem's atomic operations with the same datatype will be exclusive, but do not guarantee
-exclusivity in combination with other routines, either inside \openshmem or
-outside.
+\openshmem contains a number of routines that perform atomic operations on
+symmetric data objects (Section \ref{sec:amo}).  These routines guarantee that
+concurrent accesses to the same location by \openshmem atomic operations using
+the same datatype will be exclusive.  However, they do not guarantee
+exclusivity when concurrent accesses to the same location are performed using
+\openshmem atomic operations using different datatypes, when non-atomic
+\openshmem operations are used to access the given location, or when
+non-\openshmem operations are performed on the given location.  The result in
+such scenarios is undefined.
 
 For example: during the execution of an atomic remote integer increment
 operation on a symmetric variable \VAR{X}, no other \openshmem atomic operation

--- a/content/p2p_sync_intro.tex
+++ b/content/p2p_sync_intro.tex
@@ -4,8 +4,7 @@ object.
 The point-to-point synchronization routines can be used to portably ensure
 that memory access operations observe remote updates in the order enforced by
 the initiator \ac{PE} using the \FUNC{shmem\_fence} and \FUNC{shmem\_quiet}
-routines.  The point-to-point synchronization routines are atomic-compatible,
-as defined in Section~\ref{subsec:amo_guarantees}.
+routines.
 
 Where appropriate compiler support is available, \openshmem provides
 type-generic point-to-point synchronization interfaces via \Cstd[11] generic

--- a/content/p2p_sync_intro.tex
+++ b/content/p2p_sync_intro.tex
@@ -4,7 +4,8 @@ object.
 The point-to-point synchronization routines can be used to portably ensure
 that memory access operations observe remote updates in the order enforced by
 the initiator \ac{PE} using the \FUNC{shmem\_fence} and \FUNC{shmem\_quiet}
-routines.
+routines.  The point-to-point synchronization routines are atomic-compatible,
+as defined in Section~\ref{subsec:amo_guarantees}.
 
 Where appropriate compiler support is available, \openshmem provides
 type-generic point-to-point synchronization interfaces via \Cstd[11] generic

--- a/example_code/amo_scenario_1.c
+++ b/example_code/amo_scenario_1.c
@@ -1,0 +1,14 @@
+#include <shmem.h>
+
+int main(void) {
+    static uint64_t x = 0;
+
+    shmem_init();
+    if (shmem_my_pe() > 0)
+      shmem_uint32_atomic_or((uint32_t*)&x, shmem_my_pe()+1, 0);
+    else
+      shmem_uint64_atomic_or(&x, shmem_my_pe()+1, 0);
+
+    shmem_finalize();
+    return 0;
+}

--- a/example_code/amo_scenario_1.c
+++ b/example_code/amo_scenario_1.c
@@ -4,6 +4,8 @@ int main(void) {
     static uint64_t x = 0;
 
     shmem_init();
+    /* Undefined behavior: The following AMOs access the same location concurrently using
+     * different types. */
     if (shmem_my_pe() > 0)
       shmem_uint32_atomic_or((uint32_t*)&x, shmem_my_pe()+1, 0);
     else

--- a/example_code/amo_scenario_2.c
+++ b/example_code/amo_scenario_2.c
@@ -1,0 +1,18 @@
+#include <shmem.h>
+
+int main(void) {
+    static long psync[SHMEM_REDUCE_SYNC_SIZE];
+    static int pwrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
+    static int x = 0, y = 0;
+
+    for (int i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++)
+        psync[i] = SHMEM_SYNC_VALUE;
+
+    shmem_init();
+    shmem_int_atomic_inc(&x, (shmem_my_pe()+1) % shmem_n_pes());
+    shmem_int_sum_to_all(&y, &x, 1, 0, 0, shmem_n_pes(), pwrk, psync);
+
+    shmem_finalize();
+    return 0;
+}
+

--- a/example_code/amo_scenario_2.c
+++ b/example_code/amo_scenario_2.c
@@ -10,6 +10,9 @@ int main(void) {
 
     shmem_init();
     shmem_int_atomic_inc(&x, (shmem_my_pe()+1) % shmem_n_pes());
+    /* Undefined behavior: The following reduction operation performs accesses to symmetric
+     * variable 'x' that are concurrent with previously issued atomic increment operations
+     * on the same variable. */
     shmem_int_sum_to_all(&y, &x, 1, 0, 0, shmem_n_pes(), pwrk, psync);
 
     shmem_finalize();

--- a/example_code/amo_scenario_3.c
+++ b/example_code/amo_scenario_3.c
@@ -4,6 +4,8 @@ int main(void) {
     static int x = 0;
 
     shmem_init();
+    /* Undefined behavior: OpenSHMEM atomic increment operations are concurrent with the local
+     * increment of symmetric variable 'x'. */
     if (shmem_my_pe() > 0)
       shmem_int_atomic_inc(&x, 0);
     else

--- a/example_code/amo_scenario_3.c
+++ b/example_code/amo_scenario_3.c
@@ -1,0 +1,14 @@
+#include <shmem.h>
+
+int main(void) {
+    static int x = 0;
+
+    shmem_init();
+    if (shmem_my_pe() > 0)
+      shmem_int_atomic_inc(&x, 0);
+    else
+      x++;
+
+    shmem_finalize();
+    return 0;
+}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -528,6 +528,11 @@
 {
 }
 
+\newcommand{\cexample}[2]{
+    #1
+    \lstinputlisting[language={C}, tabsize=2,
+      basicstyle=\ttfamily\footnotesize,
+      morekeywords={size_t, ptrdiff_t, shmem_ctx_t}]{#2}}
 %
 % End library API description template commands
 %


### PR DESCRIPTION
Clarify the various cases that violate atomicity.  There should be no semantic changes.

Closes #172 