### PR TITLE
Mixed bag of clarifying edits

### DIFF
--- a/content/rma_intro.tex
+++ b/content/rma_intro.tex
@@ -1,12 +1,12 @@
 The \ac{RMA} routines described in this section can be used to perform
-asynchronous reads from  and writes to symmetric data objects. These operations
+reads from and writes to symmetric data objects. These operations
 are one-sided, meaning that the \ac{PE} invoking an operation provides all
 communication parameters and the targeted \ac{PE} is passive. A characteristic
 of one-sided communication is that it decouples communication from
 synchronization. One-sided communication mechanisms transfer data; however,
 they do not synchronize the sender of the data with the receiver of the data.
 
-\openshmem \ac{RMA} routines are performed on the symmetric data objects.  The
+\openshmem \ac{RMA} routines are performed on symmetric data objects.  The
 initiator \ac{PE} of a call is designated as the \emph{origin} \ac{PE} and the
 PE targeted by an operation is designated as the \emph{destination} PE.  The
 \source{} and \dest{} designators refer to the data objects that an operation

--- a/content/rma_intro.tex
+++ b/content/rma_intro.tex
@@ -1,16 +1,20 @@
-The \ac{RMA} routines described in this section are one-sided communication
-mechanisms of the \openshmem \ac{API}. While using these mechanisms, the user
-is required to provide parameters only on the calling side. A characteristic of
-one-sided communication is that it decouples communication from the
-synchronization. One-sided communication mechanisms transfer the data but do not
-synchronize the sender of the data with the receiver of the data. 
+The \ac{RMA} routines described in this section can be used to perform
+asynchronous reads from  and writes to symmetric data objects. These operations
+are one-sided, meaning that the \ac{PE} invoking an operation provides all
+communication parameters and the targeted \ac{PE} is passive. A characteristic
+of one-sided communication is that it decouples communication from
+synchronization. One-sided communication mechanisms transfer data; however,
+they do not synchronize the sender of the data with the receiver of the data.
 
-\openshmem \ac{RMA} routines are all performed on the symmetric objects.  The
-initiator \ac{PE} of the call is designated as \source{}, and the \ac{PE} in
-which memory is accessed is designated as \dest{}. In the case of the remote
-update routine, \PUT{}, the origin is the \source{} \ac{PE} and the destination
-\ac{PE} is the \dest{} PE. In the case of the remote read routine, \GET{}, the
-origin is the \dest{} \ac{PE} and the destination is the \source{} \ac{PE}.
+\openshmem \ac{RMA} routines are performed on the symmetric data objects.  The
+initiator \ac{PE} of a call is designated as the \emph{origin} \ac{PE} and the
+PE targeted by an operation is designated as the \emph{destination} PE.  The
+\source{} and \dest{} designators refer to the data objects that an operation
+reads from and writes to.  In the case of the remote update routine, \PUT{},
+the origin \ac{PE} provides the \source{} data object and the destination
+\ac{PE} provides the \dest{} data object. In the case of the remote read
+routine, \GET{}, the origin \ac{PE} provides the \dest{} data object and the
+destination \ac{PE} provides the \source{} data object.
 
 Where appropriate compiler support is available, \openshmem provides type-generic 
 one-sided communication interfaces via \Cstd[11] generic selection

--- a/content/rma_intro.tex
+++ b/content/rma_intro.tex
@@ -8,7 +8,7 @@ they do not synchronize the sender of the data with the receiver of the data.
 
 \openshmem \ac{RMA} routines are performed on symmetric data objects.  The
 initiator \ac{PE} of a call is designated as the \emph{origin} \ac{PE} and the
-PE targeted by an operation is designated as the \emph{destination} PE.  The
+\ac{PE} targeted by an operation is designated as the \emph{destination} \ac{PE}.  The
 \source{} and \dest{} designators refer to the data objects that an operation
 reads from and writes to.  In the case of the remote update routine, \PUT{},
 the origin \ac{PE} provides the \source{} data object and the destination

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -124,16 +124,11 @@ constraints, which are as follows:
 \begin{apiexamples}
 
 \apicexample
-    {In the following examples, the call to \FUNC{shmem\_broadcast64} copies \source{}
-    on \ac{PE} 4 to \dest{} on \acp{PE} 5, 6, and 7. 
+    {In the following example, the call to \FUNC{shmem\_broadcast64} copies \source{}
+    on \ac{PE} $0$ to \dest{} on \acp{PE} $1\dots npes-1$.
     
     \CorCpp{} example:}
     {./example_code/shmem_broadcast_example.c}
-    {}
-
-\apifexample
-    {\Fortran example:}
-    {./example_code/shmem_broadcast_example.f90}
     {}
 
 \end{apiexamples}

--- a/content/shmem_wait_until.tex
+++ b/content/shmem_wait_until.tex
@@ -62,7 +62,8 @@ CALL @\FuncDecl{SHMEM\_WAIT\_UNTIL}@(ivar, cmp, cmp_value)
     within another \ac{PE}.
 
     These routines can be used to implement point-to-point synchronization
-    between \acp{PE}.  A call to \FUNC{shmem\_wait} blocks until the value of
+    between \acp{PE} or between threads within the same \ac{PE}.  A call to
+    \FUNC{shmem\_wait} blocks until the value of
     \VAR{ivar} at the calling \ac{PE} is not equal to \VAR{cmp\_value}.  A call
     to \FUNC{shmem\_wait\_until} blocks until the value of \VAR{ivar} at the
     calling \ac{PE} satisfies the wait condition specified by the comparison

--- a/content/shmem_wait_until.tex
+++ b/content/shmem_wait_until.tex
@@ -55,9 +55,9 @@ CALL @\FuncDecl{SHMEM\_WAIT\_UNTIL}@(ivar, cmp, cmp_value)
     the value contained in the symmetric data object, \VAR{ivar}, at the
     calling \ac{PE} satisfies the wait condition.  In an \openshmem program
     with single-threaded \acp{PE}, the \VAR{ivar} object at the calling \ac{PE}
-    may be updated by an RMA, AMO, or store operation performed by another
+    may be updated by an \ac{RMA}, \ac{AMO}, or store operation performed by another
     \ac{PE}.  In an \openshmem program with multithreaded \acp{PE}, the
-    \VAR{ivar} object at the calling \ac{PE} may be updated by an RMA, AMO, or
+    \VAR{ivar} object at the calling \ac{PE} may be updated by an \ac{RMA}, \ac{AMO}, or
     store operation performed by a thread located within the calling \ac{PE} or
     within another \ac{PE}.
 

--- a/content/shmem_wait_until.tex
+++ b/content/shmem_wait_until.tex
@@ -51,17 +51,22 @@ CALL @\FuncDecl{SHMEM\_WAIT\_UNTIL}@(ivar, cmp, cmp_value)
 \end{apiarguments}
 
 \apidescription{ 
-    \FUNC{shmem\_wait} and \FUNC{shmem\_wait\_until} wait for \VAR{ivar} to be
-    changed by a write or an atomic operation issued by a \ac{PE}.
-    These  routines can be used for point-to-point direct synchronization.  A call
-    to \FUNC{shmem\_wait} does not return until a \ac{PE} writes a value
-    not equal to \VAR{cmp\_value} into \VAR{ivar} on the waiting \ac{PE}.  A call
-    to \FUNC{shmem\_wait\_until} does not return until a \ac{PE} changes
-    \VAR{ivar} to satisfy the condition implied by \VAR{cmp} and \VAR{cmp\_value}.
-    The \FUNC{shmem\_wait} routines return when \VAR{ivar} is no longer equal to \VAR{cmp\_value}. The
-    \FUNC{shmem\_wait\_until} routines return when the compare condition is true.
-    The compare condition is defined by the \VAR{ivar}  argument  compared with the
-    \VAR{cmp\_value} using the comparison operator \VAR{cmp}.
+    The \FUNC{shmem\_wait} and \FUNC{shmem\_wait\_until} operations block until
+    the value contained in the symmetric data object, \VAR{ivar}, at the
+    calling \ac{PE} satisfies the wait condition.  In an \openshmem program
+    with single-threaded \acp{PE}, the \VAR{ivar} object at the calling \ac{PE}
+    may be updated by an RMA, AMO, or store operation performed by another
+    \ac{PE}.  In an \openshmem program with multithreaded \acp{PE}, the
+    \VAR{ivar} object at the calling \ac{PE} may be updated by an RMA, AMO, or
+    store operation performed by a thread located within the calling \ac{PE} or
+    within another \ac{PE}.
+
+    These routines can be used to implement point-to-point synchronization
+    between \acp{PE}.  A call to \FUNC{shmem\_wait} blocks until the value of
+    \VAR{ivar} at the calling \ac{PE} is not equal to \VAR{cmp\_value}.  A call
+    to \FUNC{shmem\_wait\_until} blocks until the value of \VAR{ivar} at the
+    calling \ac{PE} satisfies the wait condition specified by the comparison
+    operator, \VAR{cmp}, and comparison value, \VAR{cmp\_value}.
 }
 
 
@@ -79,7 +84,7 @@ CALL @\FuncDecl{SHMEM\_WAIT\_UNTIL}@(ivar, cmp, cmp_value)
 }
 
 \apinotes{
-  As of \openshmem[1.4], the \FUNC{shmem\_wait} routine is deprecated,
+  As of \openshmem[1.4], the \FUNC{shmem\_wait} routine is deprecated;
   however, \FUNC{shmem\_wait} is equivalent to \FUNC{shmem\_wait\_until}
   where \VAR{cmp} is \CONST{SHMEM\_CMP\_NE}.
 }


### PR DESCRIPTION
This is a mixed bag of clarifying edits that were pointed out by a colleague reading the OpenSHMEM specification for the first time.  These edits are intended to improve the clarity/readability of the document without changing any semantics.