### PR TITLE
Add support for put with signal operation

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -510,7 +510,7 @@ Major changes in \openshmem[1.5] include \dots
 The following list describes the specific changes in \openshmem[1.5]:
 \begin{itemize}
 %
-\item Added support for blocking put with signal functions.
+\item Added support for blocking put-with-signal functions.
 \\ See Section \ref{subsec:shmem_put_signal}.
 %
 \item Specified the validity of communication contexts, added the constant

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -510,6 +510,9 @@ Major changes in \openshmem[1.5] include \dots
 The following list describes the specific changes in \openshmem[1.5]:
 \begin{itemize}
 %
+\item Added support for blocking put with signal functions.
+\\ See Section \ref{subsec:shmem_put_signal}.
+%
 \item Specified the validity of communication contexts, added the constant
   \CONST{SHMEM\_CTX\_INVALID}, and clarified the behavior of
   \FUNC{shmem\_ctx\_*} routines on invalid contexts.

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -67,6 +67,20 @@ ordering of memory store operations.
 See Section~\ref{subsec:shmem_ctx_create} for more detail about its use.
 \tabularnewline \hline
 %%
+\color{ForestGreen}
+\LibConstDecl{SHMEM\_SIGNAL\_SET} &
+\color{ForestGreen}
+An integer constant expression corresponding to the signal update set operation.
+See Section~\ref{subsec:shmem_put_signal} for more detail about its use.
+\tabularnewline \hline
+%%
+\color{ForestGreen}
+\LibConstDecl{SHMEM\_SIGNAL\_ADD} &
+\color{ForestGreen}
+An integer constant expression corresponding to the signal update add operation.
+See Section~\ref{subsec:shmem_put_signal} for more detail about its use.
+\tabularnewline \hline
+%%
 \LibConstDecl{SHMEM\_SYNC\_VALUE}
 \begin{DeprecateBlock}
   \LibConstDecl{\_SHMEM\_SYNC\_VALUE}

--- a/content/p2p_sync_intro.tex
+++ b/content/p2p_sync_intro.tex
@@ -3,8 +3,7 @@ for synchronization between two \acp{PE} based on the value of a symmetric data
 object.
 The point-to-point synchronization routines can be used to portably ensure
 that memory access operations observe remote updates in the order enforced by
-the initiator \ac{PE} using the put-with-signal(refer
-section~\ref{subsec:shmem_put_signal}, \FUNC{shmem\_fence} and
+the initiator \ac{PE} using the put-with-signal, \FUNC{shmem\_fence} and
 \FUNC{shmem\_quiet} routines.
 
 Where appropriate compiler support is available, \openshmem provides

--- a/content/p2p_sync_intro.tex
+++ b/content/p2p_sync_intro.tex
@@ -3,8 +3,9 @@ for synchronization between two \acp{PE} based on the value of a symmetric data
 object.
 The point-to-point synchronization routines can be used to portably ensure
 that memory access operations observe remote updates in the order enforced by
-the initiator \ac{PE} using the \FUNC{shmem\_fence} and \FUNC{shmem\_quiet}
-routines.
+the initiator \ac{PE} using the put-with-signal(refer
+section~\ref{subsec:shmem_put_signal}, \FUNC{shmem\_fence} and
+\FUNC{shmem\_quiet} routines.
 
 Where appropriate compiler support is available, \openshmem provides
 type-generic point-to-point synchronization interfaces via \Cstd[11] generic

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -1,0 +1,98 @@
+\color{Green}
+\apisummary{
+    The put with signal routines provide a method for copying data from a
+    contiguous local data object to a data object on a specified \ac{PE}
+    and set a remote flag to signal completion.
+}
+
+\begin{apidefinition}
+
+\begin{C11synopsis}
+void @\FuncDecl{shmem\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of the standard \ac{RMA} types specified by Table \ref{stdrmatypes}.
+
+\begin{Csynopsis}
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
+
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+\end{CsynopsisCol}
+where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
+
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_putmem\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+\end{CsynopsisCol}
+
+\begin{apiarguments}
+    \apiargument{IN}{ctx}{The context on which to perform the operation.
+      When this argument is not provided, the operation is performed on
+      \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
+    data object must be remotely accessible.}
+    \apiargument{IN}{source}{Data object containing the data to be copied.}
+    \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
+    arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When using
+    \Fortran, it must be a constant, variable, or array element of default
+    integer type.}
+    \apiargument{OUT}{sig\_addr}{Signal data object to be updated on the remote
+    \ac{PE} to be updated as the signal. This signal data object must be
+    remotely accessible and it can be in the same or differnt memory segment
+    as the \VAR{dest} data object.}
+    \apiargument{IN}{signal}{Unsigned 64-bit value used to set the remote
+    \VAR{sig\_addr} signal data object.}
+    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}. \VAR{pe} must be
+    of type integer. When using \Fortran, it must be a constant, variable,
+    or array element of default integer type.}
+\end{apiarguments}
+
+\apidescription{
+    The routines return after the data has been copied out of the \source{}
+    array on the local \ac{PE}. The delivery of \signal flag on the remote
+    \ac{PE} guarantees the delivery of data words into the data object on the
+    remote \ac{PE}. Furthermore, two successive put with signal routines or
+    a successive put followed by a put with signal routine may deliver data
+    out of order unless a call to \FUNC{shmem\_fence} is introduced between
+    the two calls and the delivery of the \signal flag on the remote \ac{PE}
+    guarantees only the delivery of its corresponding data object on the
+    remote \ac{PE}.
+ }
+
+\apidesctable{
+    The \dest{} and \source{} data objects must conform to certain typing
+    constraints, which are as follows:}
+    {Routine}{Data type of \VAR{dest} and \VAR{source}}
+    \apitablerow{shmem\_putmem}{Any data type. nelems is scaled in bytes.}
+    \apitablerow{shmem\_put8}{Any noncharacter type that
+        has a storage size equal to \CONST{8} bits.}
+    \apitablerow{shmem\_put16}{Any noncharacter type that
+        has a storage size equal to \CONST{16} bits.}
+    \apitablerow{shmem\_put32}{Any noncharacter type
+        that has a storage size equal to \CONST{32} bits.}
+    \apitablerow{shmem\_put64}{Any noncharacter type that
+        has a storage size equal to \CONST{64} bits.}
+    \apitablerow{shmem\_put128}{Any noncharacter type that has a
+        storage size equal to \CONST{128} bits.}
+
+\apireturnvalues{
+    None.
+}
+\apinotes{
+}
+
+\begin{apiexamples}
+
+\apicexample
+    { The following \FUNC{shmem\_put\_signal} example is for \Cstd[11] programs:}
+    {./example_code/shmem_put_signal_example.c}
+    {}
+\end{apiexamples}
+
+\end{apidefinition}
+\color{Black}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -78,8 +78,10 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 \begin{apiexamples}
 
 \apicexample
-    { The following example shows a simple ring-based broadcast operation using
-    \FUNC{shmem\_put\_signal}:}
+    {The following example demonstrates the usage of \FUNC{shmem\_put\_signal}.
+    It shows the implementation of a broadcast operation from \ac{PE} 0 to
+    itself and all other \acp{PE} in the job as a simple ring-based algorithm
+    using \FUNC{shmem\_put\_signal}:}
     {./example_code/shmem_put_signal_example.c}
     {}
 \end{apiexamples}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -76,11 +76,11 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     word in a sequence consisting of a put routine followed by a put-with-signal
     routine does not imply delivery of the put routine's data.
 
-    The put-with-signal routines are compatible with all point-to-point
-    synchronization interfaces. The delivery of \VAR{signal} flag on the remote
-    \ac{PE} must not cause partial updates. This requires the update on
-    \VAR{signal} flag to be an atomic operation, with atomicity guarantees
-    described in Section~\ref{subsec:amo_guarantees}.
+    The signal set by the put-with-signal routines is compatible
+    with all point-to-point synchronization interfaces. The delivery of
+    \VAR{signal} flag on the remote \ac{PE} must not cause partial updates. This
+    requires the update on \VAR{signal} flag to be an atomic operation, with
+    atomicity guarantees described in Section~\ref{subsec:amo_guarantees}.
 }
 
 \begin{apiexamples}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -36,7 +36,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
     data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}
-    \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
+    \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
     arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.}
     \apiargument{OUT}{sig\_addr}{Data object to be updated on the remote
     \ac{PE} as the signal. This signal data object must be
@@ -61,12 +61,12 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 }
 
 \apinotes{
-    The \VAR{dest} and \VAR{sig\_addr} data objects must both be remotely
-    accessible. The \VAR{sig\_addr} and \VAR{dest} could be of different kinds,
+    The \dest{} and \VAR{sig\_addr} data objects must both be remotely
+    accessible. The \VAR{sig\_addr} and \dest{} could be of different kinds,
     for example, one could be a global/static \Cstd variable and the other could
     be allocated on the symmetric heap.
 
-    The \VAR{sig\_addr} and \VAR{dest} may not be overlapping in memory.
+    The \VAR{sig\_addr} and \dest{} may not be overlapping in memory.
 
     The delivery of \VAR{signal} flag on the remote \ac{PE} indicates only the
     delivery of its corresponding \dest{} data words into the data object on

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -77,6 +77,13 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     routine does not imply delivery of the put routine's data.
 }
 
+\apiimpnotes{
+    Implementations must ensure that put-with-signal routines are compatible
+    with all point-to-point synchronization interfaces. The delivery of
+    \signal{} flag on the remote \ac{PE} must not cause partial updates. This
+    requires the update on \signal{} flag to be an atomic memory operation.
+}
+
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -1,4 +1,3 @@
-\color{Green}
 \apisummary{
     The put-with-signal routines provide a method for copying data from a
     contiguous local data object to a data object on a specified \ac{PE}
@@ -8,26 +7,26 @@
 \begin{apidefinition}
 
 \begin{C11synopsis}
-void @\FuncDecl{shmem\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{RMA} types specified by Table \ref{stdrmatypes}.
 
 \begin{Csynopsis}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
 \end{CsynopsisCol}
 where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_putmem\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_putmem\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
 \end{CsynopsisCol}
 
 \begin{apiarguments}
@@ -64,6 +63,9 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     for example, one could be a global/static \Cstd variable and the other could
     be allocated on the symmetric heap.
 
+    The restrict qualifier in \VAR{sig\_addr} expects the data object to be
+    distinct from \VAR{dest} and \VAR{source} data objects.
+
     The delivery of \signal{} flag on the remote \ac{PE} indicates only the
     delivery of its corresponding \dest{} data words into the data object on
     the remote \ac{PE}. Without a memory-ordering operation, there is no implied
@@ -83,4 +85,3 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 \end{apiexamples}
 
 \end{apidefinition}
-\color{Black}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -59,9 +59,10 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 }
 
 \apinotes{
-    The \VAR{dest} and \VAR{sig\_addr} data object must both be remotely
-    accessible, but may each be allocated from the symmetric heap or global/
-    static memory.
+    The \VAR{dest} and \VAR{sig\_addr} data objects must both be remotely
+    accessible. The \VAR{sig\_addr} and \VAR{dest} could be of different kinds,
+    for example, one could be a global/static \Cstd variable and the other could
+    be allocated on the symmetric heap.
 
     The delivery of \signal{} flag on the remote \ac{PE} indicates only the
     delivery of its corresponding \dest{} data words into the data object on

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -7,26 +7,26 @@
 \begin{apidefinition}
 
 \begin{C11synopsis}
-void @\FuncDecl{shmem\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{RMA} types specified by Table \ref{stdrmatypes}.
 
 \begin{Csynopsis}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
 \end{CsynopsisCol}
 where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_putmem\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_putmem\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
 \end{CsynopsisCol}
 
 \begin{apiarguments}
@@ -62,9 +62,6 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     accessible. The \VAR{sig\_addr} and \VAR{dest} could be of different kinds,
     for example, one could be a global/static \Cstd variable and the other could
     be allocated on the symmetric heap.
-
-    The restrict qualifier in \VAR{sig\_addr} expects the data object to be
-    distinct from \VAR{dest} and \VAR{source} data objects.
 
     The delivery of \signal{} flag on the remote \ac{PE} indicates only the
     delivery of its corresponding \dest{} data words into the data object on

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -2,7 +2,7 @@
 \apisummary{
     The put-with-signal routines provide a method for copying data from a
     contiguous local data object to a data object on a specified \ac{PE}
-    and subsequently update a remote flag to signal completion.
+    and subsequently updating a remote flag to signal completion.
 }
 
 \begin{apidefinition}
@@ -34,24 +34,24 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     \apiargument{IN}{ctx}{A context handle specifying the context on which to
     perform the operation. When this argument is not provided, the operation is
     performed on the default context.}
-    \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
-    data object must be remotely accessible.}
+    \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}.
+    This data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
     arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.}
     \apiargument{OUT}{sig\_addr}{Data object to be updated on the remote
     \ac{PE} as the signal. This signal data object must be remotely accessible.}
-    \apiargument{IN}{signal}{Unsigned 64-bit value that is used to update the
+    \apiargument{IN}{signal}{Unsigned 64-bit value that is used for updating the
     remote \VAR{sig\_addr} signal data object.}
     \apiargument{IN}{sig\_op}{Signal operator that represents the type of update
-    to be performed to the remote \VAR{sig\_addr} signal data object.}
+    to be performed on the remote \VAR{sig\_addr} signal data object.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.}
 \end{apiarguments}
 
 \apidescription{
     The put-with-signal routines provide a method for copying data from a
     contiguous local data object to a data object on a specified \ac{PE}
-    and subsequently update a remote flag to signal completion. The routines
+    and subsequently updating a remote flag to signal completion. The routines
     return after the data has been copied out of the \source{} array on the
     local \ac{PE}.
 
@@ -61,11 +61,11 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     \VAR{signal} flag on the remote \ac{PE} indicates the delivery of its
     corresponding \dest{} data words into the data object on the remote \ac{PE}.
 
-    The signal update by the put-with-signal routine is compatible with all
-    point-to-point synchronization interfaces. The delivery of \VAR{signal} flag
-    based on the remote \ac{PE} must not cause partial updates. Only concurrent
-    accesses on \VAR{sig\_addr} by different put-with-signal operations using
-    the same signal update operator is guaranteed to be exclusive.
+    An update to the \VAR{sig\_addr} signal data object through a put-with-signal
+    routine completes as if performed atomically with respect to any other
+    put-with-signal routine that updates the \VAR{sig\_addr} signal data object
+    using the same \VAR{sig\_op} signal update operator and any point-to-point
+    synchronization routine that accesses the \VAR{sig\_addr} signal data object.
 }
 
 \apireturnvalues{
@@ -78,7 +78,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     for example, one could be a global/static \Cstd variable and the other could
     be allocated on the symmetric heap.
 
-    The \VAR{sig\_addr} and \dest{} may not be overlapping in memory.
+    \VAR{sig\_addr} and \dest{} may not be overlapping in memory.
 
     The completion of signal update using the \VAR{signal} flag on the remote
     \ac{PE} indicates only the delivery of its corresponding \dest{} data words

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -59,15 +59,15 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 }
 
 \apinotes{
-    The \VAR{sig\_addr} data object can be in the same or different memory
-    segment as the \VAR{dest} data object.
+    The \VAR{sig\_addr} data object can be placed in the symmetric data segment
+    or the symmetric heap which can be same or different from the \VAR{dest}
+    data object.
 
     The delivery of \signal{} flag on the remote \ac{PE} guarantees only the
     delivery of its corresponding \dest{} data words into the data object on
     the remote \ac{PE}. For example, two successive put with signal routines
     or a successive put followed by a put with signal routine may deliver data
-    out of order unless a call to \FUNC{shmem\_fence} is introduced between
-    the two calls.
+    out of order.
 }
 
 \begin{apiexamples}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -30,9 +30,9 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 \end{CsynopsisCol}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
-      When this argument is not provided, the operation is performed on
-      \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \apiargument{IN}{ctx}{A context handle specifying the context on which to
+    perform the operation. When this argument is not provided, the operation is
+    performed on the default context.}
     \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
     data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -73,8 +73,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 \begin{apiexamples}
 
 \apicexample
-    { The following example is for the \FUNC{shmem\_put\_signal} usage for
-    ping-pong programs:}
+    { The following example shows a simple ring-based broacast operation using
+    \FUNC{shmem\_put\_signal}:}
     {./example_code/shmem_put_signal_example.c}
     {}
 \end{apiexamples}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -38,58 +38,43 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}
     \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
-    arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When using
-    \Fortran, it must be a constant, variable, or array element of default
-    integer type.}
-    \apiargument{OUT}{sig\_addr}{Signal data object to be updated on the remote
-    \ac{PE} to be updated as the signal. This signal data object must be
-    remotely accessible and it can be in the same or differnt memory segment
-    as the \VAR{dest} data object.}
+    arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.}
+    \apiargument{OUT}{sig\_addr}{Data object to be updated on the remote
+    \ac{PE} as the signal. This signal data object must be
+    remotely accessible.}
     \apiargument{IN}{signal}{Unsigned 64-bit value used to set the remote
     \VAR{sig\_addr} signal data object.}
-    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}. \VAR{pe} must be
-    of type integer. When using \Fortran, it must be a constant, variable,
-    or array element of default integer type.}
+    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.}
 \end{apiarguments}
 
 \apidescription{
     The routines return after the data has been copied out of the \source{}
-    array on the local \ac{PE}. The delivery of \signal flag on the remote
-    \ac{PE} guarantees the delivery of data words into the data object on the
-    remote \ac{PE}. Furthermore, two successive put with signal routines or
-    a successive put followed by a put with signal routine may deliver data
-    out of order unless a call to \FUNC{shmem\_fence} is introduced between
-    the two calls and the delivery of the \signal flag on the remote \ac{PE}
-    guarantees only the delivery of its corresponding data object on the
-    remote \ac{PE}.
- }
-
-\apidesctable{
-    The \dest{} and \source{} data objects must conform to certain typing
-    constraints, which are as follows:}
-    {Routine}{Data type of \VAR{dest} and \VAR{source}}
-    \apitablerow{shmem\_putmem}{Any data type. nelems is scaled in bytes.}
-    \apitablerow{shmem\_put8}{Any noncharacter type that
-        has a storage size equal to \CONST{8} bits.}
-    \apitablerow{shmem\_put16}{Any noncharacter type that
-        has a storage size equal to \CONST{16} bits.}
-    \apitablerow{shmem\_put32}{Any noncharacter type
-        that has a storage size equal to \CONST{32} bits.}
-    \apitablerow{shmem\_put64}{Any noncharacter type that
-        has a storage size equal to \CONST{64} bits.}
-    \apitablerow{shmem\_put128}{Any noncharacter type that has a
-        storage size equal to \CONST{128} bits.}
+    array on the local \ac{PE}. The delivery of \signal{} flag on the remote
+    \ac{PE} guarantees the delivery of its corresponding \dest{} data words
+    into the data object on the remote \ac{PE}.
+}
 
 \apireturnvalues{
     None.
 }
+
 \apinotes{
+    The \VAR{sig\_addr} data object can be in the same or different memory
+    segment as the \VAR{dest} data object.
+
+    The delivery of \signal{} flag on the remote \ac{PE} guarantees only the
+    delivery of its corresponding \dest{} data words into the data object on
+    the remote \ac{PE}. For example, two successive put with signal routines
+    or a successive put followed by a put with signal routine may deliver data
+    out of order unless a call to \FUNC{shmem\_fence} is introduced between
+    the two calls.
 }
 
 \begin{apiexamples}
 
 \apicexample
-    { The following \FUNC{shmem\_put\_signal} example is for \Cstd[11] programs:}
+    { The following example is for the \FUNC{shmem\_put\_signal} usage for
+    ping-pong programs:}
     {./example_code/shmem_put_signal_example.c}
     {}
 \end{apiexamples}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -75,13 +75,12 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     routine and another data transfer. For example, the delivery of the signal
     word in a sequence consisting of a put routine followed by a put-with-signal
     routine does not imply delivery of the put routine's data.
-}
 
-\apiimpnotes{
-    Implementations must ensure that put-with-signal routines are compatible
-    with all point-to-point synchronization interfaces. The delivery of
-    \signal{} flag on the remote \ac{PE} must not cause partial updates. This
-    requires the update on \signal{} flag to be an atomic memory operation.
+    The put-with-signal routines are compatible with all point-to-point
+    synchronization interfaces. The delivery of \VAR{signal} flag on the remote
+    \ac{PE} must not cause partial updates. This requires the update on
+    \VAR{signal} flag to be an atomic operation, with atomicity guarantees
+    described in Section~\ref{subsec:amo_guarantees}.
 }
 
 \begin{apiexamples}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -66,6 +66,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     for example, one could be a global/static \Cstd variable and the other could
     be allocated on the symmetric heap.
 
+    The \VAR{sig\_addr} and \VAR{dest} may not be overlapping in memory.
+
     The delivery of \signal{} flag on the remote \ac{PE} indicates only the
     delivery of its corresponding \dest{} data words into the data object on
     the remote \ac{PE}. Without a memory-ordering operation, there is no implied

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -47,10 +47,13 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 \end{apiarguments}
 
 \apidescription{
-    The routines return after the data has been copied out of the \source{}
-    array on the local \ac{PE}. The delivery of \signal{} flag on the remote
-    \ac{PE} indicates the delivery of its corresponding \dest{} data words
-    into the data object on the remote \ac{PE}.
+    The put-with-signal routines provide a method for copying data from a
+    contiguous local data object to a data object on a specified \ac{PE}
+    and subsequently setting a remote flag to signal completion. The routines
+    return after the data has been copied out of the \source{} array on the
+    local \ac{PE}. The delivery of \signal{} flag on the remote \ac{PE}
+    indicates the delivery of its corresponding \dest{} data words into the
+    data object on the remote \ac{PE}.
 }
 
 \apireturnvalues{

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -1,8 +1,8 @@
 \color{Green}
 \apisummary{
-    The put with signal routines provide a method for copying data from a
+    The put-with-signal routines provide a method for copying data from a
     contiguous local data object to a data object on a specified \ac{PE}
-    and set a remote flag to signal completion.
+    and subsequently setting a remote flag to signal completion.
 }
 
 \begin{apidefinition}
@@ -59,21 +59,23 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 }
 
 \apinotes{
-    The \VAR{sig\_addr} data object can be placed in the symmetric data segment
-    or the symmetric heap which can be same or different from the \VAR{dest}
-    data object.
+    The \VAR{dest} and \VAR{sig\_addr} data object must both be remotely
+    accessible, but may each be allocated from the symmetric heap or global/
+    static memory.
 
-    The delivery of \signal{} flag on the remote \ac{PE} guarantees only the
+    The delivery of \signal{} flag on the remote \ac{PE} indicates only the
     delivery of its corresponding \dest{} data words into the data object on
-    the remote \ac{PE}. For example, two successive put with signal routines
-    or a successive put followed by a put with signal routine may deliver data
-    out of order.
+    the remote \ac{PE}. Without a memory-ordering operation, there is no implied
+    ordering between the delivery of the signal word of a put-with-signal
+    routine and another data transfer. For example, the delivery of the signal
+    word in a sequence consisting of a put routine followed by a put-with-signal
+    routine does not imply delivery of the put routine's data.
 }
 
 \begin{apiexamples}
 
 \apicexample
-    { The following example shows a simple ring-based broacast operation using
+    { The following example shows a simple ring-based broadcast operation using
     \FUNC{shmem\_put\_signal}:}
     {./example_code/shmem_put_signal_example.c}
     {}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -40,9 +40,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
     arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.}
     \apiargument{OUT}{sig\_addr}{Data object to be updated on the remote
-    \ac{PE} as the signal. This signal data object must be
-    remotely accessible.}
-    \apiargument{IN}{signal}{Unsigned 64-bit value that is assigned to the
+    \ac{PE} as the signal. This signal data object must be remotely accessible.}
+    \apiargument{IN}{signal}{Unsigned 64-bit value that is used to update the
     remote \VAR{sig\_addr} signal data object.}
     \apiargument{IN}{sig\_op}{Signal operator that represents the type of update
     to be performed to the remote \VAR{sig\_addr} signal data object.}
@@ -61,6 +60,12 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     of signal update based on the \VAR{sig\_op} signal operator using the
     \VAR{signal} flag on the remote \ac{PE} indicates the delivery of its
     corresponding \dest{} data words into the data object on the remote \ac{PE}.
+
+    The signal update by the put-with-signal routine is compatible with all
+    point-to-point synchronization interfaces. The delivery of \VAR{signal} flag
+    based on the remote \ac{PE} must not cause partial updates. Only concurrent
+    accesses on \VAR{sig\_addr} by different put-with-signal operations using
+    the same signal update operator is guaranteed to be exclusive.
 }
 
 \apireturnvalues{
@@ -83,13 +88,6 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     completion of the signal update in a sequence consisting of a put routine
     followed by a put-with-signal routine does not imply delivery of the put
     routine's data.
-
-    The signal update by the put-with-signal routines is compatible with all
-    point-to-point synchronization interfaces. The delivery of \VAR{signal} flag
-    based on the \VAR{sig\_op} signal operator on the remote \ac{PE} must not
-    cause partial updates. Only concurrent accesses on \VAR{sig\_addr} by
-    different signal update operations using the same signal update operator is
-    guaranteed to be exclusive.
 }
 
 \begin{apiexamples}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -50,7 +50,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 \apidescription{
     The routines return after the data has been copied out of the \source{}
     array on the local \ac{PE}. The delivery of \signal{} flag on the remote
-    \ac{PE} guarantees the delivery of its corresponding \dest{} data words
+    \ac{PE} indicates the delivery of its corresponding \dest{} data words
     into the data object on the remote \ac{PE}.
 }
 

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -42,8 +42,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     \apiargument{OUT}{sig\_addr}{Data object to be updated on the remote
     \ac{PE} as the signal. This signal data object must be
     remotely accessible.}
-    \apiargument{IN}{signal}{Unsigned 64-bit value used to set the remote
-    \VAR{sig\_addr} signal data object.}
+    \apiargument{IN}{signal}{Unsigned 64-bit value that is assigned to the
+    remote \VAR{sig\_addr} signal data object.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.}
 \end{apiarguments}
 

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -1,32 +1,33 @@
+\color{ForestGreen}
 \apisummary{
     The put-with-signal routines provide a method for copying data from a
     contiguous local data object to a data object on a specified \ac{PE}
-    and subsequently setting a remote flag to signal completion.
+    and subsequently update a remote flag to signal completion.
 }
 
 \begin{apidefinition}
 
 \begin{C11synopsis}
-void @\FuncDecl{shmem\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
+void @\FuncDecl{shmem\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{RMA} types specified by Table \ref{stdrmatypes}.
 
 \begin{Csynopsis}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
+void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
+void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
 \end{CsynopsisCol}
 where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_putmem\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_putmem\_signal}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
+void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
 \end{CsynopsisCol}
 
 \begin{apiarguments}
@@ -43,17 +44,23 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     remotely accessible.}
     \apiargument{IN}{signal}{Unsigned 64-bit value that is assigned to the
     remote \VAR{sig\_addr} signal data object.}
+    \apiargument{IN}{sig\_op}{Signal operator that represents the type of update
+    to be performed to the remote \VAR{sig\_addr} signal data object.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.}
 \end{apiarguments}
 
 \apidescription{
     The put-with-signal routines provide a method for copying data from a
     contiguous local data object to a data object on a specified \ac{PE}
-    and subsequently setting a remote flag to signal completion. The routines
+    and subsequently update a remote flag to signal completion. The routines
     return after the data has been copied out of the \source{} array on the
-    local \ac{PE}. The delivery of \VAR{signal} flag on the remote \ac{PE}
-    indicates the delivery of its corresponding \dest{} data words into the
-    data object on the remote \ac{PE}.
+    local \ac{PE}.
+
+    The \VAR{sig\_op} signal operator determines the type of update to be
+    performed on the remote \VAR{sig\_addr} signal data object. The completion
+    of signal update based on the \VAR{sig\_op} signal operator using the
+    \VAR{signal} flag on the remote \ac{PE} indicates the delivery of its
+    corresponding \dest{} data words into the data object on the remote \ac{PE}.
 }
 
 \apireturnvalues{
@@ -68,19 +75,21 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 
     The \VAR{sig\_addr} and \dest{} may not be overlapping in memory.
 
-    The delivery of \VAR{signal} flag on the remote \ac{PE} indicates only the
-    delivery of its corresponding \dest{} data words into the data object on
-    the remote \ac{PE}. Without a memory-ordering operation, there is no implied
-    ordering between the delivery of the signal word of a put-with-signal
-    routine and another data transfer. For example, the delivery of the signal
-    word in a sequence consisting of a put routine followed by a put-with-signal
-    routine does not imply delivery of the put routine's data.
+    The completion of signal update using the \VAR{signal} flag on the remote
+    \ac{PE} indicates only the delivery of its corresponding \dest{} data words
+    into the data object on the remote \ac{PE}. Without a memory-ordering
+    operation, there is no implied ordering between the signal update of a
+    put-with-signal routine and another data transfer. For example, the
+    completion of the signal update in a sequence consisting of a put routine
+    followed by a put-with-signal routine does not imply delivery of the put
+    routine's data.
 
-    The signal set by the put-with-signal routines is compatible
-    with all point-to-point synchronization interfaces. The delivery of
-    \VAR{signal} flag on the remote \ac{PE} must not cause partial updates. This
-    requires the update on \VAR{signal} flag to be an atomic operation, with
-    atomicity guarantees described in Section~\ref{subsec:amo_guarantees}.
+    The signal update by the put-with-signal routines is compatible with all
+    point-to-point synchronization interfaces. The delivery of \VAR{signal} flag
+    based on the \VAR{sig\_op} signal operator on the remote \ac{PE} must not
+    cause partial updates. Only concurrent accesses on \VAR{sig\_addr} by
+    different signal update operations using the same signal update operator is
+    guaranteed to be exclusive.
 }
 
 \begin{apiexamples}
@@ -95,3 +104,4 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 \end{apiexamples}
 
 \end{apidefinition}
+\color{black}

--- a/content/shmem_put_signal.tex
+++ b/content/shmem_put_signal.tex
@@ -51,7 +51,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
     contiguous local data object to a data object on a specified \ac{PE}
     and subsequently setting a remote flag to signal completion. The routines
     return after the data has been copied out of the \source{} array on the
-    local \ac{PE}. The delivery of \signal{} flag on the remote \ac{PE}
+    local \ac{PE}. The delivery of \VAR{signal} flag on the remote \ac{PE}
     indicates the delivery of its corresponding \dest{} data words into the
     data object on the remote \ac{PE}.
 }
@@ -68,7 +68,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal}@(shmem_ctx_t ctx, void *dest, const 
 
     The \VAR{sig\_addr} and \VAR{dest} may not be overlapping in memory.
 
-    The delivery of \signal{} flag on the remote \ac{PE} indicates only the
+    The delivery of \VAR{signal} flag on the remote \ac{PE} indicates only the
     delivery of its corresponding \dest{} data words into the data object on
     the remote \ac{PE}. Without a memory-ordering operation, there is no implied
     ordering between the delivery of the signal word of a put-with-signal

--- a/example_code/shmem_put_signal_example.c
+++ b/example_code/shmem_put_signal_example.c
@@ -23,10 +23,10 @@ int main(void)
     uint64_t *data = shmem_calloc(size, sizeof(uint64_t));
 
     if (me == 0) {
-        shmem_put_signal(data, message, size, &sig_addr, 1, pe);
+        shmem_put_signal(data, message, size, &sig_addr, 1, SHMEM_SIGNAL_SET, pe);
     } else {
         shmem_wait_until(&sig_addr, SHMEM_CMP_EQ, 1);
-        shmem_put_signal(data, data, size, &sig_addr, 1, pe);
+        shmem_put_signal(data, data, size, &sig_addr, 1, SHMEM_SIGNAL_SET, pe);
     }
 
     free(message);

--- a/example_code/shmem_put_signal_example.c
+++ b/example_code/shmem_put_signal_example.c
@@ -1,48 +1,41 @@
 #include <stdio.h>
-#include <stdlib.h>
 #include <shmem.h>
+#include <stdlib.h>
 
-#define MAX_SIZE (2<<10)
-#define VAL_USED 10
-
-int
-main(int argc, char* argv[])
+int main(void)
 {
     int i, err_count  = 0;
 
     shmem_init();
 
-    size_t    size    = MAX_SIZE;
+    size_t    size    = (2<<10);
     int       me      = shmem_my_pe();
     int       n       = shmem_n_pes();
     int       pe      = (me + 1)%n;
-
     uint64_t* message = malloc(size * sizeof(uint64_t));
     uint64_t* data    = shmem_malloc(size * sizeof(uint64_t));
-    uint64_t* signals = shmem_malloc(sizeof(uint64_t));
+    static uint64_t sig_addr = 0;
 
-    signals[0] = 0;
     for (i = 0; i < size; i++) {
-        message[i] = VAL_USED;
+        message[i] = me;
         data[i]    = 0;
     }
     shmem_barrier_all();
 
     if (me != 0) {
-        shmem_long_wait_until((long *)&signals[0], SHMEM_CMP_EQ, 1);
+        shmem_uint64_wait_until(&sig_addr, SHMEM_CMP_EQ, 1);
     }
 
-    shmemx_putmem_signal(data, message, size*sizeof(uint64_t),
-            &signals[0], 1, pe);
+    shmem_putmem_signal(data, message, size*sizeof(uint64_t),
+            &sig_addr, 1, pe);
 
     if (me == 0) {
-        shmem_long_wait_until((long *)&signals[0], SHMEM_CMP_EQ, 1);
+        shmem_uint64_wait_until(&sig_addr, SHMEM_CMP_EQ, 1);
         printf("BCAST with put with signal is complete\n");
     }
 
     free(message);
     shmem_free(data);
-    shmem_free(signals);
 
     shmem_finalize();
     return 0;

--- a/example_code/shmem_put_signal_example.c
+++ b/example_code/shmem_put_signal_example.c
@@ -1,37 +1,34 @@
-#include <stdio.h>
 #include <shmem.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 int main(void)
 {
-    int i, err_count  = 0;
+    int i, err_count = 0;
 
     shmem_init();
 
-    size_t    size    = (2<<10);
-    int       me      = shmem_my_pe();
-    int       n       = shmem_n_pes();
-    int       pe      = (me + 1)%n;
-    uint64_t* message = malloc(size * sizeof(uint64_t));
-    uint64_t* data    = shmem_malloc(size * sizeof(uint64_t));
+    size_t          size     = 2048;
+    int             me       = shmem_my_pe();
+    int             n        = shmem_n_pes();
+    int             pe       = (me + 1) % n;
+    uint64_t *      message  = malloc(size * sizeof(uint64_t));
     static uint64_t sig_addr = 0;
 
     for (i = 0; i < size; i++) {
         message[i] = me;
-        data[i]    = 0;
     }
-    shmem_barrier_all();
+
+    uint64_t *data = shmem_calloc(size, sizeof(uint64_t));
 
     if (me != 0) {
-        shmem_uint64_wait_until(&sig_addr, SHMEM_CMP_EQ, 1);
+        shmem_wait_until(&sig_addr, SHMEM_CMP_EQ, 1);
+        memcpy(message, data, size * sizeof(uint64_t));
     }
 
-    shmem_putmem_signal(data, message, size*sizeof(uint64_t),
-            &sig_addr, 1, pe);
-
-    if (me == 0) {
-        shmem_uint64_wait_until(&sig_addr, SHMEM_CMP_EQ, 1);
-        printf("BCAST with put with signal is complete\n");
+    if (me != (n - 1)) {
+        shmem_put_signal(data, message, size, &sig_addr, 1, pe);
     }
 
     free(message);

--- a/example_code/shmem_put_signal_example.c
+++ b/example_code/shmem_put_signal_example.c
@@ -22,11 +22,11 @@ int main(void)
 
     uint64_t *data = shmem_calloc(size, sizeof(uint64_t));
 
-    if (me != 0) {
+    if (me == 0) {
+        shmem_put_signal(data, message, size, &sig_addr, 1, pe);
+    } else {
         shmem_wait_until(&sig_addr, SHMEM_CMP_EQ, 1);
         shmem_put_signal(data, data, size, &sig_addr, 1, pe);
-    } else {
-        shmem_put_signal(data, message, size, &sig_addr, 1, pe);
     }
 
     free(message);

--- a/example_code/shmem_put_signal_example.c
+++ b/example_code/shmem_put_signal_example.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <shmem.h>
+
+#define ITERATIONS (100)
+#define MAX_SIZE   (2<<18)
+
+int
+main(int argc, char* argv[])
+{
+    shmem_init();
+
+    int       me      = shmem_my_pe();
+    int       n       = shmem_n_pes();
+    int       r       = ITERATIONS;
+    size_t    bloat   = MAX_SIZE;
+    size_t    size;
+
+    for (size = 1; size < bloat; size*=2) {
+        uint64_t* message = malloc(size * sizeof(uint64_t));
+        uint64_t* data    = shmem_malloc(r * size * sizeof(uint64_t));
+        uint64_t* signals = shmem_malloc(r * sizeof(uint64_t));
+
+        memset(message, 0, size * sizeof(uint64_t));
+        memset(data, 0, r * size * sizeof(uint64_t));
+        memset(signals, 0, r * sizeof(uint64_t));
+        shmem_barrier_all();
+
+        message[0] = 10;
+        int i;
+        for (i = 0; i < r; i++) {
+            int j = i - (me == 0);
+            if (j >= 0) {
+                shmem_long_wait_until((long *)&signals[j],
+                                      SHMEM_CMP_EQ, 1);
+                message[0] = data[j * size] + 10;
+            }
+            int pe = (me + 1) % n;
+            shmemx_putmem_signal(&data[i * size], message,
+                                size * sizeof(uint64_t),
+                                &signals[i], 1, pe);
+        }
+        if (me == 0) {
+            shmem_long_wait_until((long *)&signals[r-1],
+                                  SHMEM_CMP_EQ, 1);
+            printf("Final message = %lu for size %zu\n",
+                    data[(r-1) * size], size);
+        }
+
+        shmem_barrier_all();
+        shmem_free(signals);
+        shmem_free(data);
+        free(message);
+        shmem_barrier_all();
+    }
+
+    shmem_finalize();
+  return 0;
+}

--- a/example_code/shmem_put_signal_example.c
+++ b/example_code/shmem_put_signal_example.c
@@ -24,10 +24,8 @@ int main(void)
 
     if (me != 0) {
         shmem_wait_until(&sig_addr, SHMEM_CMP_EQ, 1);
-        memcpy(message, data, size * sizeof(uint64_t));
-    }
-
-    if (me != (n - 1)) {
+        shmem_put_signal(data, data, size, &sig_addr, 1, pe);
+    } else {
         shmem_put_signal(data, message, size, &sig_addr, 1, pe);
     }
 

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -170,6 +170,9 @@ to test whether a given context handle references a valid context.
 \subsubsection{\textbf{SHMEM\_IPUT}}\label{subsec:shmem_iput}
 \input{content/shmem_iput.tex}
 
+\subsubsection{\textbf{SHMEM\_PUT\_SIGNAL}}\label{subsec:shmem_put_signal}
+\input{content/shmem_put_signal.tex}
+
 \subsubsection{\textbf{SHMEM\_GET}}\label{subsec:shmem_get}
 \input{content/shmem_get.tex}
 

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -517,7 +517,7 @@
     ##1
     \lstinputlisting[language={C}, tabsize=2,
       basicstyle=\ttfamily\footnotesize,
-      morekeywords={size_t, ptrdiff_t, shmem_ctx_t, _Thread_local}]{##2}
+      morekeywords={size_t, ptrdiff_t, shmem_ctx_t, _Thread_local, uint64_t}]{##2}
     ##3 }
 \newcommand{\apifexample}[3]{
     ##1

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -409,14 +409,16 @@
   \textbf{C11:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t, uint64_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t,
+      uint64_t, restrict},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
 {
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t, uint64_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t,
+      uint64_t, restrict},
   aboveskip=0pt, belowskip=0pt}}{}
 
 
@@ -425,7 +427,8 @@
   \textbf{C/C++:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t, uint64_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t,
+      uint64_t, restrict},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -59,6 +59,7 @@
 
 \newcommand{\source}{\textit{source}}
 \newcommand{\dest}{\textit{dest}}
+\newcommand{\signal}{\textit{signal}}
 \newcommand{\PUT}{\textit{Put}}
 \newcommand{\GET}{\textit{Get}}
 \newcommand{\OPR}[1]{\textit{#1}}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -59,7 +59,6 @@
 
 \newcommand{\source}{\textit{source}}
 \newcommand{\dest}{\textit{dest}}
-\newcommand{\signal}{\textit{signal}}
 \newcommand{\PUT}{\textit{Put}}
 \newcommand{\GET}{\textit{Get}}
 \newcommand{\OPR}[1]{\textit{#1}}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -409,7 +409,7 @@
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
     morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t,
-      uint64_t, restrict},
+      uint64_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
@@ -417,7 +417,7 @@
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
     morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t,
-      uint64_t, restrict},
+      uint64_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 
@@ -427,7 +427,7 @@
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
     morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t,
-      uint64_t, restrict},
+      uint64_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -409,14 +409,14 @@
   \textbf{C11:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t, uint64_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
 {
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t, uint64_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 
@@ -425,7 +425,7 @@
   \textbf{C/C++:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t, uint64_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}


### PR DESCRIPTION
This is a work-in-progress proposal to add put with signal operations into the OpenSHMEM standards.
This is related to issue #206. Proposed feature is available as part of Cray  SHMEM implementation.