### PR TITLE
Add template for OpenSHMEM 1.5 changelog

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -549,6 +549,17 @@ leverage the \openshmem Specification's \Cstd API through the
 
 \chapter{Changes to this Document}\label{sec:changelog}
 
+\section{Version 1.5}
+Major changes in \openshmem[1.5] include \dots
+
+The following list describes the specific changes in \openshmem[1.5]:
+\begin{itemize}
+%
+\item This item is a template for changelist entries and should be deleted
+    before this document is published.
+    \\See Annex~\ref{sec:changelog}.
+\end{itemize}
+
 \section{Version 1.4}
 Major changes in \openshmem[1.4] include
 multithreading support,


### PR DESCRIPTION
This PR adds the basic framing for the OpenSHMEM 1.5 changelog.  I'd like to add this as a document edit to avoid the same changes being replicated across multiple PRs.