### PR TITLE
Specify validity of contexts, SHMEM_CTX_INVALID

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -555,6 +555,11 @@ Major changes in \openshmem[1.5] include \dots
 The following list describes the specific changes in \openshmem[1.5]:
 \begin{itemize}
 %
+\item Specified the validity of communication contexts, added the constant
+  \CONST{SHMEM\_CTX\_INVALID}, and clarified the behavior of
+  \FUNC{shmem\_ctx\_*} routines on invalid contexts.
+  \\ See Section~\ref{sec:ctx}.
+%
 \item This item is a template for changelist entries and should be deleted
     before this document is published.
     \\See Annex~\ref{sec:changelog}.

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -41,9 +41,11 @@ See Section~\ref{subsec:thread_support} for more detail about its use.
 %%
 \LibConstDecl{\newtext{SHMEM\_CTX\_INVALID}} &
 \newtext{
-A value to which a context handle may be initialized, assigned, or
-equality-compared to indicate or test whether it is an invalid communication
-context.
+A value corresponding to an invalid communication context.
+This value can be used to initialize or update context handles to indicate
+that they do not reference a valid context.
+When managed in this way, applications can use an equality comparison
+to test whether a given context handle references a valid context.
 See Section~\ref{sec:ctx} for more detail about its use.
 }
 \tabularnewline \hline

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -39,6 +39,15 @@ may be multithreaded and any thread may invoke the \openshmem interfaces.
 See Section~\ref{subsec:thread_support} for more detail about its use.
 \tabularnewline \hline
 %%
+\LibConstDecl{\newtext{SHMEM\_CTX\_INVALID}} &
+\newtext{
+A value to which a context handle may be initialized, assigned, or
+equality-compared to indicate or test whether it is an invalid communication
+context.
+See Section~\ref{sec:ctx} for more detail about its use.
+}
+\tabularnewline \hline
+%%
 \LibConstDecl{SHMEM\_CTX\_SERIALIZED} &
 The context creation option which specifies that the given context
 is shareable but will not be used by multiple threads concurrently.

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -58,6 +58,10 @@ CALL @\FuncDecl{SHMEM\_INT8\_ADD}@(dest, value_i8, pe)
     The \FUNC{shmem\_atomic\_add} routine performs an atomic add operation. It adds
     \VAR{value} to \dest{} on \ac{PE} \VAR{pe} and atomically updates the \dest{}
     without returning the value.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
  }
 
 \apidesctable{

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -40,9 +40,9 @@ CALL @\FuncDecl{SHMEM\_INT8\_ADD}@(dest, value_i8, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
+    \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
         When this argument is not provided, the operation is performed on
-        \CONST{SHMEM\_CTX\_DEFAULT}.}
+        \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
     \apiargument{OUT}{dest}{The remotely accessible integer data object to be
         updated  on the remote \ac{PE}.  When using \CorCpp, the type of
         \dest{} should match that implied in the SYNOPSIS section.}

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -59,7 +59,7 @@ CALL @\FuncDecl{SHMEM\_INT8\_ADD}@(dest, value_i8, pe)
     \VAR{value} to \dest{} on \ac{PE} \VAR{pe} and atomically updates the \dest{}
     without returning the value.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
  }

--- a/content/shmem_atomic_and.tex
+++ b/content/shmem_atomic_and.tex
@@ -36,6 +36,10 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   \FUNC{shmem\_atomic\_and} atomically performs a non-fetching bitwise AND
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
+  \newtext{
+  If the context handle \VAR{ctx} specifies an invalid context,
+  the behavior is undefined.
+  }
 }
 
 \apireturnvalues{

--- a/content/shmem_atomic_and.tex
+++ b/content/shmem_atomic_and.tex
@@ -37,7 +37,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
   \newtext{
-  If the context handle \VAR{ctx} specifies an invalid context,
+  If the context handle \VAR{ctx} does not correspond to a valid context,
   the behavior is undefined.
   }
 }

--- a/content/shmem_atomic_and.tex
+++ b/content/shmem_atomic_and.tex
@@ -21,9 +21,9 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise AND operation.}

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -63,7 +63,7 @@ ires\_i8 = @\FuncDecl{SHMEM\_INT8\_CSWAP}@(dest, cond_i8, value_i8, pe)
     the specified \ac{PE} and return the prior contents of the data object in one
     atomic operation.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -62,6 +62,10 @@ ires\_i8 = @\FuncDecl{SHMEM\_INT8\_CSWAP}@(dest, cond_i8, value_i8, pe)
     The conditional swap routines conditionally update a \VAR{dest} data object on
     the specified \ac{PE} and return the prior contents of the data object in one
     atomic operation.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 \apidesctable{
     When using \Fortran, \VAR{dest}, \VAR{cond}, and \VAR{value} must be of the following type:

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -40,9 +40,9 @@ ires\_i8 = @\FuncDecl{SHMEM\_INT8\_CSWAP}@(dest, cond_i8, value_i8, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
+    \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
         When this argument is not provided, the operation is performed on
-        \CONST{SHMEM\_CTX\_DEFAULT}.}
+        \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
     \apiargument{OUT}{dest}{The remotely accessible integer data object to be
         updated on the remote \ac{PE}. }
     \apiargument{IN}{cond}{\VAR{cond} is compared to the remote \VAR{dest}

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -47,9 +47,9 @@ res\_r8 = @\FuncDecl{SHMEM\_REAL8\_FETCH}@(source, pe)
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{IN}{source}{The remotely accessible data object to be fetched from
     the remote \ac{PE}.}
   \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number from which

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -60,6 +60,10 @@ res\_r8 = @\FuncDecl{SHMEM\_REAL8\_FETCH}@(source, pe)
 \apidescription{
     \FUNC{shmem\_atomic\_fetch} performs an atomic fetch operation.
     It returns the contents of the \VAR{source} as an atomic operation.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 
 \apireturnvalues{

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -61,7 +61,7 @@ res\_r8 = @\FuncDecl{SHMEM\_REAL8\_FETCH}@(source, pe)
     \FUNC{shmem\_atomic\_fetch} performs an atomic fetch operation.
     It returns the contents of the \VAR{source} as an atomic operation.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -63,7 +63,7 @@ ires\_i8 = @\FuncDecl{SHMEM\_INT8\_FADD}@(dest, value_i8, pe)
     \VAR{value} to \VAR{dest} on \VAR{pe} and return the previous contents of
     \VAR{dest} as an atomic operation.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -41,9 +41,9 @@ ires\_i8 = @\FuncDecl{SHMEM\_INT8\_FADD}@(dest, value_i8, pe)
 
 \begin{apiarguments}
 
-\apiargument{IN}{ctx}{The context on which to perform the operation.
+\apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
 \apiargument{OUT}{dest}{The remotely accessible integer data object to be updated on
     the remote \ac{PE}. The type of \VAR{dest} should match that implied in the
     SYNOPSIS section.}

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -62,6 +62,10 @@ ires\_i8 = @\FuncDecl{SHMEM\_INT8\_FADD}@(dest, value_i8, pe)
     \VAR{dest} between the time of the fetch and the update.  These routines add
     \VAR{value} to \VAR{dest} on \VAR{pe} and return the previous contents of
     \VAR{dest} as an atomic operation.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 
 \apidesctable{

--- a/content/shmem_atomic_fetch_and.tex
+++ b/content/shmem_atomic_fetch_and.tex
@@ -36,7 +36,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
   \newtext{
-  If the context handle \VAR{ctx} specifies an invalid context,
+  If the context handle \VAR{ctx} does not correspond to a valid context,
   the behavior is undefined.
   }
 }

--- a/content/shmem_atomic_fetch_and.tex
+++ b/content/shmem_atomic_fetch_and.tex
@@ -20,9 +20,9 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise AND operation.}

--- a/content/shmem_atomic_fetch_and.tex
+++ b/content/shmem_atomic_fetch_and.tex
@@ -35,6 +35,10 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   \FUNC{shmem\_atomic\_fetch\_and} atomically performs a fetching bitwise AND
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
+  \newtext{
+  If the context handle \VAR{ctx} specifies an invalid context,
+  the behavior is undefined.
+  }
 }
 
 \apireturnvalues{

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -59,6 +59,10 @@ ires\_i8 = @\FuncDecl{SHMEM\_INT8\_FINC}@(dest, pe)
    These routines perform a fetch-and-increment operation.  The \dest{} on
    \ac{PE} \VAR{pe} is increased by one and the routine returns the previous
    contents of \dest{} as an atomic operation.
+   \newtext{
+   If the context handle \VAR{ctx} specifies an invalid context,
+   the behavior is undefined.
+   }
 }
 
 \apidesctable{

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -60,7 +60,7 @@ ires\_i8 = @\FuncDecl{SHMEM\_INT8\_FINC}@(dest, pe)
    \ac{PE} \VAR{pe} is increased by one and the routine returns the previous
    contents of \dest{} as an atomic operation.
    \newtext{
-   If the context handle \VAR{ctx} specifies an invalid context,
+   If the context handle \VAR{ctx} does not correspond to a valid context,
    the behavior is undefined.
    }
 }

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -42,9 +42,9 @@ ires\_i8 = @\FuncDecl{SHMEM\_INT8\_FINC}@(dest, pe)
 
 \begin{apiarguments}
 
-\apiargument{IN}{ctx}{The context on which to perform the operation.
+\apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
 \apiargument{OUT}{dest}{The remotely accessible integer data object to be updated
     on the remote \ac{PE}. The type of \dest{} should match that implied in the
     SYNOPSIS section.}

--- a/content/shmem_atomic_fetch_or.tex
+++ b/content/shmem_atomic_fetch_or.tex
@@ -36,7 +36,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
   \newtext{
-  If the context handle \VAR{ctx} specifies an invalid context,
+  If the context handle \VAR{ctx} does not correspond to a valid context,
   the behavior is undefined.
   }
 }

--- a/content/shmem_atomic_fetch_or.tex
+++ b/content/shmem_atomic_fetch_or.tex
@@ -35,6 +35,10 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   \FUNC{shmem\_atomic\_fetch\_or} atomically performs a fetching bitwise OR
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
+  \newtext{
+  If the context handle \VAR{ctx} specifies an invalid context,
+  the behavior is undefined.
+  }
 }
 
 \apireturnvalues{

--- a/content/shmem_atomic_fetch_or.tex
+++ b/content/shmem_atomic_fetch_or.tex
@@ -20,9 +20,9 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise OR operation.}

--- a/content/shmem_atomic_fetch_xor.tex
+++ b/content/shmem_atomic_fetch_xor.tex
@@ -37,7 +37,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
   \newtext{
-  If the context handle \VAR{ctx} specifies an invalid context,
+  If the context handle \VAR{ctx} does not correspond to a valid context,
   the behavior is undefined.
   }
 }

--- a/content/shmem_atomic_fetch_xor.tex
+++ b/content/shmem_atomic_fetch_xor.tex
@@ -21,9 +21,9 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise XOR operation.}

--- a/content/shmem_atomic_fetch_xor.tex
+++ b/content/shmem_atomic_fetch_xor.tex
@@ -36,6 +36,10 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   \FUNC{shmem\_atomic\_fetch\_xor} atomically performs a fetching bitwise XOR
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
+  \newtext{
+  If the context handle \VAR{ctx} specifies an invalid context,
+  the behavior is undefined.
+  }
 }
 
 \apireturnvalues{

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -39,9 +39,9 @@ CALL @\FuncDecl{SHMEM\_INT8\_INC}@(dest, pe)
 
 \begin{apiarguments}
 
-\apiargument{IN}{ctx}{The context on which to perform the operation.
+\apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
 \apiargument{OUT}{dest}{The remotely accessible integer data object to be updated
     on the remote \ac{PE}. The type of \dest{} should match that implied in the
     SYNOPSIS section.}

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -55,7 +55,7 @@ CALL @\FuncDecl{SHMEM\_INT8\_INC}@(dest, pe)
     These  routines perform  an atomic increment operation on the \VAR{dest} data
     object on \ac{PE}.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -54,6 +54,10 @@ CALL @\FuncDecl{SHMEM\_INT8\_INC}@(dest, pe)
 \apidescription{
     These  routines perform  an atomic increment operation on the \VAR{dest} data
     object on \ac{PE}.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 
 

--- a/content/shmem_atomic_or.tex
+++ b/content/shmem_atomic_or.tex
@@ -37,7 +37,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
   \newtext{
-  If the context handle \VAR{ctx} specifies an invalid context,
+  If the context handle \VAR{ctx} does not correspond to a valid context,
   the behavior is undefined.
   }
 }

--- a/content/shmem_atomic_or.tex
+++ b/content/shmem_atomic_or.tex
@@ -21,9 +21,9 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise OR operation.}

--- a/content/shmem_atomic_or.tex
+++ b/content/shmem_atomic_or.tex
@@ -36,6 +36,10 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   \FUNC{shmem\_atomic\_or} atomically performs a non-fetching bitwise OR
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
+  \newtext{
+  If the context handle \VAR{ctx} specifies an invalid context,
+  the behavior is undefined.
+  }
 }
 
 \apireturnvalues{

--- a/content/shmem_atomic_set.tex
+++ b/content/shmem_atomic_set.tex
@@ -62,7 +62,7 @@ CALL @\FuncDecl{SHMEM\_REAL8\_SET}@(dest, value_r8, pe)
     \FUNC{shmem\_atomic\_set} performs an atomic set operation. It writes the
     \VAR{value} into \VAR{dest} on \VAR{pe} as an atomic operation.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_atomic_set.tex
+++ b/content/shmem_atomic_set.tex
@@ -47,9 +47,9 @@ CALL @\FuncDecl{SHMEM\_REAL8\_SET}@(dest, value_r8, pe)
 
 \begin{apiarguments}
 
-\apiargument{IN}{ctx}{The context on which to perform the operation.
+\apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
 \apiargument{OUT}{dest}{The remotely accessible data object to be set on
     the remote \ac{PE}.}
 \apiargument{IN}{value}{The value to be atomically written to the remote \ac{PE}.}

--- a/content/shmem_atomic_set.tex
+++ b/content/shmem_atomic_set.tex
@@ -61,6 +61,10 @@ CALL @\FuncDecl{SHMEM\_REAL8\_SET}@(dest, value_r8, pe)
 \apidescription{
     \FUNC{shmem\_atomic\_set} performs an atomic set operation. It writes the
     \VAR{value} into \VAR{dest} on \VAR{pe} as an atomic operation.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 
 \apireturnvalues{

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -63,7 +63,7 @@ res\_r8 = @\FuncDecl{SHMEM\_REAL8\_SWAP}@(dest, value_r8, pe)
     It writes \VAR{value} into \dest{} on \ac{PE} and returns the previous
     contents of \dest{} as an atomic operation.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -62,6 +62,10 @@ res\_r8 = @\FuncDecl{SHMEM\_REAL8\_SWAP}@(dest, value_r8, pe)
     \FUNC{shmem\_atomic\_swap} performs an atomic swap operation.
     It writes \VAR{value} into \dest{} on \ac{PE} and returns the previous
     contents of \dest{} as an atomic operation.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 
 \apidesctable{

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -45,9 +45,9 @@ res\_r8 = @\FuncDecl{SHMEM\_REAL8\_SWAP}@(dest, value_r8, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{OUT}{dest}{The  remotely accessible integer data object to be
     updated on the remote \ac{PE}.	 When using \CorCpp, the type of
     \dest{} should match that  implied in the SYNOPSIS section.}

--- a/content/shmem_atomic_xor.tex
+++ b/content/shmem_atomic_xor.tex
@@ -36,6 +36,10 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   \FUNC{shmem\_atomic\_xor} atomically performs a non-fetching bitwise XOR
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
+  \newtext{
+  If the context handle \VAR{ctx} specifies an invalid context,
+  the behavior is undefined.
+  }
 }
 
 \apireturnvalues{

--- a/content/shmem_atomic_xor.tex
+++ b/content/shmem_atomic_xor.tex
@@ -37,7 +37,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   on the remotely accessible data object pointed to by \VAR{dest} at PE
   \VAR{pe} with the operand \VAR{value}.
   \newtext{
-  If the context handle \VAR{ctx} specifies an invalid context,
+  If the context handle \VAR{ctx} does not correspond to a valid context,
   the behavior is undefined.
   }
 }

--- a/content/shmem_atomic_xor.tex
+++ b/content/shmem_atomic_xor.tex
@@ -21,9 +21,9 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise XOR operation.}

--- a/content/shmem_ctx_create.tex
+++ b/content/shmem_ctx_create.tex
@@ -19,8 +19,11 @@ int @\FuncDecl{shmem\_ctx\_create}@(long options, shmem_ctx_t *ctx);
 \apidescription{
     The \FUNC{shmem\_ctx\_create} routine creates a new communication context
     and returns its handle through the \VAR{ctx} argument.  If the context was
-    created successfully, a value of zero is returned; otherwise, a nonzero
-    value is returned.  An unsuccessful context
+    created successfully, a value of zero is returned
+    \newtext{and the context handle pointed to by \VAR{ctx} specifies a valid context};
+    otherwise, a nonzero value is returned
+    \newtext{and the context handle pointed to by \VAR{ctx} is not modified}.
+    An unsuccessful context
     creation call is not treated as an error and the \openshmem library remains
     in a correct state.  The creation call can be reattempted with different
     options or after additional resources become available.

--- a/content/shmem_ctx_destroy.tex
+++ b/content/shmem_ctx_destroy.tex
@@ -18,6 +18,10 @@ void @\FuncDecl{shmem\_ctx\_destroy}@(shmem_ctx_t ctx);
     the context is not used after it has been destroyed, for example when the
     destroyed context is used by multiple threads.  This function
     performs an implicit quiet operation on the given context before it is freed.
+    \newtext{
+    If \VAR{ctx} has the value \CONST{SHMEM\_CTX\_INVALID}, no operation is
+    performed.
+    }
 }
 
 \apireturnvalues{
@@ -57,6 +61,16 @@ void @\FuncDecl{shmem\_ctx\_destroy}@(shmem_ctx_t ctx);
     local reduction of segment \VAR{p-1}.}
     {./example_code/shmem_ctx_pipelined_reduce.c}
     {}
+
+    \newtext{
+    \apicexample
+    {The following example demonstrates the use of \CONST{SHMEM\_CTX\_INVALID}
+    in a \Cstd[11] program that uses thread-local storage to provide each
+    thread an implicit context handle via a ``library'' put routine without
+    explicit management of the context handle from ``user'' code.}
+    {./example_code/shmem_ctx_invalid.c}
+    {}
+    }
 
 \end{apiexamples}
 

--- a/content/shmem_fence.tex
+++ b/content/shmem_fence.tex
@@ -15,9 +15,9 @@ CALL @\FuncDecl{SHMEM\_FENCE}@
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
+    \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
         When this argument is not provided, the operation is performed on
-        \CONST{SHMEM\_CTX\_DEFAULT}.}
+        \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
 \end{apiarguments}
 
 \apidescription{

--- a/content/shmem_fence.tex
+++ b/content/shmem_fence.tex
@@ -29,6 +29,10 @@ CALL @\FuncDecl{SHMEM\_FENCE}@
     subsequent \PUT{}, \ac{AMO}, memory store, and nonblocking \PUT{} routines to symmetric data
     objects to the same \ac{PE}. \FUNC{shmem\_fence} guarantees order of delivery,
     not completion. It does not guarantee order of delivery of nonblocking \GET{} routines.
+    \newtext{
+    If \VAR{ctx} has the value \CONST{SHMEM\_CTX\_INVALID}, no operation is
+    performed.
+    }
 }
 
 \apireturnvalues{

--- a/content/shmem_g.tex
+++ b/content/shmem_g.tex
@@ -27,6 +27,10 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
 \apidescription{
   These routines provide a very low latency get capability for single elements
   of most basic types. 
+  \newtext{
+  If the context handle \VAR{ctx} specifies an invalid context,
+  the behavior is undefined.
+  }
 }
 
 \apireturnvalues{

--- a/content/shmem_g.tex
+++ b/content/shmem_g.tex
@@ -28,7 +28,7 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
   These routines provide a very low latency get capability for single elements
   of most basic types. 
   \newtext{
-  If the context handle \VAR{ctx} specifies an invalid context,
+  If the context handle \VAR{ctx} does not correspond to a valid context,
   the behavior is undefined.
   }
 }

--- a/content/shmem_g.tex
+++ b/content/shmem_g.tex
@@ -17,9 +17,9 @@ TYPE @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_g}@(shmem_ctx_t ctx, const TYP
 where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 
 \begin{apiarguments}
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{IN}{source}{The remotely accessible array element or scalar data object.}
   \apiargument{IN}{pe}{The number of the remote \ac{PE} on which \VAR{source} resides.}
 \end{apiarguments}

--- a/content/shmem_get.tex
+++ b/content/shmem_get.tex
@@ -65,6 +65,10 @@ CALL @\FuncDecl{SHMEM\_REAL\_GET}@(dest, source, nelems, pe)
    object from a different \ac{PE} to a contiguous data object on the local
    \ac{PE}.  The routines return after the data has been delivered to the
    \dest{} array on the local \ac{PE}. 
+   \newtext{
+   If the context handle \VAR{ctx} specifies an invalid context,
+   the behavior is undefined.
+   }
 }
 
 \apidesctable{

--- a/content/shmem_get.tex
+++ b/content/shmem_get.tex
@@ -66,7 +66,7 @@ CALL @\FuncDecl{SHMEM\_REAL\_GET}@(dest, source, nelems, pe)
    \ac{PE}.  The routines return after the data has been delivered to the
    \dest{} array on the local \ac{PE}. 
    \newtext{
-   If the context handle \VAR{ctx} specifies an invalid context,
+   If the context handle \VAR{ctx} does not correspond to a valid context,
    the behavior is undefined.
    }
 }

--- a/content/shmem_get.tex
+++ b/content/shmem_get.tex
@@ -44,9 +44,9 @@ CALL @\FuncDecl{SHMEM\_REAL\_GET}@(dest, source, nelems, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
+    \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
         When this argument is not provided, the operation is performed on
-        \CONST{SHMEM\_CTX\_DEFAULT}.}
+        \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
     \apiargument{OUT}{dest}{Local data object to be updated.}
     \apiargument{IN}{source}{Data object on the \ac{PE} identified by \VAR{pe}
         that contains the data to be copied.  This data object must be remotely

--- a/content/shmem_get_nbi.tex
+++ b/content/shmem_get_nbi.tex
@@ -68,6 +68,10 @@ CALL @\FuncDecl{SHMEM\_REAL\_GET\_NBI}@(dest, source, nelems, pe)
     complete after a subsequent call to \FUNC{shmem\_quiet}. 
     At the completion of \FUNC{shmem\_quiet}, the 
     data has been delivered to the \dest{} array on the local \ac{PE}. 
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 
 \apidesctable{

--- a/content/shmem_get_nbi.tex
+++ b/content/shmem_get_nbi.tex
@@ -69,7 +69,7 @@ CALL @\FuncDecl{SHMEM\_REAL\_GET\_NBI}@(dest, source, nelems, pe)
     At the completion of \FUNC{shmem\_quiet}, the 
     data has been delivered to the \dest{} array on the local \ac{PE}. 
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_get_nbi.tex
+++ b/content/shmem_get_nbi.tex
@@ -45,9 +45,9 @@ CALL @\FuncDecl{SHMEM\_REAL\_GET\_NBI}@(dest, source, nelems, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
+    \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
         When this argument is not provided, the operation is performed on
-        \CONST{SHMEM\_CTX\_DEFAULT}.}
+        \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
     \apiargument{OUT}{dest}{Local data object to be updated.}
     \apiargument{IN}{source}{Data object on the \ac{PE} identified by \VAR{pe}
         that contains the data to be copied.  This data object must be remotely

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -67,7 +67,7 @@ CALL @\FuncDecl{SHMEM\_REAL\_IGET}@(dest, source, dst, sst, nelems, pe)
     local array.  The routines return when the data has been copied into the local
     \VAR{dest} array.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -37,9 +37,9 @@ CALL @\FuncDecl{SHMEM\_REAL\_IGET}@(dest, source, dst, sst, nelems, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
+    \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
         When this argument is not provided, the operation is performed on
-        \CONST{SHMEM\_CTX\_DEFAULT}.}
+        \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
     \apiargument{OUT}{dest}{Array to be updated on the local \ac{PE}. }
     \apiargument{IN}{source}{Array containing the data to be copied on the remote \ac{PE}.}
     \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -66,6 +66,10 @@ CALL @\FuncDecl{SHMEM\_REAL\_IGET}@(dest, source, dst, sst, nelems, pe)
     a symmetric array from a specified remote \ac{PE} to strided locations on a
     local array.  The routines return when the data has been copied into the local
     \VAR{dest} array.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 
 \apidesctable{

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -37,9 +37,9 @@ CALL @\FuncDecl{SHMEM\_REAL\_IPUT}@(dest, source, dst, sst, nelems, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
+    \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
         When this argument is not provided, the operation is performed on
-        \CONST{SHMEM\_CTX\_DEFAULT}.}
+        \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
     \apiargument{OUT}{dest}{Array to be updated on the remote \ac{PE}. This data
         object  must be remotely accessible.}
     \apiargument{IN}{source}{Array containing the data to be copied.}

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -71,7 +71,7 @@ CALL @\FuncDecl{SHMEM\_REAL\_IPUT}@(dest, source, dst, sst, nelems, pe)
     been copied out of the \VAR{source} array on the local \ac{PE} but not
     necessarily before the data has been delivered to the remote data object.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -70,6 +70,10 @@ CALL @\FuncDecl{SHMEM\_REAL\_IPUT}@(dest, source, dst, sst, nelems, pe)
     greater than or equal to \CONST{1}. The routines return when the data has
     been copied out of the \VAR{source} array on the local \ac{PE} but not
     necessarily before the data has been delivered to the remote data object.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 
 \apidesctable{

--- a/content/shmem_p.tex
+++ b/content/shmem_p.tex
@@ -17,9 +17,9 @@ void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_p}@(shmem_ctx_t ctx, TYPE *des
 where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 
 \begin{apiarguments}
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{OUT}{dest}{The remotely accessible array element or scalar data object
     which will receive the data on the remote \ac{PE}.}
   \apiargument{IN}{value}{The value to be transferred to \VAR{dest} on the

--- a/content/shmem_p.tex
+++ b/content/shmem_p.tex
@@ -36,7 +36,7 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
     \FUNC{shmem\_quiet} to force completion of all remote \PUT{} transfers.
 
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
 }

--- a/content/shmem_p.tex
+++ b/content/shmem_p.tex
@@ -34,6 +34,11 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
     As with \FUNC{shmem\_put}, these routines start the remote transfer and may
     return before the data is delivered to the remote \ac{PE}.  Use
     \FUNC{shmem\_quiet} to force completion of all remote \PUT{} transfers.
+
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
 }
 
 \apireturnvalues{

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -44,9 +44,9 @@ CALL @\FuncDecl{SHMEM\_REAL\_PUT}@(dest, source, nelems, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
+    \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
       When this argument is not provided, the operation is performed on
-      \CONST{SHMEM\_CTX\_DEFAULT}.}
+      \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
     \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
     data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -66,7 +66,7 @@ CALL @\FuncDecl{SHMEM\_REAL\_PUT}@(dest, source, nelems, pe)
     routines may deliver data out of order unless a call to \FUNC{shmem\_fence} is
     introduced between the two calls.
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
  }

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -64,7 +64,11 @@ CALL @\FuncDecl{SHMEM\_REAL\_PUT}@(dest, source, nelems, pe)
     on the local \ac{PE}.  The delivery of data words into the data object on the
     destination \ac{PE} may occur in any order.  Furthermore, two successive put
     routines may deliver data out of order unless a call to \FUNC{shmem\_fence} is
-    introduced between the two calls.   
+    introduced between the two calls.
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
  }
 
 \apidesctable{

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -69,6 +69,10 @@ CALL @\FuncDecl{SHMEM\_REAL\_PUT\_NBI}@(dest, source, nelems, pe)
     Furthermore, two successive put
     routines may deliver data out of order unless a call to \FUNC{shmem\_fence} is
     introduced between the two calls.   
+    \newtext{
+    If the context handle \VAR{ctx} specifies an invalid context,
+    the behavior is undefined.
+    }
  }
 
 \apidesctable{

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -44,9 +44,9 @@ CALL @\FuncDecl{SHMEM\_REAL\_PUT\_NBI}@(dest, source, nelems, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-  \apiargument{IN}{ctx}{The context on which to perform the operation.
+  \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
     When this argument is not provided, the operation is performed on
-    \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
   \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
     data object must be remotely accessible.}
   \apiargument{IN}{source}{Data object containing the data to be copied.}

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -70,7 +70,7 @@ CALL @\FuncDecl{SHMEM\_REAL\_PUT\_NBI}@(dest, source, nelems, pe)
     routines may deliver data out of order unless a call to \FUNC{shmem\_fence} is
     introduced between the two calls.   
     \newtext{
-    If the context handle \VAR{ctx} specifies an invalid context,
+    If the context handle \VAR{ctx} does not correspond to a valid context,
     the behavior is undefined.
     }
  }

--- a/content/shmem_quiet.tex
+++ b/content/shmem_quiet.tex
@@ -16,9 +16,9 @@ CALL @\FuncDecl{SHMEM\_QUIET}@
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
+    \apiargument{IN}{ctx}{\oldtext{The context on which to perform the operation.} \newtext{A context handle specifying the context on which to perform the operation.}
         When this argument is not provided, the operation is performed on
-        \CONST{SHMEM\_CTX\_DEFAULT}.}
+        \oldtext{\CONST{SHMEM\_CTX\_DEFAULT}} \newtext{the default context}.}
 \end{apiarguments}
 
 \apidescription{ 

--- a/content/shmem_quiet.tex
+++ b/content/shmem_quiet.tex
@@ -28,6 +28,10 @@ CALL @\FuncDecl{SHMEM\_QUIET}@
     memory store, and nonblocking \PUT{} and \GET{} routines to
     symmetric data objects are guaranteed to be completed and visible to all
     \acp{PE} when \FUNC{shmem\_quiet} returns. 
+    \newtext{
+    If \VAR{ctx} has the value \CONST{SHMEM\_CTX\_INVALID}, no operation is
+    performed.
+    }
 }
 
 

--- a/example_code/shmem_ctx_invalid.c
+++ b/example_code/shmem_ctx_invalid.c
@@ -1,0 +1,67 @@
+#include <stddef.h>
+#include <shmem.h>
+#include <omp.h>
+
+_Thread_local shmem_ctx_t thread_ctx = SHMEM_CTX_INVALID;
+
+void lib_thread_register(void) {
+  if (thread_ctx == SHMEM_CTX_INVALID)
+    if (shmem_ctx_create(SHMEM_CTX_PRIVATE, &thread_ctx) &&
+        shmem_ctx_create(                0, &thread_ctx))
+      thread_ctx = SHMEM_CTX_DEFAULT;
+}
+
+void lib_thread_unregister(void) {
+  if (thread_ctx != SHMEM_CTX_DEFAULT) {
+    shmem_ctx_destroy(thread_ctx);
+    thread_ctx = SHMEM_CTX_INVALID;
+  }
+}
+
+void lib_thread_putmem(void *dst, const void *src, size_t nbytes, int pe) {
+  shmem_ctx_putmem(thread_ctx, dst, src, nbytes, pe);
+}
+
+int main() {
+  int provided;
+  if (shmem_init_thread(SHMEM_THREAD_MULTIPLE, &provided))
+    return 1;
+  if (provided != SHMEM_THREAD_MULTIPLE)
+    shmem_global_exit(2);
+
+  const int my_pe = shmem_my_pe();
+  const int n_pes = shmem_n_pes();
+  const int count = 1 << 15;
+
+  int *src_bufs[n_pes];
+  int *dst_bufs[n_pes];
+  for (int i = 0; i < n_pes; i++) {
+    src_bufs[i] = shmem_malloc(count * sizeof(*src_bufs[i]));
+    if (src_bufs[i] == NULL)
+      shmem_global_exit(3);
+    dst_bufs[i] = shmem_malloc(count * sizeof(*dst_bufs[i]));
+    if (dst_bufs[i] == NULL)
+      shmem_global_exit(4);
+  }
+
+#pragma omp parallel
+  {
+    int my_thrd = omp_get_thread_num();
+#pragma omp for
+    for (int i = 0; i < n_pes; i++)
+      for (int j = 0; j < count; j++)
+        src_bufs[i][j] = (my_pe << 10) + my_thrd;
+
+    lib_thread_register();
+
+#pragma omp for
+    for (int i = 0; i < n_pes; i++)
+      lib_thread_putmem(dst_bufs[my_pe], src_bufs[i],
+                         count * sizeof(*src_bufs[i]), i);
+
+    lib_thread_unregister();
+  }
+
+  shmem_finalize();
+  return 0;
+}

--- a/example_code/shmem_ctx_invalid.c
+++ b/example_code/shmem_ctx_invalid.c
@@ -36,10 +36,10 @@ int main() {
   int *src_bufs[n_pes];
   int *dst_bufs[n_pes];
   for (int i = 0; i < n_pes; i++) {
-    src_bufs[i] = shmem_malloc(count * sizeof(*src_bufs[i]));
+    src_bufs[i] = shmem_calloc(count, sizeof(*src_bufs[i]));
     if (src_bufs[i] == NULL)
       shmem_global_exit(3);
-    dst_bufs[i] = shmem_malloc(count * sizeof(*dst_bufs[i]));
+    dst_bufs[i] = shmem_calloc(count, sizeof(*dst_bufs[i]));
     if (dst_bufs[i] == NULL)
       shmem_global_exit(4);
   }

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -143,8 +143,8 @@ the value \CONST{SHMEM\_CTX\_INVALID} to indicate or test whether the handle
 represents an invalid context.
 A valid context is either the default context or one created by a successful
 call to \FUNC{shmem\_ctx\_create} that has not yet been destroyed.
-Any other context is invalid and the behavior of its use in \ac{RMA}, \ac{AMO},
-and memory ordering routines is undefined.
+Any other context is invalid and the behavior resulting from its use in
+\ac{RMA} and \ac{AMO} routines is undefined.
 }
 
 \subsubsection{\textbf{SHMEM\_CTX\_CREATE}}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -118,7 +118,7 @@ symmetric data objects in the symmetric heap.
 
 \subsection{Communication Management Routines}
 \label{sec:ctx}
-All \openshmem \ac{RMA}, \ac{AMO}, and memory ordering routines are
+All \openshmem \ac{RMA}, \ac{AMO}, and memory ordering routines \oldtext{are} \newtext{must be}
 performed on a \newtext{valid} communication context.  The communication context defines an
 independent ordering and completion environment, allowing users to manage the
 overlap of communication with computation and also to manage communication
@@ -129,22 +129,27 @@ additionally provide thread isolation, eliminating overheads resulting from
 thread interference.
 
 \oldtext{A handle to the desired context}
-\newtext{A communication context is specified by a context handle, which} is
+\newtext{A specific communication context is referenced through a context handle, which} is
 passed as an argument in the \Cstd \CTYPE{shmem\_ctx\_*} and type-generic \ac{API}
 routines.  \ac{API} routines that do not accept a context \newtext{handle} argument operate on the
 default context.  The default context can be used explicitly through the
 \LibHandleRef{SHMEM\_CTX\_DEFAULT} handle.
-
 Context handles are of type \CTYPE{shmem\_ctx\_t} and \newtext{may be used} \oldtext{are valid} for
 language-level assignment and equality comparison.
+
 \newtext{
-A context handle may be initialized to, assigned, or equality-compared with
-the value \CONST{SHMEM\_CTX\_INVALID} to indicate or test whether the handle
-represents an invalid context.
-A valid context is either the default context or one created by a successful
-call to \FUNC{shmem\_ctx\_create} that has not yet been destroyed.
-Any other context is invalid and the behavior resulting from its use in
-\ac{RMA} and \ac{AMO} routines is undefined.
+The default context is valid for the duration of the \openshmem portion of
+an application.
+Contexts created by a successful call to \FUNC{shmem\_ctx\_create} remain
+valid until they are destroyed.
+A handle value that does not correspond to a valid context is considered
+to be invalid, and its use in \ac{RMA} and \ac{AMO} routines results in
+undefined behavior.
+A context handle may be initialized to or assigned the value
+\CONST{SHMEM\_CTX\_INVALID} to indicate that handle does not reference a
+valid communication context.
+When managed in this way, applications can use an equality comparison
+to test whether a given context handle references a valid context.
 }
 
 \subsubsection{\textbf{SHMEM\_CTX\_CREATE}}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -118,8 +118,8 @@ symmetric data objects in the symmetric heap.
 
 \subsection{Communication Management Routines}
 \label{sec:ctx}
-All \openshmem RMA, AMO, and memory ordering routines are
-performed on a communication context.  The communication context defines an
+All \openshmem \ac{RMA}, \ac{AMO}, and memory ordering routines are
+performed on a \newtext{valid} communication context.  The communication context defines an
 independent ordering and completion environment, allowing users to manage the
 overlap of communication with computation and also to manage communication
 operations performed by separate threads within a multithreaded \ac{PE}.  For
@@ -128,12 +128,24 @@ communication and computation.  In multithreaded environments, contexts may
 additionally provide thread isolation, eliminating overheads resulting from
 thread interference.
 
-Context handles are of type \CTYPE{shmem\_ctx\_t} and are valid for
-language-level assignment and equality comparison.  A handle to the desired context is
-passed as an argument in the \Cstd \CTYPE{shmem\_ctx\_*} and type-generic API
-routines.  API routines that do not accept a context argument operate on the
+\oldtext{A handle to the desired context}
+\newtext{A communication context is specified by a context handle, which} is
+passed as an argument in the \Cstd \CTYPE{shmem\_ctx\_*} and type-generic \ac{API}
+routines.  \ac{API} routines that do not accept a context \newtext{handle} argument operate on the
 default context.  The default context can be used explicitly through the
 \LibHandleRef{SHMEM\_CTX\_DEFAULT} handle.
+
+Context handles are of type \CTYPE{shmem\_ctx\_t} and \newtext{may be used} \oldtext{are valid} for
+language-level assignment and equality comparison.
+\newtext{
+A context handle may be initialized to, assigned, or equality-compared with
+the value \CONST{SHMEM\_CTX\_INVALID} to indicate or test whether the handle
+represents an invalid context.
+A valid context is either the default context or one created by a successful
+call to \FUNC{shmem\_ctx\_create} that has not yet been destroyed.
+Any other context is invalid and the behavior of its use in \ac{RMA}, \ac{AMO},
+and memory ordering routines is undefined.
+}
 
 \subsubsection{\textbf{SHMEM\_CTX\_CREATE}}
 \label{subsec:shmem_ctx_create}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -516,7 +516,7 @@
     ##1
     \lstinputlisting[language={C}, tabsize=2,
       basicstyle=\ttfamily\footnotesize,
-      morekeywords={size_t, ptrdiff_t, shmem_ctx_t}]{##2}
+      morekeywords={size_t, ptrdiff_t, shmem_ctx_t, _Thread_local}]{##2}
     ##3 }
 \newcommand{\apifexample}[3]{
     ##1


### PR DESCRIPTION
## Summary of Changes

This PR addresses issue #221 with the following changes:

* Defines the validity of communication contexts and the handles that refer to them.
* Adds the `SHMEM_CTX_INVALID` compile-time constant
* Specifies the behavior of `shmem_ctx_*` routines on invalid contexts:
  * `shmem_ctx_{destroy, fence, quiet}` perform no operation
  * RMA and AMO `shmem_ctx_*` routines have undefined behavior
* Adds a change-log entry
* Revises use of `SHMEM_CTX_DEFAULT` vs. "the default context"

## Notes

* On (much) closer reading of "communication contexts" and "context handles", I wonder whether we should update the following argument-description text that permeates the `shmem_ctx_*` routines:

  > `ctx`: The context on which to perform the operation. When this argument is not provided, the operation is performed on `SHMEM_CTX_DEFAULT`.

  To something like:

  > `ctx`: **A context handle specifying** the context on which to perform the operation. When this argument is not provided, the operation is performed on **the default context** ~~`SHMEM_CTX_DEFAULT`~~.

  The distinction here is that multiple handles may refer to the same context. (This is separate from the shared vs. private distinction with contexts.) Further, `SHMEM_CTX_DEFAULT` is a _context handle_, not the context itself.