### PR TITLE
Add support for NBI put-with-signal operation

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -510,6 +510,9 @@ Major changes in \openshmem[1.5] include \dots
 The following list describes the specific changes in \openshmem[1.5]:
 \begin{itemize}
 %
+\item Added support for nonblocking put-with-signal functions.
+\\ See Section \ref{subsec:shmem_put_signal_nbi}.
+%
 \item Specified the validity of communication contexts, added the constant
   \CONST{SHMEM\_CTX\_INVALID}, and clarified the behavior of
   \FUNC{shmem\_ctx\_*} routines on invalid contexts.

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -8,32 +8,32 @@
 \begin{apidefinition}
 
 \begin{C11synopsis}
-void @\FuncDecl{shmem\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{RMA} types specified by Table \ref{stdrmatypes}.
 
 \begin{Csynopsis}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
 \end{CsynopsisCol}
 where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_putmem\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_putmem\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
 \end{CsynopsisCol}
 
 \begin{apiarguments}
-    \apiargument{IN}{ctx}{The context on which to perform the operation.
-      When this argument is not provided, the operation is performed on
-      \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \apiargument{IN}{ctx}{A context handle specifying the context on which to
+    perform the operation. When this argument is not provided, the operation is
+    performed on the default context.}
     \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
     data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}
@@ -48,9 +48,12 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
 \end{apiarguments}
 
 \apidescription{
-    The routines return after posting the operation. The operation is considered
-    complete after the subsequent call to \FUNC{shmem\_quiet}. At the completion
-    of \FUNC{shmem\_quiet}, the data has been copied out of the \VAR{source}
+    The nonblocking put-with-signal routines provide a method for copying data
+    from a contiguous local data object to a data object on a specified \ac{PE}
+    and subsequently setting a remote flag to signal completion. The routines
+    return after posting the operation. The operation is considered complete
+    after the subsequent call to \FUNC{shmem\_quiet}. At the completion of
+    \FUNC{shmem\_quiet}, the data has been copied out of the \VAR{source}
     array on the local \ac{PE} and delivered into the \VAR{dest} array on the
     destination \ac{PE}. The delivery of \VAR{signal} flag on the remote
     \ac{PE} indicates the delivery of its corresponding \VAR{dest} data words
@@ -66,9 +69,6 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     accessible. The \VAR{sig\_addr} and \VAR{dest} could be of different kinds,
     for example, one could be a global/static \Cstd variable and the other could
     be allocated on the symmetric heap.
-
-    The restrict qualifier in \VAR{sig\_addr} expects the data object to be
-    distinct from \VAR{dest} and \VAR{source} data objects.
 
     The delivery of \VAR{signal} flag on the remote \ac{PE} indicates only the
     delivery of its corresponding \VAR{dest} data words into the data object on

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -70,6 +70,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     for example, one could be a global/static \Cstd variable and the other could
     be allocated on the symmetric heap.
 
+    The \VAR{sig\_addr} and \VAR{dest} may not be overlapping in memory.
+
     The delivery of \VAR{signal} flag on the remote \ac{PE} indicates only the
     delivery of its corresponding \VAR{dest} data words into the data object on
     the remote \ac{PE}. Without a memory-ordering operation, there is no implied

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -1,0 +1,84 @@
+\color{Green}
+\apisummary{
+    The nonblocking put-with-signal routines provide a method for copying data
+    from a contiguous local data object to a data object on a specified \ac{PE}
+    and subsequently setting a remote flag to signal completion.
+}
+
+\begin{apidefinition}
+
+\begin{C11synopsis}
+void @\FuncDecl{shmem\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of the standard \ac{RMA} types specified by Table \ref{stdrmatypes}.
+
+\begin{Csynopsis}
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
+
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+\end{CsynopsisCol}
+where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
+
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_putmem\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *restrict sig_addr, uint64_t signal, int pe);
+\end{CsynopsisCol}
+
+\begin{apiarguments}
+    \apiargument{IN}{ctx}{The context on which to perform the operation.
+      When this argument is not provided, the operation is performed on
+      \CONST{SHMEM\_CTX\_DEFAULT}.}
+    \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
+    data object must be remotely accessible.}
+    \apiargument{IN}{source}{Data object containing the data to be copied.}
+    \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
+    arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.}
+    \apiargument{OUT}{sig\_addr}{Data object to be updated on the remote
+    \ac{PE} as the signal. This signal data object must be
+    remotely accessible.}
+    \apiargument{IN}{signal}{Unsigned 64-bit value that is assigned to the
+    remote \VAR{sig\_addr} signal data object.}
+    \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.}
+\end{apiarguments}
+
+\apidescription{
+    The routines return after posting the operation. The operation is considered
+    complete after the subsequent call to \FUNC{shmem\_quiet}. At the completion
+    of \FUNC{shmem\_quiet}, the data has been copied out of the \VAR{source}
+    array on the local \ac{PE} and delivered into the \VAR{dest} array on the
+    destination \ac{PE}. The delivery of \VAR{signal} flag on the remote
+    \ac{PE} indicates the delivery of its corresponding \VAR{dest} data words
+    into the data object on the remote \ac{PE}.
+}
+
+\apireturnvalues{
+    None.
+}
+
+\apinotes{
+    The \VAR{dest} and \VAR{sig\_addr} data objects must both be remotely
+    accessible. The \VAR{sig\_addr} and \VAR{dest} could be of different kinds,
+    for example, one could be a global/static \Cstd variable and the other could
+    be allocated on the symmetric heap.
+
+    The restrict qualifier in \VAR{sig\_addr} expects the data object to be
+    distinct from \VAR{dest} and \VAR{source} data objects.
+
+    The delivery of \VAR{signal} flag on the remote \ac{PE} indicates only the
+    delivery of its corresponding \VAR{dest} data words into the data object on
+    the remote \ac{PE}. Without a memory-ordering operation, there is no implied
+    ordering between the delivery of the signal word of a nonblocking
+    put-with-signal routine and another data transfer. For example, the delivery
+    of the signal word in a sequence consisting of a put routine followed by a
+    nonblocking put-with-signal routine does not imply delivery of the put
+    routine's data.
+}
+
+\end{apidefinition}
+\color{Black}

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -36,7 +36,7 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
     data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}
-    \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
+    \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
     arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.}
     \apiargument{OUT}{sig\_addr}{Data object to be updated on the remote
     \ac{PE} as the signal. This signal data object must be
@@ -52,10 +52,10 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     and subsequently setting a remote flag to signal completion. The routines
     return after posting the operation. The operation is considered complete
     after the subsequent call to \FUNC{shmem\_quiet}. At the completion of
-    \FUNC{shmem\_quiet}, the data has been copied out of the \VAR{source}
-    array on the local \ac{PE} and delivered into the \VAR{dest} array on the
+    \FUNC{shmem\_quiet}, the data has been copied out of the \source{}
+    array on the local \ac{PE} and delivered into the \dest{} array on the
     destination \ac{PE}. The delivery of \VAR{signal} flag on the remote
-    \ac{PE} indicates the delivery of its corresponding \VAR{dest} data words
+    \ac{PE} indicates the delivery of its corresponding \dest{} data words
     into the data object on the remote \ac{PE}.
 }
 
@@ -64,15 +64,15 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
 }
 
 \apinotes{
-    The \VAR{dest} and \VAR{sig\_addr} data objects must both be remotely
-    accessible. The \VAR{sig\_addr} and \VAR{dest} could be of different kinds,
+    The \dest{} and \VAR{sig\_addr} data objects must both be remotely
+    accessible. The \VAR{sig\_addr} and \dest{} could be of different kinds,
     for example, one could be a global/static \Cstd variable and the other could
     be allocated on the symmetric heap.
 
-    The \VAR{sig\_addr} and \VAR{dest} may not be overlapping in memory.
+    The \VAR{sig\_addr} and \dest{} may not be overlapping in memory.
 
     The delivery of \VAR{signal} flag on the remote \ac{PE} indicates only the
-    delivery of its corresponding \VAR{dest} data words into the data object on
+    delivery of its corresponding \dest{} data words into the data object on
     the remote \ac{PE}. Without a memory-ordering operation, there is no implied
     ordering between the delivery of the signal word of a nonblocking
     put-with-signal routine and another data transfer. For example, the delivery

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -79,13 +79,12 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     of the signal word in a sequence consisting of a put routine followed by a
     nonblocking put-with-signal routine does not imply delivery of the put
     routine's data.
-}
 
-\apiimpnotes{
-    Implementations must ensure that put-with-signal routines are compatible
-    with all point-to-point synchronization interfaces. The delivery of
-    \VAR{signal} flag on the remote \ac{PE} must not cause partial updates. This
-    requires the update on \VAR{signal} flag to be an atomic memory operation.
+    The nonblocking put-with-signal routines are compatible with all
+    point-to-point synchronization interfaces. The delivery of \VAR{signal} flag
+    on the remote \ac{PE} must not cause partial updates. This requires the
+    update on \VAR{signal} flag to be an atomic operation, with atomicity
+    guarantees described in Section~\ref{subsec:amo_guarantees}.
 }
 
 \end{apidefinition}

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -80,11 +80,11 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     nonblocking put-with-signal routine does not imply delivery of the put
     routine's data.
 
-    The nonblocking put-with-signal routines are compatible with all
-    point-to-point synchronization interfaces. The delivery of \VAR{signal} flag
-    on the remote \ac{PE} must not cause partial updates. This requires the
-    update on \VAR{signal} flag to be an atomic operation, with atomicity
-    guarantees described in Section~\ref{subsec:amo_guarantees}.
+    The signal set by the nonblocking put-with-signal routines is compatible
+    with all point-to-point synchronization interfaces. The delivery of
+    \VAR{signal} flag on the remote \ac{PE} must not cause partial updates. This
+    requires the update on \VAR{signal} flag to be an atomic operation, with
+    atomicity guarantees described in Section~\ref{subsec:amo_guarantees}.
 }
 
 \end{apidefinition}

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -82,5 +82,12 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     routine's data.
 }
 
+\apiimpnotes{
+    Implementations must ensure that put-with-signal routines are compatible
+    with all point-to-point synchronization interfaces. The delivery of
+    \signal{} flag on the remote \ac{PE} must not cause partial updates. This
+    requires the update on \signal{} flag to be an atomic memory operation.
+}
+
 \end{apidefinition}
 \color{Black}

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -1,62 +1,75 @@
+\color{ForestGreen}
 \apisummary{
     The nonblocking put-with-signal routines provide a method for copying data
     from a contiguous local data object to a data object on a specified \ac{PE}
-    and subsequently setting a remote flag to signal completion.
+    and subsequently updating a remote flag to signal completion.
 }
 
 \begin{apidefinition}
 
 \begin{C11synopsis}
-void @\FuncDecl{shmem\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
+void @\FuncDecl{shmem\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{RMA} types specified by Table \ref{stdrmatypes}.
 
 \begin{Csynopsis}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
+void @\FuncDecl{shmem\_ctx\_\FuncParam{TYPENAME}\_put\_signal\_nbi}@(shmem_ctx_t ctx, TYPE *dest, const TYPE *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_put\FuncParam{SIZE}\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
+void @\FuncDecl{shmem\_ctx\_put\FuncParam{SIZE}\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
 \end{CsynopsisCol}
 where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
 
 \begin{CsynopsisCol}
-void @\FuncDecl{shmem\_putmem\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
-void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int pe);
+void @\FuncDecl{shmem\_putmem\_signal\_nbi}@(void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
+void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, const void *source, size_t nelems, uint64_t *sig_addr, uint64_t signal, int sig_op, int pe);
 \end{CsynopsisCol}
 
 \begin{apiarguments}
     \apiargument{IN}{ctx}{A context handle specifying the context on which to
     perform the operation. When this argument is not provided, the operation is
     performed on the default context.}
-    \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
-    data object must be remotely accessible.}
+    \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}.
+    This data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}
     \apiargument{IN}{nelems}{Number of elements in the \dest{} and \source{}
     arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd.}
     \apiargument{OUT}{sig\_addr}{Data object to be updated on the remote
-    \ac{PE} as the signal. This signal data object must be
-    remotely accessible.}
-    \apiargument{IN}{signal}{Unsigned 64-bit value that is assigned to the
+    \ac{PE} as the signal. This signal data object must be remotely accessible.}
+    \apiargument{IN}{signal}{Unsigned 64-bit value that is used for updating the
     remote \VAR{sig\_addr} signal data object.}
+    \apiargument{IN}{sig\_op}{Signal operator that represents the type of update
+    to be performed on the remote \VAR{sig\_addr} signal data object.}
     \apiargument{IN}{pe}{\ac{PE} number of the remote \ac{PE}.}
 \end{apiarguments}
 
 \apidescription{
     The nonblocking put-with-signal routines provide a method for copying data
     from a contiguous local data object to a data object on a specified \ac{PE}
-    and subsequently setting a remote flag to signal completion. The routines
-    return after posting the operation. The operation is considered complete
-    after the subsequent call to \FUNC{shmem\_quiet}. At the completion of
-    \FUNC{shmem\_quiet}, the data has been copied out of the \source{}
-    array on the local \ac{PE} and delivered into the \dest{} array on the
-    destination \ac{PE}. The delivery of \VAR{signal} flag on the remote
-    \ac{PE} indicates the delivery of its corresponding \dest{} data words
-    into the data object on the remote \ac{PE}.
+    and subsequently updating a remote flag to signal completion.
+
+    The routines return after posting the operation. The operation is considered
+    complete after a subsequent call to \FUNC{shmem\_quiet}. At the completion
+    of \FUNC{shmem\_quiet}, the data has been copied out of the \source{} array
+    on the local \ac{PE} and delivered into the \dest{} array on the destination
+    \ac{PE}. The delivery of \VAR{signal} flag on the remote \ac{PE} indicates
+    the delivery of its corresponding \dest{} data words into the data object on
+    the remote \ac{PE}.
+
+    The \VAR{sig\_op} signal operator determines the type of update to be
+    performed on the remote \VAR{sig\_addr} signal data object.
+
+    An update to the \VAR{sig\_addr} signal data object through a non-blocking
+    put-with-signal routine completes as if performed atomically with respect to
+    any other non-blocking put-with-signal routine that updates the
+    \VAR{sig\_addr} signal data object using the same \VAR{sig\_op} signal
+    update operator and any point-to-point synchronization routine that accesses
+    the \VAR{sig\_addr} signal data object.
 }
 
 \apireturnvalues{
@@ -69,22 +82,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
     for example, one could be a global/static \Cstd variable and the other could
     be allocated on the symmetric heap.
 
-    The \VAR{sig\_addr} and \dest{} may not be overlapping in memory.
-
-    The delivery of \VAR{signal} flag on the remote \ac{PE} indicates only the
-    delivery of its corresponding \dest{} data words into the data object on
-    the remote \ac{PE}. Without a memory-ordering operation, there is no implied
-    ordering between the delivery of the signal word of a nonblocking
-    put-with-signal routine and another data transfer. For example, the delivery
-    of the signal word in a sequence consisting of a put routine followed by a
-    nonblocking put-with-signal routine does not imply delivery of the put
-    routine's data.
-
-    The signal set by the nonblocking put-with-signal routines is compatible
-    with all point-to-point synchronization interfaces. The delivery of
-    \VAR{signal} flag on the remote \ac{PE} must not cause partial updates. This
-    requires the update on \VAR{signal} flag to be an atomic operation, with
-    atomicity guarantees described in Section~\ref{subsec:amo_guarantees}.
+    \VAR{sig\_addr} and \dest{} may not be overlapping in memory.
 }
 
 \end{apidefinition}
+\color{black}

--- a/content/shmem_put_signal_nbi.tex
+++ b/content/shmem_put_signal_nbi.tex
@@ -1,4 +1,3 @@
-\color{Green}
 \apisummary{
     The nonblocking put-with-signal routines provide a method for copying data
     from a contiguous local data object to a data object on a specified \ac{PE}
@@ -85,9 +84,8 @@ void @\FuncDecl{shmem\_ctx\_putmem\_signal\_nbi}@(shmem_ctx_t ctx, void *dest, c
 \apiimpnotes{
     Implementations must ensure that put-with-signal routines are compatible
     with all point-to-point synchronization interfaces. The delivery of
-    \signal{} flag on the remote \ac{PE} must not cause partial updates. This
-    requires the update on \signal{} flag to be an atomic memory operation.
+    \VAR{signal} flag on the remote \ac{PE} must not cause partial updates. This
+    requires the update on \VAR{signal} flag to be an atomic memory operation.
 }
 
 \end{apidefinition}
-\color{Black}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -185,6 +185,9 @@ to test whether a given context handle references a valid context.
 \subsubsection{\textbf{SHMEM\_PUT\_NBI}}\label{subsec:shmem_put_nbi}
 \input{content/shmem_put_nbi.tex}
 
+\subsubsection{\textbf{SHMEM\_PUT\_SIGNAL\_NBI}}\label{subsec:shmem_put_signal_nbi}
+\input{content/shmem_put_signal_nbi.tex}
+
 \subsubsection{\textbf{SHMEM\_GET\_NBI}}\label{subsec:shmem_get_nbi}
 \input{content/shmem_get_nbi.tex}
 

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -408,7 +408,8 @@
   \textbf{C11:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, uint64_t,
+    restrict, shmem_ctx_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
@@ -424,7 +425,8 @@
   \textbf{C/C++:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, uint64_t,
+    restrict, shmem_ctx_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}
@@ -433,7 +435,8 @@
   \color{red}
   {\lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, uint64_t,
+    restrict, shmem_ctx_t},
     aboveskip=0pt, belowskip=0pt}}}{}
 
 \lstnewenvironment{Fsynopsis}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -408,8 +408,8 @@
   \textbf{C11:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, uint64_t,
-    restrict, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t,
+    uint64_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
@@ -425,8 +425,8 @@
   \textbf{C/C++:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, uint64_t,
-    restrict, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t,
+    uint64_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}
@@ -435,8 +435,8 @@
   \color{red}
   {\lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
-    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, uint64_t,
-    restrict, shmem_ctx_t},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t,
+    uint64_t},
     aboveskip=0pt, belowskip=0pt}}}{}
 
 \lstnewenvironment{Fsynopsis}


### PR DESCRIPTION
This PR extends the #218 proposal adding non-blocking support for put-with-signal operations. The nonblocking variant of the put-with-signal operation is semantically equivalent to:

shmem_put_nbi();
shmem_fence();
shmem_put_nbi();

Following the trend of no-example for any NBI operations, there is no example added for this proposed routine in this PR. And the placement of the routine, will also be modified based on Issue #216.

Expected DOC changes:
1. Since the change log entry framework and the keyword highlighting changes are added as part of #218 - there is no need to do it again in this PR. We will clean it up after reading.
