### PR TITLE
DOC-edit: RM unnecessary white spaces in backmatter and defs

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -164,9 +164,9 @@ or the input is not in accordance with the Specification, the behavior
 is undefined.
 
 \begin{longtable}{|>{\raggedright}p{0.3\textwidth}|>{\raggedright}p{0.6\textwidth}|}
-\hline 
+\hline
 \textbf{Inappropriate Usage} & \textbf{Undefined Behavior}\tabularnewline
-\hline 
+\hline
 \endhead
 Uninitialized library & If the \openshmem library is not initialized,
 calls to non-initializing \openshmem routines have undefined
@@ -185,18 +185,18 @@ non-existent \ac{PE}, then the \openshmem library may handle this
 situation in an implementation-defined way.  For example, the library may report
 an error message saying that the \ac{PE} accessed is outside the range of
 accessible \acp{PE}, or may exit without a warning.\tabularnewline
-\hline 
+\hline
 Use of non-symmetric variables & Some routines require remotely accessible
 variables to perform their function.  For example, a \PUT{} to a non-symmetric variable may
 be trapped where possible and the library may abort the program.  Another
 implementation may choose to continue execution with or without a warning.
 \tabularnewline
-\hline 
+\hline
 Non-symmetric allocation of symmetric memory & The symmetric memory management routines are
 collectives. For example, all \acp{PE} in the program must call
 \FUNC{shmem\_malloc} with the same \VAR{size} argument.  Program behavior after a
 mismatched \FUNC{shmem\_malloc} call is undefined.\tabularnewline
-\hline 
+\hline
 Use of null pointers with non-zero \VAR{len} specified & In any \openshmem routine
 that takes a pointer and \VAR{len} describing the number of elements in that
 pointer, a null pointer may not be given unless the corresponding \VAR{len} is also
@@ -209,7 +209,7 @@ The following cases summarize this behavior:
     \item \VAR{len} is not 0, pointer is non-null: supported.
 \end{itemize}
 \tabularnewline
-\hline 
+\hline
 \end{longtable}
 
 
@@ -590,7 +590,7 @@ The following list describes the specific changes in \openshmem[1.4]:
 \FUNC{shmem\_global\_exit}.
 \\ See Section \ref{subsec:shmem_global_exit}.
 %
-\item Clarified ordering semantics of memory ordering, point-to-point synchronization, and collective 
+\item Clarified ordering semantics of memory ordering, point-to-point synchronization, and collective
 synchronization routines.
 %
 \item Clarified deprecation overview and added deprecation rationale in Annex F.
@@ -707,7 +707,7 @@ The following list describes the specific changes in \openshmem[1.3]:
 	\FUNC{SHMEM\_SET}.
 \\See Sections \ref{subsec:shmem_atomic_fetch} and \ref{subsec:shmem_atomic_set}
 %
-\item New alltoall data exchange operations, \FUNC{SHMEM\_ALLTOALL} 
+\item New alltoall data exchange operations, \FUNC{SHMEM\_ALLTOALL}
 	and \FUNC{SHMEM\_ALLTOALLS}.
 \\See Sections \ref{subsec:shmem_alltoall} and \ref{subsec:shmem_alltoalls}.
 %
@@ -765,7 +765,7 @@ The following list describes the specific changes in \openshmem[1.2]:
     \FUNC{shmem\_ptr}.
 \\See Section \ref{subsec:shmem_ptr}.
 %
-\item New API to query the version and name information. 
+\item New API to query the version and name information.
 \\See Section \ref{subsec:shmem_info_get_version} and \ref{subsec:shmem_info_get_name}.
 %
 \item \openshmem library API normalization. All \Cstd symmetric memory management
@@ -776,7 +776,7 @@ The following list describes the specific changes in \openshmem[1.2]:
 \\See Section \ref{subsec:shfree}.
 %
 \item Deprecation of \Fortran API routine \FUNC{SHMEM\_PUT}.
-\\See Section \ref{subsec:shmem_put}. 
+\\See Section \ref{subsec:shmem_put}.
 %
 \item Clarification related to \FUNC{shmem\_wait}.
 \\See Section \ref{subsec:shmem_wait_until}.
@@ -804,7 +804,7 @@ and general readabilty and usability improvements to the document structure.
 The following list describes the specific changes in \openshmem[1.1]:
 \begin{itemize}
 %
-\item Clarifications of the completion semantics of memory synchronization 
+\item Clarifications of the completion semantics of memory synchronization
       interfaces.
 \\See Section \ref{subsec:memory_order}.
 %
@@ -842,21 +842,21 @@ The following list describes the specific changes in \openshmem[1.1]:
 \\See Section \ref{subsec:library_constants} and \ref{subsec:shmem_wait_until}.
 %
 \item Added \ac{API} calls: \FUNC{shmem\_char\_p}, \FUNC{shmem\_char\_g}.
-\\See Sections \ref{subsec:shmem_p} and \ref{subsec:shmem_g}. 
+\\See Sections \ref{subsec:shmem_p} and \ref{subsec:shmem_g}.
 %
 \item Removed \ac{API} calls: \FUNC{shmem\_char\_put},
       \FUNC{shmem\_char\_get}.
-\\See Sections \ref{subsec:shmem_put} and \ref{subsec:shmem_get}. 
+\\See Sections \ref{subsec:shmem_put} and \ref{subsec:shmem_get}.
 %
 \item The usage of \CTYPE{ptrdiff\_t}, \CTYPE{size\_t}, and \CTYPE{int} in the
       interface signature was made consistent with the description.
 \\See Sections \ref{subsec:coll}, \ref{subsec:shmem_iput}, and \ref{subsec:shmem_iget}.
 %
 \item Revised \FUNC{shmem\_barrier} example.
-\\See Section \ref{subsec:shmem_barrier}. 
+\\See Section \ref{subsec:shmem_barrier}.
 %
 \item Clarification of the initial value of \VAR{pSync} work arrays for
-\FUNC{shmem\_barrier}.\\ See Section \ref{subsec:shmem_barrier}. 
+\FUNC{shmem\_barrier}.\\ See Section \ref{subsec:shmem_barrier}.
 %
 \item Clarification of the expected behavior when multiple \FUNC{start\_pes}
 calls are encountered.
@@ -877,26 +877,26 @@ calls are encountered.
       \ref{subsec:shmem_atomic_fetch_add}.
 %
 \item Clarification of the expected behavior on program \OPR{exit}.
-\\See Section \ref{subsec:execution_model}, Execution Model. 
+\\See Section \ref{subsec:execution_model}, Execution Model.
 %
 \item More detailed description for the progress of \openshmem operations
 provided.
-\\See Section \ref{subsec:progress}. 
+\\See Section \ref{subsec:progress}.
 %
 \item Clarification of naming convention for non-standard interfaces and their
 inclusion in \HEADER{shmemx.h}.
-\\See Section \ref{subsec:bindings}. 
+\\See Section \ref{subsec:bindings}.
 %
 \item Various fixes to \openshmem code examples across the Specification to
-include appropriate header files. 
+include appropriate header files.
 %
 \item Removing requirement that implementations should detect size mismatch and
 return error information for \FUNC{shmalloc} and ensuring consistent
 language.
-\\See Sections \ref{subsec:shfree} and Annex \ref{sec:undefined}. 
+\\See Sections \ref{subsec:shfree} and Annex \ref{sec:undefined}.
 %
 \item \Fortran programming fixes for examples.\\ See Sections
-\ref{subsec:shmem_reductions} and \ref{subsec:shmem_wait_until}. 
+\ref{subsec:shmem_reductions} and \ref{subsec:shmem_wait_until}.
 %
 \item Clarifications of the reuse \VAR{pSync} and \VAR{pWork} across
 collectives.
@@ -904,7 +904,7 @@ collectives.
       \ref{subsec:shmem_collect} and \ref{subsec:shmem_reductions}.
 %
 \item Name changes for UV and ICE for \ac{SGI} systems.
-\\See Annex \ref{sec:openshmem_history}. 
+\\See Annex \ref{sec:openshmem_history}.
 %
 \end{itemize}
 

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -7,8 +7,8 @@
 
 \hyphenation{Open-SHMEM}
 
-\renewcommand{\chaptername}{Chapter} 
-\renewcommand{\appendixname}{Annex} 
+\renewcommand{\chaptername}{Chapter}
+\renewcommand{\appendixname}{Annex}
 
 % Place some penalty for doing the break
 % The penalty for a ``\gb'' should be greater than a \hyphenpenalty.
@@ -17,15 +17,15 @@
 \penalty10000}
 
 % This macro enables that all "_" (underscore) characters in the pfd
-% file are searchable, and that cut&paste will copy the "_" as underscore. 
+% file are searchable, and that cut&paste will copy the "_" as underscore.
 % Without the following macro, the \_ is treated in searches and cut&paste
-% as a " " (space character). 
-% This macro does not modify the behavior of _ in math or in verbatim 
+% as a " " (space character).
+% This macro does not modify the behavior of _ in math or in verbatim
 % environments. In verbatim environments, the "_" is always treated
 % as a searchable character.
 %
-\DeclareRobustCommand{\_}{\texttt{\char`\_}} 
-% 
+\DeclareRobustCommand{\_}{\texttt{\char`\_}}
+%
 
 \def\colorswapnt{\colorlet{saved}{.}\color{ForestGreen}}
 \def\colorswapot{\colorlet{saved}{.}\color{red}}
@@ -186,11 +186,11 @@
 %
 %
 \makeatletter
-\def\section{\@startsection {section}{1}{\z@}{-3.5ex plus -1ex minus 
+\def\section{\@startsection {section}{1}{\z@}{-3.5ex plus -1ex minus
 -.2ex}{2.3ex plus .2ex}{\Large\sf}}
-\def\subsection{\@startsection{subsection}{2}{\z@}{-3.25ex plus -1ex minus 
+\def\subsection{\@startsection{subsection}{2}{\z@}{-3.25ex plus -1ex minus
 -.2ex}{1.5ex plus .2ex}{\large\sf}}
-\def\subsubsection{\@startsection{subsubsection}{3}{\z@}{-3.25ex plus 
+\def\subsubsection{\@startsection{subsubsection}{3}{\z@}{-3.25ex plus
 -1ex minus -.2ex}{1.5ex plus .2ex}{\normalsize\sf\bf}}
 \def\paragraph{\@startsection {paragraph}{4}{\z@}{3.25ex plus 1ex minus .2ex}
 {-1em}{\normalsize\sf\bf}} % Indent after \paragraph
@@ -209,12 +209,12 @@
   breakatwhitespace=true,         % sets if automatic breaks should only happen at whitespace
   basicstyle=\ttfamily\footnotesize,
   breaklines=true,                 % sets automatic line breaking
-  extendedchars=true,              % lets you use non-ASCII characters; for 8-bits 
+  extendedchars=true,              % lets you use non-ASCII characters; for 8-bits
                                    % encodings only, does not work with UTF-8
-  keepspaces=true,                 % keeps spaces in text, useful for keeping indentation of code 
+  keepspaces=true,                 % keeps spaces in text, useful for keeping indentation of code
                                    % (possibly needs columns=flexible)
   morekeywords={*,...},            % if you want to add more keywords to the set
-  showspaces=false,                % show spaces everywhere adding particular underscores; 
+  showspaces=false,                % show spaces everywhere adding particular underscores;
                                    % it overrides 'showstringspaces'
   showstringspaces=false,          % underline spaces within strings only
   showtabs=false,                  % show tabs within strings adding particular underscores
@@ -226,16 +226,16 @@
     basicstyle=\ttfamily\footnotesize,
     breaklines=true,                 % sets automatic line breaking
     escapeinside={\%*}{*)},          % if you want to add LaTeX within your code
-    extendedchars=true,              % lets you use non-ASCII characters; for 8-bits 
+    extendedchars=true,              % lets you use non-ASCII characters; for 8-bits
                                      % encodings only, does not work with UTF-8
     keepspaces=true,                 % keeps spaces in text, useful for keeping
                                      % indentation of code (possibly needs columns=flexible)
     morekeywords={*,...},            % if you want to add more keywords to the set
-    showspaces=false,                % show spaces everywhere adding particular underscores; 
+    showspaces=false,                % show spaces everywhere adding particular underscores;
                                      % it overrides 'showstringspaces'
     showstringspaces=false,          % underline spaces within strings only
     showtabs=false,                  % show tabs within strings adding particular underscores
-    backgroundcolor=\color{gray}, 
+    backgroundcolor=\color{gray},
   }
 }
 
@@ -388,7 +388,7 @@
 
 \newenvironment{apidefinition}{
 \begin{description}
-\item[SYNOPSIS] \hfill \\ \\ 
+\item[SYNOPSIS] \hfill \\ \\
 \vspace{-2em}
 }
 {
@@ -404,15 +404,15 @@
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{C11synopsis}
-{ 
-  \textbf{C11:} 
+{
+  \textbf{C11:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
     morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
-{ 
+{
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
     morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
@@ -420,17 +420,17 @@
 
 
 \lstnewenvironment{Csynopsis}
-{ 
-  \textbf{C/C++:} 
+{
+  \textbf{C/C++:}
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
     morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}
-{ 
-  \textbf{C/C++:} 
-  \color{red}  
+{
+  \textbf{C/C++:}
+  \color{red}
   {\lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
     escapechar=@,
     morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
@@ -449,11 +449,11 @@
 \newenvironment{apiarguments}{
 \newcommand{\apiargument}[3]{
 \begin{tabular}{p{2cm} p{2cm} p{10cm}}
-\textbf{##1} & \textit{##2} & {##3} \\ 
+\textbf{##1} & \textit{##2} & {##3} \\
 \end{tabular}
 }
 \hfill
-\item[DESCRIPTION] \hfill 
+\item[DESCRIPTION] \hfill
 
 \begin{description}
 \item[Arguments] \hfill \\
@@ -466,7 +466,7 @@
 \newcommand{\apidescription}[1]{
 \begin{description}
 \vspace{-1em}
-\item[API description] \hfill \\ 
+\item[API description] \hfill \\
     \begin{sloppypar}
     #1
     \end{sloppypar}
@@ -480,10 +480,10 @@
        \hline \tabularnewline
        \end{tabular}\\
         #4
-}  
+}
 
 \newcommand{\apireturnvalues}[1]{
-\hfill 
+\hfill
 \item[Return Values] \hfill \\
     #1
 \\


### PR DESCRIPTION
Removing unnecessary white spaces in the backmatter and def files.