### PR TITLE
Fix broken reference

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -833,7 +833,7 @@ The following list describes the specific changes in \openshmem[1.1]:
 \\See Section \ref{subsec:shmem_pe_accessible} and \ref{subsec:shmem_addr_accessible}.
 %
 \item Added an annex on interoperability with \ac{MPI}.
-\\See Annex \ref{sec:mpi}.
+\\See Annex D.
 %
 \item Added examples to the different interfaces.
 %


### PR DESCRIPTION
We broke the following reference in the OpenSHMEM 1.1 changelog with #215:
```
LaTeX Warning: Reference `sec:mpi' on page 126 undefined on input line 836.
```