### PR TITLE
Clarify reduction src/dest overlap text

### DIFF
--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -244,10 +244,11 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     perform.  The \source{} array on all \acp{PE} participating in the reduction
     provides one element for each reduction.  The results of the reductions are placed in the
     \dest{} array on all \acp{PE} participating in the reduction.
-    
-    The \source{} and \dest{} arrays must not point to partially overlapping
-    memory regions.  That is, they must point to the same region in memory or
-    to completely disjoint regions in memory.
+
+    The \source{} and \dest{} arguments must either be the same symmetric
+    address, or two different symmetric addresses corresponding to buffers that
+    do not overlap in memory. That is, they must be completely overlapping or
+    completely disjoint.
 
     Team-based reduction routines operate over all \acp{PE} in the provided team argument. All
     \acp{PE} in the provided team must participate in the reduction. If an invalid team handle

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -125,8 +125,9 @@ void @\FuncDecl{shmem\_longlong\_xor\_to\_all}@(long long *dest, const long long
     \dest{} array on all \acp{PE} in the active set.  The active set is defined
     by the \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet.
 
-    The \source{} and \dest{} arrays may be the same array, but they may not be
-    overlapping arrays.
+    The \source{} and \dest{} arrays must not point to partially overlapping
+    memory regions.  That is, they must point to the same region in memory or
+    to completely disjoint regions in memory.
 
     As with all \openshmem collective routines, each of these routines assumes
     that only \acp{PE} in the active set call the routine.  If a \ac{PE} not in


### PR DESCRIPTION
The current text has been around since at least as far back as the T3E documentation, but it's hard (at least for me) to grok.  This PR updates the description of src/dest overlap using the language from the original SHMEM collectives document, ["SHMEM User’s Guide for C" by Barriuso and Knies '94](https://www.cs.cmu.edu/afs/cs/project/cmcl/link.iwarp/OldFiles/archive/fx-papers/cri-shmem-users-guide.ps).