### PR TITLE
Root update in team broadcast; data type relaxation

### DIFF
--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -67,44 +67,54 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
 
 \apidescription{   
     \openshmem broadcast routines are collective routines over an active set or
-    existing \openshmem team. They copy data object
-    \source{} on the processor specified by \VAR{PE\_root} and store the values at
-    \dest{} on the other \acp{PE} participating in the collective operation.
-    The data is not copied to the \dest{} area on the root \ac{PE}.
+    valid \openshmem team.
+    They copy the \source{} data object on the \ac{PE} specified by
+    \VAR{PE\_root} to the \dest{} data object on the \acp{PE}
+    participating in the collective operation.
+    The same \dest{} and \source{} data objects and the same value of
+    \VAR{PE\_root} must be passed by all \acp{PE} participating in the
+    collective operation.
 
-    The same \dest{} and \source{} data objects and the same value of \VAR{PE\_root} must be
-    passed by all \acp{PE} participating in the collective operation.
 
-    Team-based broadcast routines operate over all \acp{PE} in the provided team argument. All
-    \acp{PE} in the provided team must participate in the operation.
-    If an invalid team handle or \LibConstRef{SHMEM\_TEAM\_INVALID} is passed to this routine,
-    the behavior is undefined.
-
-    As with all team-based \openshmem routines, \ac{PE}
-    numbering is relative to the team. The specified root \ac{PE} must be a valid \ac{PE}
-    number for the team, between \CONST{0} and \VAR{N-1}, where \VAR{N} is
-    the size of the team.
-
-    Active-set-based broadcast routines operate over all \acp{PE} in the active set
-    defined by the \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet.
-
-    As with all active-set-based collective routines,
-    each of these routines assumes that
-    only \acp{PE} in the active set call the routine.  If a \ac{PE} not in the
-    active set calls an active-set-based
-    collective routine, the behavior is undefined.
+    For team-based broadcasts:
+    \begin{itemize}
+    \item The \dest{} object is updated on all \acp{PE}.
+    \item All \acp{PE} in the \VAR{team} argument must participate in
+      the operation.
+    \item If an invalid team handle or
+      \LibConstRef{SHMEM\_TEAM\_INVALID} is passed to this routine,
+      the behavior is undefined.
+    \item \ac{PE} numbering is relative to the team. The specified
+      root \ac{PE} must be a valid \ac{PE} number for the team,
+      between \CONST{0} and \VAR{N$-$1}, where \VAR{N} is the size of
+      the team.
+    \end{itemize}
     
-    The values of arguments \VAR{PE\_root}, \VAR{PE\_start}, \VAR{logPE\_stride},
-    and \VAR{PE\_size} must be the same value on all \acp{PE} in the active set.
-    The value of \VAR{PE\_root} must be between \CONST{0} and \VAR{PE\_size}.
-    The same \VAR{pSync} work array must be passed by all \acp{PE} in the active set.
+    For active-set-based broadcasts:
+    \begin{itemize}
+    \item The \dest{} object is updated on all \acp{PE} other than the
+      root \ac{PE}.
+    \item All \acp{PE} in the active set defined by the
+      \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet
+      must participate in the operation.
+    \item Only \acp{PE} in the active set may call the routine.  If a
+      \ac{PE} not in the active set calls an active-set-based
+      collective routine, the behavior is undefined.
+    \item The values of arguments \VAR{PE\_root}, \VAR{PE\_start},
+      \VAR{logPE\_stride}, and \VAR{PE\_size} must be the same value
+      on all \acp{PE} in the active set.
+    \item The value of \VAR{PE\_root} must be between \CONST{0} and
+      \VAR{PE\_size $-$ 1}.
+    \item The same \VAR{pSync} work array must be passed by all \acp{PE}
+      in the active set.
+    \end{itemize}
 
-    Before any \ac{PE} calls a broadcast routine, the following conditions must be ensured:
+    Before any \ac{PE} calls a broadcast routine, the following
+    conditions must be ensured:
     \begin{itemize}
     \item The \dest{} array on all \acp{PE} participating in the broadcast
-      %%
       is ready to accept the broadcast data.
-    \item If using active-set-based routines, the
+    \item For active-set-based broadcasts, the
       \VAR{pSync} array on all \acp{PE} in the
       active set is not still in use from a prior call to a collective
       \openshmem routine.
@@ -114,11 +124,16 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
     Upon return from a broadcast routine, the following are true for the local
     \ac{PE}:
     \begin{itemize}
-    \item If the current \ac{PE} is not the root \ac{PE},
-      the \dest{} data object is updated.
+    \item For team-based broadcasts, the \dest{} data object is
+      updated.
+    \item For active-set-based broadcasts:
+      \begin{itemize}
+      \item If the current \ac{PE} is not the root \ac{PE}, the
+        \dest{} data object is updated.
+      \item The values in the \VAR{pSync} array are restored to the
+        original values.
+      \end{itemize}
     \item The \source{} data object may be safely reused.
-    \item If using active-set-based routines,
-    the values in the \VAR{pSync} array are restored to the original values.
     \end{itemize}
 }
 
@@ -127,17 +142,24 @@ The  \dest{}  and \source{} data  objects must conform to certain typing
 constraints, which are as follows:
 }{Routine}{Data type of \VAR{dest} and \VAR{source}}
 
-\apitablerow{shmem\_broadcastmem}{\Cstd: Any data  type.  nelems is scaled in bytes.}
-\apitablerow{shmem\_broadcast64}{No \CorCpp{} structures are allowed.}
-\apitablerow{shmem\_broadcast32}{No \CorCpp{} structures are allowed.}
+\apitablerow{\FUNC{shmem\_broadcastmem}}{\source{} and \dest{} objects are
+  byte aligned; \VAR{nelems} is the object size in bytes}
+\apitablerow{\FUNC{shmem\_broadcast64}}{\source{} and \dest{} objects are
+  8-byte aligned; \VAR{nelems} is the count of the number of 8-byte
+  elements}
+\apitablerow{\FUNC{shmem\_broadcast32}}{\source{} and \dest{} objects are
+  4-byte aligned; \VAR{nelems} is the count of the number of 4-byte
+  elements}
 
 \apireturnvalues{
-   Zero on successful local completion. Nonzero otherwise.
+  For team-based broadcasts, zero on successful local completion; otherwise, nonzero.
+
+  For active-set-based broadcasts, none.
 }
 
 \apinotes{
-    All \openshmem broadcast routines restore \VAR{pSync} to its original contents.
-    Multiple calls to \openshmem routines that use the same \VAR{pSync} array do not
+    Active-set-based \openshmem broadcast routines restore \VAR{pSync} to its original contents.
+    Multiple calls to active-set-based routines that use the same \VAR{pSync} array do not
     require that \VAR{pSync} be reinitialized after the first call.
 
     The user must ensure that the \VAR{pSync} array is not being updated by any

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -39,12 +39,10 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
 \apiargument{IN}{source}{A symmetric data object that can be of any data type
     that is permissible for the \dest{} argument.}
 \apiargument{IN}{nelems}{The number of elements in \source.
-    nelems must be of type \VAR{size\_t} in \Cstd.  When
-    using \Fortran, it must be a default integer value.}
+    \VAR{nelems} must be of type \VAR{size\_t}.}
 \apiargument{IN}{PE\_root}{Zero-based ordinal of the \ac{PE}, with respect to
     the team or active set, from which the data is copied.
-    \VAR{PE\_root} must be of type \CTYPE{int}.
-    When using \Fortran, it must be a default integer value.}
+    \VAR{PE\_root} must be of type \CTYPE{int}.}
 
 \begin{DeprecateBlock}
 

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -114,13 +114,15 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
 The  \dest{}  and \source{} data  objects must conform to certain typing
 constraints, which are as follows:
 }{Routine}{Data type of \VAR{dest} and \VAR{source}}
-\apitablerow{\FUNC{shmem\_collectmem}, \FUNC{shmem\_fcollectmem}}{\Cstd: Any data  type. \VAR{nelems} is scaled in bytes.}%
-\apitablerow{\FUNC{shmem\_collect64}, \FUNC{shmem\_fcollect64}}%
-    {Any noncharacter type that has an element size of \CONST{64} bits. No \Fortran derived types nor
-    \CorCpp{} structures are allowed.}
-\apitablerow{\FUNC{shmem\_collect32}, \FUNC{shmem\_fcollect32}}%
-    {Any noncharacter type that has an element size of \CONST{32} bits. No \Fortran derived types nor
-    \CorCpp{} structures are allowed.}
+\apitablerow{\FUNC{shmem\_collectmem}, \FUNC{shmem\_fcollectmem}}{
+  \source{} and \dest{} objects are byte aligned;
+  \VAR{nelems} is the object size in bytes}
+\apitablerow{\FUNC{shmem\_collect64}, \FUNC{shmem\_fcollect64}}{
+  \source{} and \dest{} objects are 8-byte aligned;
+  \VAR{nelems} is the count of the number of 8-byte elements}
+\apitablerow{\FUNC{shmem\_collect32}, \FUNC{shmem\_fcollect32}}{
+  \source{} and \dest{} objects are 4-byte aligned;
+  \VAR{nelems} is the count of the number of 4-byte elements}
 
 \apireturnvalues{
     Zero on successful local completion. Nonzero otherwise.


### PR DESCRIPTION
This PR:
- Changes team-based broadcasts to update the `dest` object on all PEs, including the root PE.
- Revises the text of `shmem_broadcast` for clarity by more clearly distinguishing team- and active-set-based behaviors.
- Updates the data-type tables for `shmem_{broadcast, collect}` to allow C structures, reducing the
  restriction only to size and alignment.
- Removes lingering Fortran references in `shmem_{broadcast, collect}`