### PR TITLE
Change HINTS name for SHMEM_MALLOC_WITH_HINTS interface

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -520,6 +520,10 @@ Major changes in \openshmem[1.5] include \dots
 The following list describes the specific changes in \openshmem[1.5]:
 \begin{itemize}
 %
+\item Added \FUNC{shmem\_malloc\_with\_hints} interface and corresponding hints
+\CONST{SHMEM\_MALLOC\_ATOMICS\_REMOTE} and \CONST{SHMEM\_MALLOC\_SIGNAL\_REMOTE}.
+\\ See Section \ref{subsec:shmmallochint} and \ref{subsec:library_constants}.
+%
 \item Added support for nonblocking \ac{AMO} functions.
 \\ See Section \ref{sec:amo-nbi}.
 %

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -96,6 +96,18 @@ See Section~\ref{subsec:shmem_put_signal} and
 Section~\ref{subsec:shmem_put_signal_nbi} for more detail about its use.
 \tabularnewline \hline
 %%
+\LibConstDecl{SHMEM\_MALLOC\_ATOMICS\_REMOTE} &
+The hint to the memory allocation routine which specifies that the allocated
+memory will be used for atomic variables. See Section \ref{subsec:shmmallochint}
+for more detail about its use.
+\tabularnewline \hline
+%%
+\LibConstDecl{SHMEM\_MALLOC\_SIGNAL\_REMOTE} &
+The hint to the memory allocation routine which specifies that the allocated
+memory will be used for signal variables. See Section
+\ref{subsec:shmmallochint} for more detail about its use.
+\tabularnewline \hline
+%%
 \LibConstDecl{SHMEM\_SYNC\_VALUE}
 \begin{DeprecateBlock}
   \LibConstDecl{\_SHMEM\_SYNC\_VALUE}

--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -64,12 +64,12 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
 	\tabularnewline \hline
 	
 		
-	\LibConstDecl{SHMEM\_HINT\_ATOMICS\_REMOTE} &
+	\LibConstDecl{SHMEM\_MALLOC\_ATOMICS\_REMOTE} &
 	\newline 
 	Memory used for \VAR{atomic} operations
 	\tabularnewline \hline
 	
-	\LibConstDecl{SHMEM\_HINT\_SIGNAL} &
+	\LibConstDecl{SHMEM\_MALLOC\_SIGNAL\_REMOTE} &
 	\newline
 	Memory used for \VAR{signal} operations
 	\tabularnewline \hline
@@ -80,7 +80,7 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
 
 \apinotes{
 		The \openshmem programs should allocate memory with
-		\CONST{SHMEM\_HINT\_ATOMICS\_REMOTE}, when the majority of
+		\CONST{SHMEM\_MALLOC\_ATOMICS\_REMOTE}, when the majority of
 		operations performed on this memory are atomic operations, and origin
 		and target \ac{PE} of the atomic operations do not share a memory domain
 		.i.e., symmetric objects on the target \ac{PE} is not accessible using


### PR DESCRIPTION
As per discussion during the Nov spec meeting, the names of the HINTS are changed as below:


**SHMEM_HINTS_ATOMICS_REMOTE -> SHMEM_MALLOC_ATOMICS_REMOTE**
**SHMEM_HINTS_SIGNAL -> SHMEM_MALLOC_SIGNAL_REMOTE**
