### PR TITLE
Create GitHub Action workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended texlive-fonts-recommended texlive-fonts-extra
+      run: |
+        sudo apt-get update
+        sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended texlive-fonts-recommended texlive-fonts-extra
     - name: Build PDF
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
     - name: Upload PDF artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Build PDF
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
     - name: Rename PDF
-      run: mv main_spec.pdf openshmem-draft.pdf
+      run: mv main_spec.pdf openshmem-draft-$COMMIT.pdf
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v1
       with:
-        name: openshmem-draft
-        path: openshmem-draft.pdf
+        name: openshmem-draft-${{ env.COMMIT }}
+        path: openshmem-draft-${{ env.COMMIT }}.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    env:
-        COMMIT: ${GITHUB_SHA::7}
-
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
@@ -19,9 +16,9 @@ jobs:
     - name: Build PDF
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
     - name: Rename PDF
-      run: mv main_spec.pdf openshmem-draft-$COMMIT.pdf
+      run: mv main_spec.pdf openshmem-draft-${{ github.sha }}.pdf
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v1
       with:
-        name: openshmem-draft-${{ env.COMMIT }}
-        path: openshmem-draft-${{ env.COMMIT }}.pdf
+        name: openshmem-draft-${{ github.sha }}
+        path: openshmem-draft-${{ github.sha }}.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended latex-xcolor texlive-fonts-recommended texlive-fonts-extra
+      run: sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended texlive-fonts-recommended texlive-fonts-extra
     - name: Build PDF
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
     - name: Upload PDF artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended latex-xcolor texlive-fonts-recommended texlive-fonts-extra
+    - name: Build PDF
+      run: make LATEXOPT="-interaction batchmode -halt-on-error"
+    - name: Upload PDF artifact
+      uses: actions/upload-artifact@v1
+      with:
+        name: openshmem-draft-${GITHUB_SHA::7}.pdf
+        path: main_spec.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
     - name: Build PDF
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
     - name: Rename PDF
-      run: mv main_spec.pdf openshmem-draft-${{ github.sha }}.pdf
+      run: mv main_spec.pdf openshmem-draft-${{ github.sha.substring(0,7) }}.pdf
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v1
       with:
-        name: openshmem-draft-${{ github.sha }}
-        path: openshmem-draft-${{ github.sha }}.pdf
+        name: openshmem-draft-${{ github.sha.substring(0,7) }}
+        path: openshmem-draft-${{ github.sha.substring(0,7) }}.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v1
+      env:
+        COMMIT: ${GITHUB_SHA::7}
       with:
-        name: openshmem-draft-${GITHUB_SHA::7}.pdf
+        name: openshmem-draft-$COMMIT
         path: main_spec.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+        COMMIT: ${GITHUB_SHA::7}
+
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
@@ -15,10 +18,10 @@ jobs:
         sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended texlive-fonts-recommended texlive-fonts-extra
     - name: Build PDF
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
+    - name: Rename PDF
+      run: mv main_spec.pdf openshmem-draft-$COMMIT.pdf
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v1
-      env:
-        COMMIT: ${GITHUB_SHA::7}
       with:
-        name: openshmem-draft-$COMMIT
-        path: main_spec.pdf
+        name: openshmem-draft
+        path: openshmem-draft-$COMMIT.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
     - name: Build PDF
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
     - name: Rename PDF
-      run: mv main_spec.pdf openshmem-draft-$COMMIT.pdf
+      run: mv main_spec.pdf openshmem-draft.pdf
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v1
       with:
         name: openshmem-draft
-        path: openshmem-draft-$COMMIT.pdf
+        path: openshmem-draft.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install dependencies
-      run: apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended latex-xcolor texlive-fonts-recommended texlive-fonts-extra
+      run: sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended latex-xcolor texlive-fonts-recommended texlive-fonts-extra
     - name: Build PDF
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
     - name: Upload PDF artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
     - name: Build PDF
       run: make LATEXOPT="-interaction batchmode -halt-on-error"
     - name: Rename PDF
-      run: mv main_spec.pdf openshmem-draft-${{ github.sha.substring(0,7) }}.pdf
+      run: mv main_spec.pdf openshmem-draft-${{ github.sha }}.pdf
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v1
       with:
-        name: openshmem-draft-${{ github.sha.substring(0,7) }}
-        path: openshmem-draft-${{ github.sha.substring(0,7) }}.pdf
+        name: openshmem-draft-${{ github.sha }}
+        path: openshmem-draft-${{ github.sha }}.pdf


### PR DESCRIPTION
This PR sets up a [GitHub Actions](https://help.github.com/en/actions) workflow to generate a draft OpenSHMEM PDF and upload the PDF as a build artifact. This will make the generated PDFs available on every PR/push.

In the eventual v2 release of [actions/upload-artifact](https://github.com/actions/upload-artifact), this workflow could be modified to upload the PDF artifact directly (vs. zipped; see https://github.com/actions/upload-artifact/issues/3) and possibly use the short (vs. full) commit hash.

@jdinan Please 'Squash and Merge' when ready/approved.