### PR TITLE
Clarify SHMEM_TEAM_SHARED membership via shmem_ptr

### DIFF
--- a/content/library_handles.tex
+++ b/content/library_handles.tex
@@ -23,10 +23,12 @@ See Section~\ref{subsec:team} for more detail about its use.
 %%
 \LibHandleDecl{SHMEM\_TEAM\_SHARED} &
 Handle of type \CTYPE{shmem\_team\_t} that corresponds to a team of \acp{PE}
-that share a memory domain. When this handle is used by some \ac{PE},
-it will refer to the team of all \acp{PE} that would return a non-null
-pointer from \FUNC{shmem\_ptr} for all symmetric heap objects on that \ac{PE},
-and vice versa. This means that symmetric heap objects on each \ac{PE} are
+that share a memory domain.  \LibHandleRef{SHMEM\_TEAM\_SHARED} refers to
+the team of all PEs that would mutually return a non-null address from a
+call to \FUNC{shmem\_ptr} for all symmetric heap objects.  That is,
+\FUNC{shmem\_ptr} must return a non-null pointer to the local PE for all
+symmetric heap objects on all target \acp{PE} in the team.  This means that
+symmetric heap objects on each \ac{PE} are
 directly load/store accessible by all \acp{PE} in the team.
 See Section~\ref{subsec:team} for more detail about its use.
 \tabularnewline \hline

--- a/content/library_handles.tex
+++ b/content/library_handles.tex
@@ -25,8 +25,8 @@ See Section~\ref{subsec:team} for more detail about its use.
 Handle of type \CTYPE{shmem\_team\_t} that corresponds to a team of \acp{PE}
 that share a memory domain. When this handle is used by some \ac{PE},
 it will refer to the team of all \acp{PE} that would return a non-null
-pointer from \FUNC{shmem\_ptr} for symmetric objects on that \ac{PE},
-and vice versa. This means that symmetric objects on each \ac{PE} are
+pointer from \FUNC{shmem\_ptr} for all symmetric heap objects on that \ac{PE},
+and vice versa. This means that symmetric heap objects on each \ac{PE} are
 directly load/store accessible by all \acp{PE} in the team.
 See Section~\ref{subsec:team} for more detail about its use.
 \tabularnewline \hline


### PR DESCRIPTION
This ticket reverts the proposed change from #307 (to relax the correspondence of `SHMEM_TEAM_SHARED` with `shmem_ptr`) and instead specifies that _all_ symmetric heap objects on the PEs must be accessible for those PEs to be included in `SHMEM_TEAM_SHARED`.

Some more background information:  We learned from #307 that we generally prefer `SHMEM_TEAM_SHARED` and `shmem_ptr` to have a direct correspondence.  We also realized that the `shmem_ptr` interface allows implementations to freely limit accessibility, which resolves any problems with representing non-triplet teams (thanks @minsii!).  We also became aware that `shmem_ptr` may lack "symmetry" with regard to other PE's, and may lack "coverage" with regard to the whole symmetric heap/data segments ([discussed here](https://github.com/openshmem-org/specification/pull/307#issuecomment-562697535)).  This PR (#325) addresses the symmetry/coverage issues of `shmem_ptr` by proposing that the entire symmetric _heap_ be accessible for `SHMEM_TEAM_SHARED` membership.  (It does not prohibit membership if objects on the data segment are _also_ accessible).

Side note: Another option may be for `SHMEM_TEAM_SHARED` membership to require PE accessibility across _both_ the symmetric heap and data segments (but apparently some implementations may not support `shmem_ptr` on the data segment).  ~~In that case, it may be cleaner to rely on the `shmem_pe_accessible` routine rather than "`shmem_ptr` with caveats" to define `SHMEM_TEAM_SHARED`...~~
