### PR TITLE
Fix LaTeX to support and remove Notes/None

### DIFF
--- a/content/execution_model.tex
+++ b/content/execution_model.tex
@@ -42,23 +42,22 @@ communication calls involving that \ac{PE} should progress regardless of when
 that \ac{PE} next engages in an \openshmem call.
 
 \parimpnotes{
-  \vspace{-\topsep}
-  \begin{itemize}
-  \item An \openshmem implementation for hardware that does not provide
-    asynchronous communication capabilities may require a software progress
-    thread in order to process remotely-issued communication requests without
-    explicit program calls to the \openshmem library.
-  \item High performance implementations of \openshmem are expected to leverage
-    hardware offload capabilities and provide asynchronous one-sided
-    communication without software assistance.
-  \item Implementations should avoid deferring the execution of one-sided
-    operations until a synchronization point where data is known to be
-    available. High-quality implementations should attempt asynchronous delivery
-    whenever possible, for performance reasons. Additionally, the \openshmem
-    community discourages releasing \openshmem implementations that do not
-    provide asynchronous one-sided operations, as these have very limited
-    performance value for \openshmem programs.
-  \end{itemize}
+  An \openshmem implementation for hardware that does not provide
+  asynchronous communication capabilities may require a software progress
+  thread in order to process remotely-issued communication requests without
+  explicit program calls to the \openshmem library.
+
+  High performance implementations of \openshmem are expected to leverage
+  hardware offload capabilities and provide asynchronous one-sided
+  communication without software assistance.
+
+  Implementations should avoid deferring the execution of one-sided
+  operations until a synchronization point where data is known to be
+  available. High-quality implementations should attempt asynchronous delivery
+  whenever possible, for performance reasons. Additionally, the \openshmem
+  community discourages releasing \openshmem implementations that do not
+  provide asynchronous one-sided operations, as these have very limited
+  performance value for \openshmem programs.
 }
 
 \subsection{Invoking OpenSHMEM Operations}

--- a/content/execution_model.tex
+++ b/content/execution_model.tex
@@ -41,23 +41,25 @@ without that \ac{PE} issuing any explicit \openshmem calls. One-sided \openshmem
 communication calls involving that \ac{PE} should progress regardless of when
 that \ac{PE} next engages in an \openshmem call.
 
-\textbf{Note to implementors:}
-\begin{itemize}
+\parimpnotes{
+  \vspace{-\topsep}
+  \begin{itemize}
   \item An \openshmem implementation for hardware that does not provide
-      asynchronous communication capabilities may require a software progress
-      thread in order to process remotely-issued communication requests without
-      explicit program calls to the \openshmem library.
+    asynchronous communication capabilities may require a software progress
+    thread in order to process remotely-issued communication requests without
+    explicit program calls to the \openshmem library.
   \item High performance implementations of \openshmem are expected to leverage
-      hardware offload capabilities and provide asynchronous one-sided
-      communication without software assistance.
+    hardware offload capabilities and provide asynchronous one-sided
+    communication without software assistance.
   \item Implementations should avoid deferring the execution of one-sided
-      operations until a synchronization point where data is known to be
-      available. High-quality implementations should attempt asynchronous delivery
-      whenever possible, for performance reasons. Additionally, the \openshmem
-      community discourages releasing \openshmem implementations that do not
-      provide asynchronous one-sided operations, as these have very limited
-      performance value for \openshmem programs.
-\end{itemize}
+    operations until a synchronization point where data is known to be
+    available. High-quality implementations should attempt asynchronous delivery
+    whenever possible, for performance reasons. Additionally, the \openshmem
+    community discourages releasing \openshmem implementations that do not
+    provide asynchronous one-sided operations, as these have very limited
+    performance value for \openshmem programs.
+  \end{itemize}
+}
 
 \subsection{Invoking OpenSHMEM Operations}
 

--- a/content/interoperability.tex
+++ b/content/interoperability.tex
@@ -34,14 +34,14 @@ a call to \FUNC{shmem\_finalize}; the \ac{MPI} environment of the program must b
 by a call to \FUNC{MPI\_Init} or \FUNC{MPI\_Init\_thread} and be finalized by a
 call to \FUNC{MPI\_Finalize}.
 
-\apiimpnotes{
-Portable implementations of OpenSHMEM and \ac{MPI} must ensure that the initialization
-calls can be made in an arbitrary order within a program; the same rule also
-applies to the finalization calls. A software runtime that utilizes a shared
-communication resource for \openshmem and \ac{MPI} communication may maintain an
-internal reference counter in order to ensure that the shared resource is
-initialized only once and thus no shared resource is released until the last
-finalization call is made.
+\parimpnotes{
+  Portable implementations of OpenSHMEM and \ac{MPI} must ensure that the initialization
+  calls can be made in an arbitrary order within a program; the same rule also
+  applies to the finalization calls. A software runtime that utilizes a shared
+  communication resource for \openshmem and \ac{MPI} communication may maintain an
+  internal reference counter in order to ensure that the shared resource is
+  initialized only once and thus no shared resource is released until the last
+  finalization call is made.
 }
 
 

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -55,10 +55,6 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_atomic_and.tex
+++ b/content/shmem_atomic_and.tex
@@ -45,8 +45,4 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   None.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -63,10 +63,6 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     \VAR{dest} data type.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_atomic_compare_swap_nbi.tex
+++ b/content/shmem_atomic_compare_swap_nbi.tex
@@ -55,8 +55,4 @@ where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -58,8 +58,4 @@ where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
     the remote data object.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -63,10 +63,6 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     the same as the \VAR{dest}.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_atomic_fetch_add_nbi.tex
+++ b/content/shmem_atomic_fetch_add_nbi.tex
@@ -51,8 +51,4 @@ where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_and.tex
+++ b/content/shmem_atomic_fetch_and.tex
@@ -45,8 +45,4 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   operation is performed.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_and_nbi.tex
+++ b/content/shmem_atomic_fetch_and_nbi.tex
@@ -50,8 +50,4 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   None.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -57,10 +57,6 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     the increment.  The data type of the return value is the same as the \dest.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_atomic_fetch_inc_nbi.tex
+++ b/content/shmem_atomic_fetch_inc_nbi.tex
@@ -47,8 +47,4 @@ where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_nbi.tex
+++ b/content/shmem_atomic_fetch_nbi.tex
@@ -46,8 +46,4 @@ where \TYPE{} is one of the extended \ac{AMO} types and has a corresponding
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_or.tex
+++ b/content/shmem_atomic_fetch_or.tex
@@ -45,8 +45,4 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   operation is performed.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_or_nbi.tex
+++ b/content/shmem_atomic_fetch_or_nbi.tex
@@ -50,8 +50,4 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   None.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_xor.tex
+++ b/content/shmem_atomic_fetch_xor.tex
@@ -46,8 +46,4 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   operation is performed.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_xor_nbi.tex
+++ b/content/shmem_atomic_fetch_xor_nbi.tex
@@ -50,8 +50,4 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   None.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -54,10 +54,6 @@ and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_atomic_or.tex
+++ b/content/shmem_atomic_or.tex
@@ -45,8 +45,4 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   None.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_set.tex
+++ b/content/shmem_atomic_set.tex
@@ -58,8 +58,4 @@ where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -56,10 +56,6 @@ where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
        prior to the swap is returned.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_atomic_swap_nbi.tex
+++ b/content/shmem_atomic_swap_nbi.tex
@@ -47,8 +47,4 @@ where \TYPE{} is one of the extended \ac{AMO} types and has a corresponding
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_atomic_xor.tex
+++ b/content/shmem_atomic_xor.tex
@@ -45,8 +45,4 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
   None.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -42,8 +42,4 @@ void *@\FuncDecl{shmem\_calloc}@(size_t count, size_t size);
   address of the allocated space; otherwise, it returns a null pointer.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_ctx_create.tex
+++ b/content/shmem_ctx_create.tex
@@ -68,9 +68,5 @@ int @\FuncDecl{shmem\_ctx\_create}@(long options, shmem_ctx_t *ctx);
     Zero on success and nonzero otherwise.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}
 

--- a/content/shmem_ctx_get_team.tex
+++ b/content/shmem_ctx_get_team.tex
@@ -38,10 +38,6 @@ int @\FuncDecl{shmem\_ctx\_get\_team}@(shmem_ctx_t ctx, shmem_team_t *team);
   Zero on success; otherwise, nonzero.
 }
 
-\apinotes{
-  None.
-}
-
 \begin{apiexamples}
 
     \apicexample

--- a/content/shmem_g.tex
+++ b/content/shmem_g.tex
@@ -36,10 +36,6 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
     Returns a single element of type specified in the synopsis.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_iget.tex
+++ b/content/shmem_iget.tex
@@ -54,8 +54,4 @@ where \SIZE{} is one of \CONST{8, 16, 32, 64, 128}.
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_info_get_name.tex
+++ b/content/shmem_info_get_name.tex
@@ -30,8 +30,4 @@ void @\FuncDecl{shmem\_info\_get\_name}@(char *name);
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_info_get_version.tex
+++ b/content/shmem_info_get_version.tex
@@ -24,8 +24,4 @@ void @\FuncDecl{shmem\_info\_get\_version}@(int *major, int *minor);
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_p.tex
+++ b/content/shmem_p.tex
@@ -43,10 +43,6 @@ where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYP
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
 
     \apicexample

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -54,10 +54,6 @@ void @\FuncDecl{shmem\_ctx\_putmem}@(shmem_ctx_t ctx, void *dest, const void *so
     None.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -58,6 +58,5 @@ void @\FuncDecl{shmem\_ctx\_putmem\_nbi}@(shmem_ctx_t ctx, void *dest, const voi
 \apireturnvalues{
     None.
 }
-\apinotes{ None.}
 
 \end{apidefinition}

--- a/content/shmem_query_thread.tex
+++ b/content/shmem_query_thread.tex
@@ -25,7 +25,4 @@ thread levels, and \FUNC{shmem\_query\_thread} returns this thread level.
 None.
 }
 
-\apinotes{
-None.
-}
 \end{apidefinition}

--- a/content/shmem_signal_fetch.tex
+++ b/content/shmem_signal_fetch.tex
@@ -24,8 +24,4 @@ uint64_t @\FuncDecl{shmem\_signal\_fetch}@(const uint64_t *sig_addr);
     calling \ac{PE}.
 }
 
-\apinotes{
-    None.
-}
-
 \end{apidefinition}

--- a/content/shmem_signal_wait_until.tex
+++ b/content/shmem_signal_wait_until.tex
@@ -40,11 +40,6 @@ uint64_t @\FuncDecl{shmem\_signal\_wait\_until}@(uint64_t *sig_addr, int cmp, ui
     calling \ac{PE} that satisfies the wait condition.
 }
 
-
-\apinotes{
-    None.
-}
-
 \apiimpnotes{
     Implementations must ensure that \FUNC{shmem\_signal\_wait\_until} do not
     return before the update of the memory indicated by \VAR{sig\_addr} is fully

--- a/content/shmem_team_config_t.tex
+++ b/content/shmem_team_config_t.tex
@@ -64,8 +64,4 @@ typedef struct {
 
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_team_create_ctx.tex
+++ b/content/shmem_team_create_ctx.tex
@@ -58,10 +58,6 @@ int @\FuncDecl{shmem\_team\_create\_ctx}@(shmem_team_t team, long options, shmem
   Zero on success and nonzero otherwise.
 }
 
-\apinotes{
-  None.
-}
-
 \begin{apiexamples}
      See example in Section \ref{subsec:shmem_ctx_get_team}
 \end{apiexamples}

--- a/content/shmem_team_destroy.tex
+++ b/content/shmem_team_destroy.tex
@@ -35,8 +35,4 @@ If \VAR{team} is otherwise invalid, the behavior is undefined.
   None.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_team_get_config.tex
+++ b/content/shmem_team_get_config.tex
@@ -31,8 +31,4 @@ If \VAR{team} is otherwise invalid, the behavior is undefined.
   otherwise, it returns nonzero.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_test.tex
+++ b/content/shmem_test.tex
@@ -45,10 +45,6 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
   comparison operator \VAR{cmp} evaluates to true; otherwise, it returns 0.
 }
 
-\apinotes{
-  None.
-}
-
 \begin{apiexamples}
   \apicexample
       {The following example demonstrates the use of \FUNC{shmem\_test} to

--- a/content/shmem_test_all.tex
+++ b/content/shmem_test_all.tex
@@ -65,8 +65,4 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
     \FUNC{shmem\_test\_all} returns 1 if all variables in \VAR{ivars} satisfy the test condition or if \VAR{nelems} is 0, otherwise this routine returns 0.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_test_all_vector.tex
+++ b/content/shmem_test_all_vector.tex
@@ -70,8 +70,4 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
     returns 0.
 }
 
-\apinotes{
-  None.
-}
-
 \end{apidefinition}

--- a/content/shmem_test_any.tex
+++ b/content/shmem_test_any.tex
@@ -71,10 +71,6 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
     conditions in the test set are satisfied, this routine returns \CONST{SIZE\_MAX}.
 }
 
-\apinotes{
-  None.
-}
-
 \begin{apiexamples}
   \apicexample
       {The following \Cstd[11] example demonstrates the use of

--- a/content/shmem_test_any_vector.tex
+++ b/content/shmem_test_any_vector.tex
@@ -72,9 +72,4 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
     conditions in the test set are satisfied, this routine returns \CONST{SIZE\_MAX}.
 }
 
-\apinotes{
-  None.
-}
-
-
 \end{apidefinition}

--- a/content/shmem_test_some.tex
+++ b/content/shmem_test_some.tex
@@ -86,10 +86,6 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
     the \VAR{indices} array. If the test set is empty, this routine returns 0.
 }
 
-\apinotes{
-  None.
-}
-
 \begin{apiexamples}
   \apicexample
       {The following \Cstd[11] example demonstrates the use of

--- a/content/shmem_test_some_vector.tex
+++ b/content/shmem_test_some_vector.tex
@@ -83,9 +83,4 @@ corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.
     the \VAR{indices} array. If the test set is empty, this routine returns 0.
 }
 
-\apinotes{
-  None.
-}
-
-
 \end{apidefinition}

--- a/content/shmem_wait_until_all.tex
+++ b/content/shmem_wait_until_all.tex
@@ -68,10 +68,6 @@ corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
     None.
 }
 
-\apinotes{
-    None.
-}
-
 
 \begin{apiexamples}
   \apicexample

--- a/content/shmem_wait_until_all_vector.tex
+++ b/content/shmem_wait_until_all_vector.tex
@@ -66,9 +66,5 @@ corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
     None.
 }
 
-\apinotes{
-    None.
-}
-
 
 \end{apidefinition}

--- a/content/shmem_wait_until_any.tex
+++ b/content/shmem_wait_until_any.tex
@@ -70,11 +70,6 @@ corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
     empty, this routine returns \CONST{SIZE\_MAX}.
 }
 
-\apinotes{
-    None.
-}
-
-
 \begin{apiexamples}
   \apicexample
       {The following \Cstd[11] example demonstrates the use of

--- a/content/shmem_wait_until_any_vector.tex
+++ b/content/shmem_wait_until_any_vector.tex
@@ -70,10 +70,6 @@ corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
     empty, this routine returns \CONST{SIZE\_MAX}.
 }
 
-\apinotes{
-    None.
-}
-
 \begin{apiexamples}
   \apicexample
       {The following \Cstd[11] example demonstrates the use of

--- a/content/shmem_wait_until_some.tex
+++ b/content/shmem_wait_until_some.tex
@@ -86,10 +86,6 @@ corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
     the \VAR{indices} array. If the wait set is empty, this routine returns 0.
 }
 
-\apinotes{
-    None.
-}
-
 
 \begin{apiexamples}
   \apicexample

--- a/content/shmem_wait_until_some_vector.tex
+++ b/content/shmem_wait_until_some_vector.tex
@@ -87,9 +87,5 @@ corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
     routine returns 0.
 }
 
-\apinotes{
-    None.
-}
-
 
 \end{apidefinition}

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -399,6 +399,7 @@
 \vspace{-2em}
 }
 {
+\end{description} % ends \begin{description} from \apidescription
 \end{description}
 }
 
@@ -511,7 +512,6 @@
 \item[Notes] \hfill \\
     #1
 \hfill \\
-\end{description}
 }
 
 \newcommand{\apiimpnotes}[1]{

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -515,14 +515,14 @@
 }
 
 \newcommand{\apiimpnotes}[1]{
-\item[Note to implementors] \hfill \\
+\item[Note to implementers] \hfill \\
     #1
 \hfill \\
 }
 
 \newcommand{\parimpnotes}[1]{
 \begin{description}
-\item[Note to implementors] \phantom{a} \newline
+\item[Note to implementers] \leavevmode \\
     #1
 \end{description}
 }

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -515,10 +515,15 @@
 }
 
 \newcommand{\apiimpnotes}[1]{
-\begin{description}
 \item[Note to implementors] \hfill \\
     #1
 \hfill \\
+}
+
+\newcommand{\parimpnotes}[1]{
+\begin{description}
+\item[Note to implementors] \phantom{a} \newline
+    #1
 \end{description}
 }
 


### PR DESCRIPTION
This PR:

- Fixes the LaTeX environment to allow removing `\apinotes{}`
- Removes all instances of `\apinotes{ None. }`

Replaces #87 