### PR TITLE
Run GitHub workflow on PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [pull_request, push]
 
 jobs:
   build:


### PR DESCRIPTION
The initial GitHub action would run on a push for a branch or active PR, but not on the initial PR. I think this fixes that.