### PR TITLE
Remove hard tabs

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -757,23 +757,23 @@ The following list describes the specific changes in \openshmem[1.3]:
 \\See Section \ref{subsec:library_constants}.
 %
 \item Added a type-generic interface to \openshmem \ac{RMA} and \ac{AMO}
-	operations based on \Cstd[11] Generics.
+    operations based on \Cstd[11] Generics.
 \\See Sections \ref{sec:rma}, \ref{sec:rma_nbi} and \ref{sec:amo}.
 %
 \item New nonblocking variants of remote memory access, \FUNC{SHMEM\_PUT\_NBI}
-	and \FUNC{SHMEM\_GET\_NBI}.
+    and \FUNC{SHMEM\_GET\_NBI}.
 \\See Sections \ref{subsec:shmem_put_nbi} and \ref{subsec:shmem_get_nbi}.
 %
 \item New atomic elemental read and write operations, \FUNC{SHMEM\_FETCH} and
-	\FUNC{SHMEM\_SET}.
+    \FUNC{SHMEM\_SET}.
 \\See Sections \ref{subsec:shmem_atomic_fetch} and \ref{subsec:shmem_atomic_set}
 %
 \item New alltoall data exchange operations, \FUNC{SHMEM\_ALLTOALL}
-	and \FUNC{SHMEM\_ALLTOALLS}.
+    and \FUNC{SHMEM\_ALLTOALLS}.
 \\See Sections \ref{subsec:shmem_alltoall} and \ref{subsec:shmem_alltoalls}.
 %
 \item Added \CTYPE{volatile} to remotely accessible pointer argument in
-	\FUNC{SHMEM\_WAIT} and \FUNC{SHMEM\_LOCK}.
+    \FUNC{SHMEM\_WAIT} and \FUNC{SHMEM\_LOCK}.
 \\See Sections \ref{subsec:shmem_wait_until} and \ref{subsec:shmem_lock}.
 %
 \item Deprecation of \FUNC{SHMEM\_CACHE}.

--- a/content/shmem_barrier.tex
+++ b/content/shmem_barrier.tex
@@ -81,9 +81,9 @@ void @\FuncDecl{shmem\_barrier}@(int PE_start, int logPE_stride, int PE_size, lo
 \begin{apiexamples}
 
 \apicexample
-	{The following barrier example is for \Cstd[11] programs:}
-	{./example_code/shmem_barrier_example.c}
-	{}
+    {The following barrier example is for \Cstd[11] programs:}
+    {./example_code/shmem_barrier_example.c}
+    {}
 
 \end{apiexamples}
 

--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -27,7 +27,7 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
     In addition to the \VAR{size} argument, the \VAR{hints} argument is provided by the user. 
     The \VAR{hints} describes the expected manner in which the \openshmem program may use the allocated memory.
     The valid usage hints are described in Table~\ref{usagehints}. Multiple hints may be requested by combining them with a bitwise \CONST{OR} operation.
-	A zero option can be given if no options are requested.
+    A zero option can be given if no options are requested.
     
     The information provided by the \VAR{hints} is used to optimize for performance by the implementation. 
     If the implementation cannot optimize, the behavior is same as \FUNC{shmem\_malloc}.
@@ -51,40 +51,39 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
     otherwise, it returns a null pointer.
 }
 
-	\begin{longtable}{|p{0.45\textwidth}|p{0.5\textwidth}|}
-	\hline
-	\textbf{Hints} & \textbf{Usage hint}
-	\tabularnewline \hline
-	\endhead
-	%%
-	\newline
-	\CONST{0} &
-	\newline
-	Behavior same as \FUNC{shmem\_malloc}
-	\tabularnewline \hline
-	
-		
-	\LibConstDecl{SHMEM\_MALLOC\_ATOMICS\_REMOTE} &
-	\newline 
-	Memory used for \VAR{atomic} operations
-	\tabularnewline \hline
-	
-	\LibConstDecl{SHMEM\_MALLOC\_SIGNAL\_REMOTE} &
-	\newline
-	Memory used for \VAR{signal} operations
-	\tabularnewline \hline
+\begin{longtable}{|p{0.45\textwidth}|p{0.5\textwidth}|}
+    \hline
+    \textbf{Hints} & \textbf{Usage hint}
+    \tabularnewline \hline
+    \endhead
+    %%
+    \newline
+    \CONST{0} &
+    \newline
+    Behavior same as \FUNC{shmem\_malloc}
+    \tabularnewline \hline
 
-	\TableCaptionRef{Memory usage hints}
-        \label{usagehints}
-    \end{longtable}
+    \LibConstDecl{SHMEM\_MALLOC\_ATOMICS\_REMOTE} &
+    \newline 
+    Memory used for \VAR{atomic} operations
+    \tabularnewline \hline
+
+    \LibConstDecl{SHMEM\_MALLOC\_SIGNAL\_REMOTE} &
+    \newline
+    Memory used for \VAR{signal} operations
+    \tabularnewline \hline
+
+    \TableCaptionRef{Memory usage hints}
+    \label{usagehints}
+\end{longtable}
 
 \apinotes{
-		The \openshmem programs should allocate memory with
-		\CONST{SHMEM\_MALLOC\_ATOMICS\_REMOTE}, when the majority of
-		operations performed on this memory are atomic operations, and origin
-		and target \ac{PE} of the atomic operations do not share a memory domain
-		.i.e., symmetric objects on the target \ac{PE} is not accessible using
-		load/store operations from the origin \ac{PE} or vice versa.
+    The \openshmem programs should allocate memory with
+    \CONST{SHMEM\_MALLOC\_ATOMICS\_REMOTE}, when the majority of
+    operations performed on this memory are atomic operations, and origin
+    and target \ac{PE} of the atomic operations do not share a memory domain
+    .i.e., symmetric objects on the target \ac{PE} is not accessible using
+    load/store operations from the origin \ac{PE} or vice versa.
 }
 \end{apidefinition}
 \newpage

--- a/content/shmem_n_pes.tex
+++ b/content/shmem_n_pes.tex
@@ -31,8 +31,8 @@ int @\FuncDecl{shmem\_n\_pes}@(void);
 \begin{apiexamples}
 
 \apicexample
-	 {The following \FUNC{shmem\_my\_pe} and \FUNC{shmem\_n\_pes} example is for
-	  \CorCpp{} programs:}
+    {The following \FUNC{shmem\_my\_pe} and \FUNC{shmem\_n\_pes} example is for
+    \CorCpp{} programs:}
     {./example_code/shmem_npes_example.c}
     {}
 

--- a/content/shmem_ptr.tex
+++ b/content/shmem_ptr.tex
@@ -12,7 +12,7 @@ void *@\FuncDecl{shmem\_ptr}@(const void *dest, int pe);
 \apiargument{IN}{dest}{The symmetric address of the remotely accessible data
     object to be referenced.}
 \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number on which \dest{} is to
-		 be accessed.}
+    be accessed.}
 \end{apiarguments}
 
 \apidescription{


### PR DESCRIPTION
Document edit (whitespace only) to remove hard tabs and generally fix indentation. Needs two reviews to be merged as a document edit.

@manjugv This touches a couple of your edits, would appreciate if you can review.