### PR TITLE
SHMEM_CTX_INVALID for context creation failure in shmem_ctx_create

### DIFF
--- a/content/shmem_ctx_create.tex
+++ b/content/shmem_ctx_create.tex
@@ -21,8 +21,8 @@ int @\FuncDecl{shmem\_ctx\_create}@(long options, shmem_ctx_t *ctx);
     and returns its handle through the \VAR{ctx} argument.  If the context was
     created successfully, a value of zero is returned
     and the context handle pointed to by \VAR{ctx} specifies a valid context;
-    otherwise, a nonzero value is returned
-    and the context handle pointed to by \VAR{ctx} is not modified.
+    otherwise, a nonzero value is returned and \VAR{ctx} is set to
+    \LibConstRef{SHMEM\_CTX\_INVALID}.
     An unsuccessful context
     creation call is not treated as an error and the \openshmem library remains
     in a correct state.  The creation call can be reattempted with different


### PR DESCRIPTION
Signed-off-by: Md <md.rahman@intel.com>