### PR TITLE
RMA, AMO, Reduction edits

### DIFF
--- a/content/atomics_intro.tex
+++ b/content/atomics_intro.tex
@@ -15,8 +15,8 @@ Section~\ref{sec:rma}, the \acp{AMO} are performed only on symmetric objects.
   the remote data object.
 
   The fetching routines include:
-  \FUNC{shmem\_atomic\_\{fetch, compare\_swap, swap\}} and
-  \FUNC{shmem\_atomic\_fetch\_\{inc, add, and, or, xor\}}.
+  \FUNC{shmem\_atomic\_\{fetch, compare\_swap, swap\}\{\_nbi\}} and
+  \FUNC{shmem\_atomic\_fetch\_\{inc, add, and, or, xor\}\{\_nbi\}}.
 
 \item
   The \emph{non-fetching} routines update the remote data object in a single
@@ -27,7 +27,7 @@ Section~\ref{sec:rma}, the \acp{AMO} are performed only on symmetric objects.
   atomic routines.
 
   The non-fetching routines include:
-  \FUNC{shmem\_atomic\_\{set, inc, add, and, or, xor\}}.
+  \FUNC{shmem\_atomic\_\{set, inc, add, and, or, xor\}\{\_nbi\}}.
 
 \end{itemize}
 
@@ -36,11 +36,11 @@ type-generic \ac{AMO} interfaces via \Cstd[11] generic selection.
 The type-generic support for the \ac{AMO} routines is as follows:
 
 \begin{itemize}
-\item \FUNC{shmem\_atomic\_\{compare\_swap, fetch\_inc, inc, fetch\_add, add\}}
+\item \FUNC{shmem\_atomic\_\{compare\_swap, fetch\_inc, inc, fetch\_add, add\}\{\_nbi\}}
   support the ``standard \ac{AMO} types'' listed in Table~\ref{stdamotypes},
 \item \FUNC{shmem\_atomic\_\{fetch, set, swap\}} support
   the ``extended \ac{AMO} types'' listed in Table~\ref{extamotypes}, and
-\item \FUNC{shmem\_atomic\_\{fetch\_and, and, fetch\_or, or, fetch\_xor, xor\}}
+\item \FUNC{shmem\_atomic\_\{fetch\_and, and, fetch\_or, or, fetch\_xor, xor\}\{\_nbi\}}
   support the ``bitwise \ac{AMO} types'' listed in Table~\ref{bitamotypes}.
 \end{itemize}
 

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -32,7 +32,7 @@
 \end{table}
 
 
-\paragraph{AND}
+\subsubsubsection{AND}
 Performs a bitwise AND reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -55,7 +55,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_and\_to\_all}@(TYPE *dest, const TY
 \end{DeprecateBlock}
 where \TYPE{} is one of the integer types supported for the AND operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
-\paragraph{OR}
+\subsubsubsection{OR}
 Performs a bitwise OR reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -78,7 +78,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_or\_to\_all}@(TYPE *dest, const TYP
 \end{DeprecateBlock}
 where \TYPE{} is one of the integer types supported for the OR operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
-\paragraph{XOR}
+\subsubsubsection{XOR}
 Performs a bitwise exclusive OR (XOR) reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -101,7 +101,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_xor\_to\_all}@(TYPE *dest, const TY
 \end{DeprecateBlock}
 where \TYPE{} is one of the integer types supported for the XOR operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
-\paragraph{MAX}
+\subsubsubsection{MAX}
 Performs a maximum-value reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -125,7 +125,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_max\_to\_all}@(TYPE *dest, const TY
 \end{DeprecateBlock}
 where \TYPE{} is one of the integer or real types supported for the MAX operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
-\paragraph{MIN}
+\subsubsubsection{MIN}
 Performs a minimum-value reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -149,7 +149,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_min\_to\_all}@(TYPE *dest, const TY
 \end{DeprecateBlock}
 where \TYPE{} is one of the integer or real types supported for the MIN operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
-\paragraph{SUM}
+\subsubsubsection{SUM}
 Performs a sum reduction across a set of \acp{PE}.\newline
 
 %% C11
@@ -173,7 +173,7 @@ void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_sum\_to\_all}@(TYPE *dest, const TY
 \end{DeprecateBlock}
 where \TYPE{} is one of the integer, real, or complex types supported for the SUM operation and has a corresponding \TYPENAME{} as specified by Table \ref{reducetypes}.
 
-\paragraph{PROD}
+\subsubsubsection{PROD}
 Performs a product reduction across a set of \acp{PE}.\newline
 
 %% C11

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -207,30 +207,31 @@ than or equal to the size of the \openshmem team, then the behavior is undefined
 \subsection{Remote Memory Access Routines}\label{sec:rma}
 \input{content/rma_intro.tex}
 
-\subsubsection{\textbf{SHMEM\_PUT}}\label{subsec:shmem_put}
+\subsubsection{Blocking Remote Memory Access Routines}\label{sec:rma_nbi}
+\subsubsubsection{\textbf{SHMEM\_PUT}}\label{subsec:shmem_put}
 \input{content/shmem_put.tex}
 
-\subsubsection{\textbf{SHMEM\_P}}\label{subsec:shmem_p}
+\subsubsubsection{\textbf{SHMEM\_P}}\label{subsec:shmem_p}
 \input{content/shmem_p.tex}
 
-\subsubsection{\textbf{SHMEM\_IPUT}}\label{subsec:shmem_iput}
+\subsubsubsection{\textbf{SHMEM\_IPUT}}\label{subsec:shmem_iput}
 \input{content/shmem_iput.tex}
 
-\subsubsection{\textbf{SHMEM\_GET}}\label{subsec:shmem_get}
+\subsubsubsection{\textbf{SHMEM\_GET}}\label{subsec:shmem_get}
 \input{content/shmem_get.tex}
 
-\subsubsection{\textbf{SHMEM\_G}}\label{subsec:shmem_g}
+\subsubsubsection{\textbf{SHMEM\_G}}\label{subsec:shmem_g}
 \input{content/shmem_g.tex}
 
-\subsubsection{\textbf{SHMEM\_IGET}}\label{subsec:shmem_iget}
+\subsubsubsection{\textbf{SHMEM\_IGET}}\label{subsec:shmem_iget}
 \input{content/shmem_iget.tex}
 
-\subsection{Nonblocking Remote Memory Access Routines}\label{sec:rma_nbi}
+\subsubsection{Nonblocking Remote Memory Access Routines}\label{sec:rma_nbi}
 
-\subsubsection{\textbf{SHMEM\_PUT\_NBI}}\label{subsec:shmem_put_nbi}
+\subsubsubsection{\textbf{SHMEM\_PUT\_NBI}}\label{subsec:shmem_put_nbi}
 \input{content/shmem_put_nbi.tex}
 
-\subsubsection{\textbf{SHMEM\_GET\_NBI}}\label{subsec:shmem_get_nbi}
+\subsubsubsection{\textbf{SHMEM\_GET\_NBI}}\label{subsec:shmem_get_nbi}
 \input{content/shmem_get_nbi.tex}
 
 
@@ -238,93 +239,95 @@ than or equal to the size of the \openshmem team, then the behavior is undefined
 \subsection{Atomic Memory Operations}\label{sec:amo}
 \input{content/atomics_intro}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH}}
+\subsubsection{Blocking Atomic Memory Operations}\label{sec:amo-nbi}
+
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH}}
 \label{subsec:shmem_atomic_fetch}
 \input{content/shmem_atomic_fetch.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_SET}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_SET}}
 \label{subsec:shmem_atomic_set}
 \input{content/shmem_atomic_set.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_COMPARE\_SWAP}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_COMPARE\_SWAP}}
 \label{subsec:shmem_atomic_compare_swap}
 \input{content/shmem_atomic_compare_swap.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_SWAP}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_SWAP}}
 \label{subsec:shmem_atomic_swap}
 \input{content/shmem_atomic_swap.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_INC}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_INC}}
 \label{subsec:shmem_atomic_fetch_inc}
 \input{content/shmem_atomic_fetch_inc.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_INC}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_INC}}
 \label{subsec:shmem_atomic_inc}
 \input{content/shmem_atomic_inc.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_ADD}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_ADD}}
 \label{subsec:shmem_atomic_fetch_add}
 \input{content/shmem_atomic_fetch_add.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_ADD}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_ADD}}
 \label{subsec:shmem_atomic_add}
 \input{content/shmem_atomic_add.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_AND}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_AND}}
 \label{subsec:shmem_atomic_fetch_and}
 \input{content/shmem_atomic_fetch_and.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_AND}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_AND}}
 \label{subsec:shmem_atomic_and}
 \input{content/shmem_atomic_and.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_OR}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_OR}}
 \label{subsec:shmem_atomic_fetch_or}
 \input{content/shmem_atomic_fetch_or.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_OR}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_OR}}
 \label{subsec:shmem_atomic_or}
 \input{content/shmem_atomic_or.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_XOR}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_XOR}}
 \label{subsec:shmem_atomic_fetch_xor}
 \input{content/shmem_atomic_fetch_xor.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_XOR}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_XOR}}
 \label{subsec:shmem_atomic_xor}
 \input{content/shmem_atomic_xor.tex}
 
-\subsection{Nonblocking Atomic Memory Operations}\label{sec:amo-nbi}
+\subsubsection{Nonblocking Atomic Memory Operations}\label{sec:amo-nbi}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_NBI}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_NBI}}
 \label{subsec:shmem_atomic_fetch_nbi}
 \input{content/shmem_atomic_fetch_nbi.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_COMPARE\_SWAP\_NBI}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_COMPARE\_SWAP\_NBI}}
 \label{subsec:shmem_atomic_compare_swap_nbi}
 \input{content/shmem_atomic_compare_swap_nbi.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_SWAP\_NBI}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_SWAP\_NBI}}
 \label{subsec:shmem_atomic_swap_nbi}
 \input{content/shmem_atomic_swap_nbi.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_INC\_NBI}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_INC\_NBI}}
 \label{subsec:shmem_atomic_fetch_inc_nbi}
 \input{content/shmem_atomic_fetch_inc_nbi.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_ADD\_NBI}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_ADD\_NBI}}
 \label{subsec:shmem_atomic_fetch_add_nbi}
 \input{content/shmem_atomic_fetch_add_nbi.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_AND\_NBI}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_AND\_NBI}}
 \label{subsec:shmem_atomic_fetch_and_nbi}
 \input{content/shmem_atomic_fetch_and_nbi.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_OR\_NBI}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_OR\_NBI}}
 \label{subsec:shmem_atomic_fetch_or_nbi}
 \input{content/shmem_atomic_fetch_or_nbi.tex}
 
-\subsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_XOR\_NBI}}
+\subsubsubsection{\textbf{SHMEM\_ATOMIC\_FETCH\_XOR\_NBI}}
 \label{subsec:shmem_atomic_fetch_xor_nbi}
 \input{content/shmem_atomic_fetch_xor_nbi.tex}
 

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -89,6 +89,8 @@
   \parbox[t]{5cm}{~\\[-4pt] #1: \\\hspace*{8mm} \LibConstRef{#2} \\~}}
 \newcommand{\LibHandleDecl}[2][\CorCpp]{%
   \parbox[t]{0pt}{~\\[-4pt] #1: \\\hspace*{8mm} \LibHandleRef{#2} \\~}}
+\newcommand{\subsubsubsection}[1]{\paragraph{#1}\mbox{}\par\nobreak}
+\setlength{\parindent}{0pt}
 
 \begin{acronym}
 \acro{RMA}{\emph{Remote Memory Access}}


### PR DESCRIPTION
* Adding macro for subsubsubsection
* Moving blocking and non_blocking RMA into one subsubsection
* Moving blocking and non_blocking AMO into one subsubsection
* Updating AMO introduction to reflect support for non_blocking
operations
* Reduction paragraph was replaced with subsubsubsection to make the
text consistent

Signed-off-by: Pavel Shamis (Pasha) <pasharesearch@gmail.com>