### PR TITLE
LaTeX and minor editorial fixes

### DIFF
--- a/main_spec.tex
+++ b/main_spec.tex
@@ -1,4 +1,4 @@
-\documentclass[10pt]{book}
+\documentclass[10pt,oneside]{book}
 
 \input{utils/packages}
 

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -322,7 +322,7 @@
 \newcommand{\apidescription}[1]{
 \begin{description}
 \vspace{-1em}
-\item[API description] \hfill \\
+\item[API Description] \hfill \\
     \sloppy
     #1
 \hfill
@@ -358,14 +358,14 @@
 }
 
 \newcommand{\apiimpnotes}[1]{
-\item[Note to implementers] \hfill \\
+\item[Note to Implementers] \hfill \\
     #1
 \hfill \\
 }
 
 \newcommand{\parimpnotes}[1]{
 \begin{description}
-\item[Note to implementers] \leavevmode \\
+\item[Note to Implementers] \leavevmode \\
     #1
 \end{description}
 }

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -323,9 +323,8 @@
 \begin{description}
 \vspace{-1em}
 \item[API description] \hfill \\
-    \begin{sloppypar}
+    \sloppy
     #1
-    \end{sloppypar}
 \hfill
 }
 

--- a/utils/packages.tex
+++ b/utils/packages.tex
@@ -6,11 +6,10 @@
 \usepackage{multirow}
 \usepackage[normalem]{ulem}
 \usepackage{float}
-\usepackage[usenames,dvipsnames]{color}
+\usepackage[usenames,dvipsnames,table]{xcolor}
 \usepackage{amsmath}
 \usepackage{amsthm}
 \usepackage{amsfonts}
-\usepackage[table]{xcolor}
 \usepackage{xspace}
 \usepackage{xhfill}
 \usepackage{fancyhdr}


### PR DESCRIPTION
- Fixes vertical spacing to allow "ragged whitespace" at page bottom
- Removes whitespace after "API description" heading
- Consistently capitalize API subtitles
- Fix packages to remove color warnings 