### PR TITLE
Fix pdflatex xcolor warning

### DIFF
--- a/utils/packages.tex
+++ b/utils/packages.tex
@@ -6,11 +6,10 @@
 \usepackage{multirow}
 \usepackage[normalem]{ulem}
 \usepackage{float}
-\usepackage[usenames,dvipsnames]{color}
 \usepackage{amsmath}
 \usepackage{amsthm}
 \usepackage{amsfonts}
-\usepackage[table]{xcolor}
+\usepackage[usenames,dvipsnames,table]{xcolor}
 \usepackage{xspace}
 \usepackage{xhfill}
 \usepackage{fancyhdr}


### PR DESCRIPTION
Document edit. Resolves these warnings during build:
```
Package xcolor Warning: Incompatible color definition on input line 15.
```