### PR TITLE
Fix typo in History: SGI -> Cray

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -214,7 +214,7 @@ clusters, and InfiniBand-based clusters.
     \item Cray was acquired by \ac{SGI} in 1996
     \item Cray was acquired by Tera in 2000 (MTA)
     \item Platforms: Cray T3D, T3E, C90, J90, SV1, SV2, X1, X2, XE, XMT, XT
-    \item \ac{HPE} acquired \ac{SGI} in 2019
+    \item \ac{HPE} acquired Cray in 2019
     \end{itemize}
   \item \ac{SGI} SHMEM
     \begin{itemize}


### PR DESCRIPTION
Simple backmatter fix for my bad typo in the *History of OpenSHMEM* annex.