### PR TITLE
Reduce barriall and sync figure alignements

### DIFF
--- a/content/synchronization_model.tex
+++ b/content/synchronization_model.tex
@@ -72,7 +72,7 @@ a local \ac{PE} need to be visible  to all other \acp{PE} before the local
 {Collective synchronization over all \acp{PE}} \\
  \FUNC{shmem\_barrier\_all}
 &
-\raisebox{-\totalheight}{\includegraphics[width=0.8\textwidth]{figures/barrierall}}
+\raisebox{-\totalheight}{\includegraphics[width=0.7\textwidth]{figures/barrierall}}
 \end{tabular}
 
 \begin{tabular}{p{0.2\textwidth} | p{0.7\textwidth}}
@@ -92,7 +92,7 @@ via \openshmem is required over all \acp{PE}. } \tabularnewline
 Collective synchronization over \\
 \FUNC{shmem\_team\_sync}
 &
-\raisebox{-\totalheight}{\includegraphics[width=0.8\textwidth]{figures/sync}}
+\raisebox{-\totalheight}{\includegraphics[width=0.7\textwidth]{figures/sync}}
 \end{tabular}
 
 \begin{tabular}{p{0.2\textwidth} | p{0.7\textwidth}}

--- a/content/synchronization_model.tex
+++ b/content/synchronization_model.tex
@@ -13,7 +13,7 @@ where they may be useful.\\
 {Point-to-point synchronization}\\
 \FUNC{shmem\_wait\_until}
 &
-\raisebox{-\totalheight}{\includegraphics[width=0.7\textwidth]{figures/wait}}
+\raisebox{-\totalheight}{\includegraphics[width=\linewidth]{figures/wait}}
 \end{tabular}
 
 \begin{tabular}{p{0.2\textwidth} | p{0.7\textwidth}}
@@ -30,7 +30,7 @@ the remote \ac{PE} is to update. \tabularnewline
 {Ordering puts issued by a local \ac{PE}} \\
 \FUNC{shmem\_fence}
 &
-\raisebox{-\totalheight}{\includegraphics[width=0.7\textwidth]{figures/fence}}
+\raisebox{-\totalheight}{\includegraphics[width=\linewidth]{figures/fence}}
 \end{tabular}
 
 \begin{tabular}{p{0.2\textwidth} | p{0.7\textwidth}}
@@ -50,7 +50,7 @@ issued after the \FUNC{fence} call. \tabularnewline
 {Ordering puts issued by all \ac{PE} }\\
 \FUNC{shmem\_quiet}
 &
-\raisebox{-\totalheight}{\includegraphics[width=0.7\textwidth]{figures/quiet}}
+\raisebox{-\totalheight}{\includegraphics[width=\linewidth]{figures/quiet}}
 \end{tabular}
 
 \begin{tabular}{p{0.2\textwidth} | p{0.7\textwidth}}
@@ -72,7 +72,7 @@ a local \ac{PE} need to be visible  to all other \acp{PE} before the local
 {Collective synchronization over all \acp{PE}} \\
  \FUNC{shmem\_barrier\_all}
 &
-\raisebox{-\totalheight}{\includegraphics[width=0.7\textwidth]{figures/barrierall}}
+\raisebox{-\totalheight}{\includegraphics[width=\linewidth]{figures/barrierall}}
 \end{tabular}
 
 \begin{tabular}{p{0.2\textwidth} | p{0.7\textwidth}}
@@ -92,7 +92,7 @@ via \openshmem is required over all \acp{PE}. } \tabularnewline
 Collective synchronization over \\
 \FUNC{shmem\_team\_sync}
 &
-\raisebox{-\totalheight}{\includegraphics[width=0.7\textwidth]{figures/sync}}
+\raisebox{-\totalheight}{\includegraphics[width=\linewidth]{figures/sync}}
 \end{tabular}
 
 \begin{tabular}{p{0.2\textwidth} | p{0.7\textwidth}}


### PR DESCRIPTION
Reduced the size of the figures for barrierall and sync - the size
is similar to all other figures and it fits well within the page
limit.

This is better than recreating the images and making some extensive changes.

Hope this is fine.