### PR TITLE
Clarify undefined-behavior entry for concurrent use of teams

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -181,12 +181,16 @@ The following cases summarize this behavior:
 \end{itemize}
 \tabularnewline
 \hline
-Concurrent use of a team & Teams are not thread-safe objects.
-Concurrent use of a team from multiple threads results in undefined
-behavior.  Such a situation can arise when one thread is calling a
-team-implicit collective (e.g., \FUNC{shmem\_barrier\_all}), which
-implicitly operates on the world team, and another calls a team-based
-collective (e.g., \FUNC{shmem\_broadcastmem}). \tabularnewline
+Multithreaded use of a team in concurrent team-based collectives &
+Team-based collective operations are not thread-safe on the same \VAR{team}
+object.
+Concurrent use of a team from multiple threads may result in undefined
+behavior.
+For example, it is undefined behavior for one thread to call a team-implicit
+collective which implicitly operates on the world team (e.g.,
+\FUNC{shmem\_barrier\_all}) and another thread to concurrently call a
+team-based collective (e.g., \FUNC{shmem\_broadcastmem}) on the same world team
+object, \LibHandleRef{SHMEM\_TEAM\_WORLD}. \tabularnewline
 \hline
 Destroying a team with unfreed private contexts & Before destroying a given
 team, the user is responsible for destroying all contexts created from that team

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -184,7 +184,7 @@ The following cases summarize this behavior:
 Multithreaded use of a team in concurrent team-based collectives &
 Team-based collective operations are not thread-safe on the same \VAR{team}
 object.
-Concurrent use of a team from multiple threads may result in undefined
+Concurrent collective operations on the same team from multiple threads may result in undefined
 behavior.
 For example, it is undefined behavior for one thread to call a team-implicit
 collective which implicitly operates on the world team (e.g.,


### PR DESCRIPTION
This PR clarifies the undefined-behavior "Concurrent use of teams" entry that was a discussion point on the April 27, 2020 v1.5rc2 meeting.

- Changed focus of first sentence to warn that team-based collectives
are not thread-safe if operating on the same team object. All team-based
collectives take a `\VAR{team}` argument input.

- Amended second sentence to now say "may be undefined behavior".
This precludes concurrent thread-safe usage of a team in operations such
as `shmem_team_translate_pe`.

- Explicitly emphasized the example as concurrent collective on the same
team object, `SHMEM_TEAM_WORLD`. This leads the application developer
toward a viable solution for this usage: clone the world team (though it
does beg the question of whether implementers could also clone
the world team to deconflict from application usage of
`SHMEM_TEAM_WORLD`).