### PR TITLE
Add permission to copy statement

### DIFF
--- a/content/coverpage.tex
+++ b/content/coverpage.tex
@@ -243,7 +243,11 @@ This document is a collaborative effort consisting of several releases of \opens
 
 \section*{Acknowledgments}
 The \openshmem specification belongs to Open Source Software Solutions, Inc.
-(OSSS), a non-profit organization, under an agreement with HPE. For a current list
+(OSSS), a non-profit organization, under an agreement with HPE.
+Permission to copy without fee all or part of this material is granted,
+provided the OSSS notice and the title of this document appear, and notice is
+given that copying is by permission of OSSS.
+For a current list
 of Contributors and Collaborators, please see
   \url{http://www.openshmem.org/site/Contributors/}.
 We gratefully acknowledge support from


### PR DESCRIPTION
We reviewed the proposed copyright and license updates at the April 27 RCM and concluded that more time is needed to adopt these changes. In the meantime, we felt it would be appropriate to adopt this permission to copy statement that is used by MPI.