### PR TITLE
Shorten annex heading for Deprecated API

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -240,10 +240,10 @@ A listing of \openshmem implementations can be found on
 
 
 
-\chapter{OpenSHMEM Specification and Deprecated \ac{API}}\label{sec:dep}
+\chapter{Deprecated \acs{API}}\label{sec:dep}
 
 \section{Overview}\label{dep:overview}
-\TableIndex{Deprecated \ac{API}}
+\TableIndex{Deprecated \acs{API}}
 For the \openshmem Specification, deprecation is the process of identifying
 \ac{API} that is supported but no longer recommended for use by users.
 The deprecated \ac{API} \textbf{must} be supported until clearly


### PR DESCRIPTION
Closes https://github.com/openshmem-org/specification/issues/429

Makes the PDF bookmark easier to glance toward.