### PR TITLE
Resolve compiler warning in 2D team split example

### DIFF
--- a/example_code/shmem_team_split_2D.c
+++ b/example_code/shmem_team_split_2D.c
@@ -24,7 +24,7 @@ static void find_xyz_dims(int npes, int *x, int *y, int *z) {
 }
 
 int main(void) {
-  int xdim, ydim, zdim;
+  int xdim = 1, ydim = 1, zdim = 1;
 
   shmem_init();
   int mype = shmem_my_pe();

--- a/example_code/shmem_team_split_2D.c
+++ b/example_code/shmem_team_split_2D.c
@@ -15,6 +15,7 @@ static void find_xy_dims(int npes, int *x, int *y) {
 /*  Find x, y, and z such that x * y * z == npes and
  *  abs(x - y) + abs(x - z) + abs(y - z) is minimized.  */
 static void find_xyz_dims(int npes, int *x, int *y, int *z) {
+  *x = *y = *z = 1;
   for(int divider = ceil(cbrt(npes)); divider >= 1; divider--)
     if (npes % divider == 0) {
       *x = divider;
@@ -24,7 +25,7 @@ static void find_xyz_dims(int npes, int *x, int *y, int *z) {
 }
 
 int main(void) {
-  int xdim = 1, ydim = 1, zdim = 1;
+  int xdim, ydim, zdim;
 
   shmem_init();
   int mype = shmem_my_pe();


### PR DESCRIPTION
The Clang compiler (at least) warns about not initializing the x, y, and z dimensional variables in the `shmem_team_split_2D.c` example code.

This is pretty low priority because the `find_xyz_dims` function should successfully set these variables (unless `shmem_n_pes` or `cbrt(npes)` return something unexpected) but we should fix it anyway.  An error check on these variables after `find_xyz_dims` is an alternative approach.