### PR TITLE
Clarifying Team Collectives

### DIFF
--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -34,11 +34,11 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
 \apiargument{IN}{team}{A valid \openshmem team handle to a team.}%
 
 \apiargument{OUT}{dest}{Symmetric address of a data object large enough to receive
-    the combined total of \VAR{nelems} elements from each \ac{PE} in the
+    the combined total of \VAR{nelems} elements from each \ac{PE} in the team or
     active set.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{source}{Symmetric address of a data object that contains \VAR{nelems}
-    elements of data for each \ac{PE} in the active set, ordered according to
+    elements of data for each \ac{PE} in the team or active set, ordered according to
     destination \ac{PE}.
     The type of \source{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{nelems}{
@@ -117,7 +117,7 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
     Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine,
     the following conditions must be ensured:
     \begin{itemize}
-    \item The \VAR{dest} data object on all \acp{PE} in the active set is
+    \item The \VAR{dest} data object on all \acp{PE} in the team or active set is
       ready to accept the \FUNC{shmem\_alltoall} data.
     \item For active-set-based routines, the \VAR{pSync} array
     on all \acp{PE} in the active set is not still in use from a prior call

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -34,11 +34,11 @@ void @\FuncDecl{shmem\_alltoalls64}@(void *dest, const void *source, ptrdiff_t d
 \apiargument{IN}{team}{A valid \openshmem team handle.}%
 
 \apiargument{OUT}{dest}{Symmetric address of a data object large enough to receive 
-    the combined total of \VAR{nelems} elements from each \ac{PE} in the
+    the combined total of \VAR{nelems} elements from each \ac{PE} in the team or
     active set.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{source}{Symmetric address of a data object that contains \VAR{nelems}
-    elements of data for each \ac{PE} in the active set, ordered according to
+    elements of data for each \ac{PE} in the team or active set, ordered according to
     destination \ac{PE}.
     The type of \source{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -1,6 +1,6 @@
 \apisummary{
     The following functions perform reduction operations across all
-    \acp{PE} in a set of \acp{PE}.
+    \acp{PE} in an \openshmem team or active set of \acp{PE}.
 }
 
 \begin{apidefinition}
@@ -32,7 +32,7 @@
 
 \subsubsubsection{AND}
 \label{subsec:shmem_and_reduce}
-Performs a bitwise AND reduction across a set of \acp{PE}.\newline
+Performs a bitwise AND reduction across an \openshmem team or active set of \acp{PE}.\newline
 
 %% C11
 \begin{C11synopsis}
@@ -56,7 +56,7 @@ where \TYPE{} is one of the integer types supported for the AND operation and ha
 
 \subsubsubsection{OR}
 \label{subsec:shmem_or_reduce}
-Performs a bitwise OR reduction across a set of \acp{PE}.\newline
+Performs a bitwise OR reduction across an \openshmem team or active set of \acp{PE}.\newline
 
 %% C11
 \begin{C11synopsis}
@@ -80,7 +80,7 @@ where \TYPE{} is one of the integer types supported for the OR operation and has
 
 \subsubsubsection{XOR}
 \label{subsec:shmem_xor_reduce}
-Performs a bitwise exclusive OR (XOR) reduction across a set of \acp{PE}.\newline
+Performs a bitwise exclusive OR (XOR) reduction across an \openshmem team or active set of \acp{PE}.\newline
 
 %% C11
 \begin{C11synopsis}
@@ -104,7 +104,7 @@ where \TYPE{} is one of the integer types supported for the XOR operation and ha
 
 \subsubsubsection{MAX}
 \label{subsec:shmem_max_reduce}
-Performs a maximum-value reduction across a set of \acp{PE}.\newline
+Performs a maximum-value reduction across an \openshmem team or active set of \acp{PE}.\newline
 
 %% C11
 \begin{C11synopsis}
@@ -129,7 +129,7 @@ where \TYPE{} is one of the integer or real types supported for the MAX operatio
 
 \subsubsubsection{MIN}
 \label{subsec:shmem_min_reduce}
-Performs a minimum-value reduction across a set of \acp{PE}.\newline
+Performs a minimum-value reduction across an \openshmem team or active set of \acp{PE}.\newline
 
 %% C11
 \begin{C11synopsis}
@@ -154,7 +154,7 @@ where \TYPE{} is one of the integer or real types supported for the MIN operatio
 
 \subsubsubsection{SUM}
 \label{subsec:shmem_sum_reduce}
-Performs a sum reduction across a set of \acp{PE}.\newline
+Performs a sum reduction across an \openshmem team or active set of \acp{PE}.\newline
 
 %% C11
 \begin{C11synopsis}
@@ -179,7 +179,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the SU
 
 \subsubsubsection{PROD}
 \label{subsec:shmem_prod_reduce}
-Performs a product reduction across a set of \acp{PE}.\newline
+Performs a product reduction across an \openshmem team or active set of \acp{PE}.\newline
 
 %% C11
 \begin{C11synopsis}
@@ -291,8 +291,8 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 \end{apiarguments}
 
 \apidescription{
-    \openshmem reduction routines are collective routines over an active set or
-    existing \openshmem team that compute one or more reductions across symmetric
+    \openshmem reduction routines are collective routines over an \openshmem team or
+    active set that compute one or more reductions across symmetric
     arrays on multiple \acp{PE}.  A reduction performs an associative binary routine
     across a set of values.
 


### PR DESCRIPTION
Some descriptions of collective routines did not specify support for OpenSHMEM teams, but rather only active sets.  These changes clarify that they support both teams and active sets (now deprecated).