### PR TITLE
Clarify return value for team split on SHMEM_TEAM_INVALID

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -664,6 +664,10 @@ The following list describes the specific changes in \openshmem[1.6]:
   \FUNC{shmem\_team\_ptr}.
 \ChangelogRef{subsec:shmem_team_ptr}%
 %
+\item Clarified that \FUNC{shmem\_team\_split\_strided} and
+    \FUNC{shmem\_team\_split\_strided} return a nonzero value when the parent
+    team compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID}.
+\ChangelogRef{subsec:shmem_team_split_strided, subsec:shmem_team_split_2d}%
 \end{itemize}
 
 \section{Version 1.5}

--- a/content/shmem_team_split_2d.tex
+++ b/content/shmem_team_split_2d.tex
@@ -95,9 +95,10 @@ See Section~\ref{subsec:shmem_team_config_t} for field mask names and
 default configuration parameters.
 
 If \VAR{parent\_team} compares equal to
-\LibConstRef{SHMEM\_TEAM\_INVALID}, then no new teams will be created
-and both \VAR{xaxis\_team} and \VAR{yaxis\_team} will be assigned the
-value \LibConstRef{SHMEM\_TEAM\_INVALID}.
+\LibConstRef{SHMEM\_TEAM\_INVALID}, then no new teams will be created,
+both \VAR{xaxis\_team} and \VAR{yaxis\_team} will be assigned the
+value \LibConstRef{SHMEM\_TEAM\_INVALID}, and \FUNC{shmem\_team\_split\_2d}
+will return a nonzero value.
 If \VAR{parent\_team} is otherwise invalid, the behavior is undefined.
 
 If any \VAR{xaxis\_team} or \VAR{yaxis\_team} on any \ac{PE} in

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -85,8 +85,10 @@ default configuration parameters.
 
 If \VAR{parent\_team}
 compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID}, then no new team
-will be created and \VAR{new\_team} will be assigned the value
-\LibConstRef{SHMEM\_TEAM\_INVALID}.  If \VAR{parent\_team} is otherwise invalid, the behavior is undefined.
+will be created, \VAR{new\_team} will be assigned the value
+\LibConstRef{SHMEM\_TEAM\_INVALID}, and \FUNC{shmem\_team\_split\_strided} will
+return a nonzero value.  If \VAR{parent\_team} is otherwise invalid, the
+behavior is undefined.
 }
 
 \apireturnvalues{

--- a/example_code/shmem_team_split_2D.c
+++ b/example_code/shmem_team_split_2D.c
@@ -24,7 +24,7 @@ static void find_xyz_dims(int npes, int *x, int *y, int *z) {
 }
 
 int main(void) {
-  int xdim = 1, ydim = 1, zdim = 1;
+  int xdim, ydim, zdim;
 
   shmem_init();
   int mype = shmem_my_pe();


### PR DESCRIPTION
This PR is meant to address #450 (as well as https://github.com/Sandia-OpenSHMEM/SOS/issues/969 and https://github.com/Sandia-OpenSHMEM/SOS/issues/972).

I don't believe https://github.com/openshmem-org/specification/commit/8b44a29f6075a666aa3fcb3a9d123d1e808c0ec8 is a semantic change - just a clarification that a split operation on a SHMEM_TEAM_INVALID parent is indeed considered "unsuccessful" and the routine should return a nonzero value.

I also included a small change to the 2D team split example code (https://github.com/openshmem-org/specification/commit/ec66ff256fe78c9dba04afdb90b23bd02e66f22b).  This has no effect on the example, but leaving these variables uninitialized commonly causes a compiler warning.  Please let me know if you prefer this in a separate PR...