### PR TITLE
Fix type table issue in reductions section

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -664,7 +664,7 @@ The following list describes the specific changes in \openshmem[1.6]:
   \FUNC{shmem\_team\_ptr}.
 \ChangelogRef{subsec:shmem_team_ptr}%
 %
-\item Removed OpenSHMEM 1.5 Table 9, which was an incomplete duplicate of
+\item Removed \openshmem[1.5] Table 9, which was an incomplete duplicate of
     OpenSHMEM 1.5 Table 10, and clarified the types, names, and supporting
     operations for team-based reductions.
 \ChangelogRef{teamreducetypes}%

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -665,7 +665,7 @@ The following list describes the specific changes in \openshmem[1.6]:
 \ChangelogRef{subsec:shmem_team_ptr}%
 %
 \item Removed \openshmem[1.5] Table 9, which was an incomplete duplicate of
-    OpenSHMEM 1.5 Table 10, and clarified the types, names, and supporting
+    \openshmem[1.5] Table 10, and clarified the types, names, and supporting
     operations for team-based reductions.
 \ChangelogRef{teamreducetypes}%
 \end{itemize}

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -664,6 +664,10 @@ The following list describes the specific changes in \openshmem[1.6]:
   \FUNC{shmem\_team\_ptr}.
 \ChangelogRef{subsec:shmem_team_ptr}%
 %
+\item Removed OpenSHMEM 1.5 Table 9, which was an incomplete duplicate of
+    OpenSHMEM 1.5 Table 10, and clarified the types, names, and supporting
+    operations for team-based reductions.
+\ChangelogRef{teamreducetypes}%
 \end{itemize}
 
 \section{Version 1.5}

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -10,203 +10,6 @@
     \begin{tabular}{|l|l|l|l|l|}
       \hline
       \TYPE              & \TYPENAME  & \multicolumn{3}{c|}{Operations Supporting \TYPE}\\ \hline
-      unsigned char      & uchar      & AND, OR, XOR & & \\ \hline
-      short              & short      & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
-      unsigned short     & ushort     & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
-      int                & int        & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
-      unsigned int       & uint       & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
-      long               & long       & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
-      unsigned long      & ulong      & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline  
-      long long          & longlong   & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
-      unsigned long long & ulonglong  & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
-      float              & float      & & MAX, MIN & SUM, PROD \\ \hline
-      double             & double     & & MAX, MIN & SUM, PROD \\ \hline
-      long double        & longdouble & & MAX, MIN & SUM, PROD \\ \hline
-      double \_Complex   & complexd   & & & SUM, PROD \\ \hline
-      float  \_Complex   & complexf   & & & SUM, PROD \\ \hline
-    \end{tabular}
-    \TableCaptionRef{Reduction Types, Names and Supporting Operations}
-    \label{reducetypes}
-  \end{center} 
-\end{table}
-
-\subsubsubsection{AND}
-\label{subsec:shmem_and_reduce}
-Performs a bitwise AND reduction across a set of \acp{PE}.\newline
-
-%% C11
-\begin{C11synopsis}
-int @\FuncDecl{shmem\_and\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{C11synopsis}
-where \TYPE{} is one of the integer types supported for the AND operation as specified by Table \ref{teamreducetypes}.
-
-%% C/C++
-\begin{Csynopsis}
-\end{Csynopsis}
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_and\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{CsynopsisCol}
-
-\begin{DeprecateBlock}
-\begin{CsynopsisCol}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_and\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
-\end{CsynopsisCol}
-\end{DeprecateBlock}
-where \TYPE{} is one of the integer types supported for the AND operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
-
-\subsubsubsection{OR}
-\label{subsec:shmem_or_reduce}
-Performs a bitwise OR reduction across a set of \acp{PE}.\newline
-
-%% C11
-\begin{C11synopsis}
-int @\FuncDecl{shmem\_or\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{C11synopsis}
-where \TYPE{} is one of the integer types supported for the OR operation as specified by Table \ref{teamreducetypes}.
-
-%% C/C++
-\begin{Csynopsis}
-\end{Csynopsis}
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_or\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{CsynopsisCol}
-
-\begin{DeprecateBlock}
-\begin{CsynopsisCol}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_or\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
-\end{CsynopsisCol}
-\end{DeprecateBlock}
-where \TYPE{} is one of the integer types supported for the OR operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
-
-\subsubsubsection{XOR}
-\label{subsec:shmem_xor_reduce}
-Performs a bitwise exclusive OR (XOR) reduction across a set of \acp{PE}.\newline
-
-%% C11
-\begin{C11synopsis}
-int @\FuncDecl{shmem\_xor\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{C11synopsis}
-where \TYPE{} is one of the integer types supported for the XOR operation as specified by Table \ref{teamreducetypes}.
-
-%% C/C++
-\begin{Csynopsis}
-\end{Csynopsis}
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_xor\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{CsynopsisCol}
-
-\begin{DeprecateBlock}
-\begin{CsynopsisCol}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_xor\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
-\end{CsynopsisCol}
-\end{DeprecateBlock}
-where \TYPE{} is one of the integer types supported for the XOR operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
-
-\subsubsubsection{MAX}
-\label{subsec:shmem_max_reduce}
-Performs a maximum-value reduction across a set of \acp{PE}.\newline
-
-%% C11
-\begin{C11synopsis}
-int @\FuncDecl{shmem\_max\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{C11synopsis}
-where \TYPE{} is one of the integer or real types supported for the MAX operation as specified by Table \ref{teamreducetypes}.
-
-%% C/C++
-\begin{Csynopsis}
-\end{Csynopsis}
-
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_max\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{CsynopsisCol}
-
-\begin{DeprecateBlock}
-\begin{CsynopsisCol}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_max\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
-\end{CsynopsisCol}
-\end{DeprecateBlock}
-where \TYPE{} is one of the integer or real types supported for the MAX operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
-
-\subsubsubsection{MIN}
-\label{subsec:shmem_min_reduce}
-Performs a minimum-value reduction across a set of \acp{PE}.\newline
-
-%% C11
-\begin{C11synopsis}
-int @\FuncDecl{shmem\_min\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{C11synopsis}
-where \TYPE{} is one of the integer or real types supported for the MIN operation as specified by Table \ref{teamreducetypes}.
-
-%% C/C++
-\begin{Csynopsis}
-\end{Csynopsis}
-
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_min\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{CsynopsisCol}
-
-\begin{DeprecateBlock}
-\begin{CsynopsisCol}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_min\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
-\end{CsynopsisCol}
-\end{DeprecateBlock}
-where \TYPE{} is one of the integer or real types supported for the MIN operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
-
-\subsubsubsection{SUM}
-\label{subsec:shmem_sum_reduce}
-Performs a sum reduction across a set of \acp{PE}.\newline
-
-%% C11
-\begin{C11synopsis}
-int @\FuncDecl{shmem\_sum\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{C11synopsis}
-where \TYPE{} is one of the integer, real, or complex types supported for the SUM operation as specified by Table \ref{teamreducetypes}.
-
-%% C/C++
-\begin{Csynopsis}
-\end{Csynopsis}
-
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_sum\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{CsynopsisCol}
-
-\begin{DeprecateBlock}
-\begin{CsynopsisCol}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_sum\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
-\end{CsynopsisCol}
-\end{DeprecateBlock}
-where \TYPE{} is one of the integer, real, or complex types supported for the SUM operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
-
-\subsubsubsection{PROD}
-\label{subsec:shmem_prod_reduce}
-Performs a product reduction across a set of \acp{PE}.\newline
-
-%% C11
-\begin{C11synopsis}
-int @\FuncDecl{shmem\_prod\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{C11synopsis}
-where \TYPE{} is one of the integer, real, or complex types supported for the PROD operation as specified by Table \ref{teamreducetypes}.
-
-%% C/C++
-\begin{Csynopsis}
-\end{Csynopsis}
-
-\begin{CsynopsisCol}
-int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_prod\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
-\end{CsynopsisCol}
-
-\begin{DeprecateBlock}
-\begin{CsynopsisCol}
-void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_prod\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
-\end{CsynopsisCol}
-\end{DeprecateBlock}
-where \TYPE{} is one of the integer, real, or complex types supported for the PROD operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
-
-\begin{table}[h]
-  \begin{center}
-    \begin{tabular}{|l|l|l|l|l|}
-      \hline
-      \TYPE              & \TYPENAME  & \multicolumn{3}{c|}{Operations Supporting \TYPE}\\ \hline
       char               & char       &              & MAX, MIN & SUM, PROD \\ \hline
       signed char        & schar      &              & MAX, MIN & SUM, PROD \\ \hline
       short              & short      &              & MAX, MIN & SUM, PROD \\ \hline
@@ -258,6 +61,185 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     \label{asetreducetypes}
   \end{center}
 \end{table}
+
+\subsubsubsection{AND}
+\label{subsec:shmem_and_reduce}
+Performs a bitwise AND reduction across a set of \acp{PE}.\newline
+
+%% C11
+\begin{C11synopsis}
+int @\FuncDecl{shmem\_and\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{C11synopsis}
+where \TYPE{} is one of the integer types supported for the AND operation as specified by Table \ref{teamreducetypes}.
+
+%% C/C++
+\begin{Csynopsis}
+\end{Csynopsis}
+\begin{CsynopsisCol}
+int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_and\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{CsynopsisCol}
+where \TYPE{} is one of the integer types supported for the AND operation and has a corresponding \TYPENAME{} as specified by Table \ref{teamreducetypes}.
+
+\begin{DeprecateBlock}
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_and\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
+\end{CsynopsisCol}
+\end{DeprecateBlock}
+where \TYPE{} is one of the integer types supported for the AND operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
+
+\subsubsubsection{OR}
+\label{subsec:shmem_or_reduce}
+Performs a bitwise OR reduction across a set of \acp{PE}.\newline
+
+%% C11
+\begin{C11synopsis}
+int @\FuncDecl{shmem\_or\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{C11synopsis}
+where \TYPE{} is one of the integer types supported for the OR operation as specified by Table \ref{teamreducetypes}.
+
+%% C/C++
+\begin{Csynopsis}
+\end{Csynopsis}
+\begin{CsynopsisCol}
+int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_or\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{CsynopsisCol}
+where \TYPE{} is one of the integer types supported for the OR operation and has a corresponding \TYPENAME{} as specified by Table \ref{teamreducetypes}.
+
+\begin{DeprecateBlock}
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_or\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
+\end{CsynopsisCol}
+\end{DeprecateBlock}
+where \TYPE{} is one of the integer types supported for the OR operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
+
+\subsubsubsection{XOR}
+\label{subsec:shmem_xor_reduce}
+Performs a bitwise exclusive OR (XOR) reduction across a set of \acp{PE}.\newline
+
+%% C11
+\begin{C11synopsis}
+int @\FuncDecl{shmem\_xor\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{C11synopsis}
+where \TYPE{} is one of the integer types supported for the XOR operation as specified by Table \ref{teamreducetypes}.
+
+%% C/C++
+\begin{Csynopsis}
+\end{Csynopsis}
+\begin{CsynopsisCol}
+int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_xor\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{CsynopsisCol}
+where \TYPE{} is one of the integer types supported for the XOR operation and has a corresponding \TYPENAME{} as specified by Table \ref{teamreducetypes}.
+
+\begin{DeprecateBlock}
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_xor\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
+\end{CsynopsisCol}
+\end{DeprecateBlock}
+where \TYPE{} is one of the integer types supported for the XOR operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
+
+\subsubsubsection{MAX}
+\label{subsec:shmem_max_reduce}
+Performs a maximum-value reduction across a set of \acp{PE}.\newline
+
+%% C11
+\begin{C11synopsis}
+int @\FuncDecl{shmem\_max\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{C11synopsis}
+where \TYPE{} is one of the integer or real types supported for the MAX operation as specified by Table \ref{teamreducetypes}.
+
+%% C/C++
+\begin{Csynopsis}
+\end{Csynopsis}
+
+\begin{CsynopsisCol}
+int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_max\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{CsynopsisCol}
+where \TYPE{} is one of the integer or real types supported for the MAX operation and has a corresponding \TYPENAME{} as specified by Table \ref{teamreducetypes}.
+
+\begin{DeprecateBlock}
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_max\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
+\end{CsynopsisCol}
+\end{DeprecateBlock}
+where \TYPE{} is one of the integer or real types supported for the MAX operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
+
+\subsubsubsection{MIN}
+\label{subsec:shmem_min_reduce}
+Performs a minimum-value reduction across a set of \acp{PE}.\newline
+
+%% C11
+\begin{C11synopsis}
+int @\FuncDecl{shmem\_min\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{C11synopsis}
+where \TYPE{} is one of the integer or real types supported for the MIN operation as specified by Table \ref{teamreducetypes}.
+
+%% C/C++
+\begin{Csynopsis}
+\end{Csynopsis}
+
+\begin{CsynopsisCol}
+int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_min\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{CsynopsisCol}
+where \TYPE{} is one of the integer or real types supported for the MIN operation and has a corresponding \TYPENAME{} as specified by Table \ref{teamreducetypes}.
+
+\begin{DeprecateBlock}
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_min\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
+\end{CsynopsisCol}
+\end{DeprecateBlock}
+where \TYPE{} is one of the integer or real types supported for the MIN operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
+
+\subsubsubsection{SUM}
+\label{subsec:shmem_sum_reduce}
+Performs a sum reduction across a set of \acp{PE}.\newline
+
+%% C11
+\begin{C11synopsis}
+int @\FuncDecl{shmem\_sum\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{C11synopsis}
+where \TYPE{} is one of the integer, real, or complex types supported for the SUM operation as specified by Table \ref{teamreducetypes}.
+
+%% C/C++
+\begin{Csynopsis}
+\end{Csynopsis}
+
+\begin{CsynopsisCol}
+int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_sum\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{CsynopsisCol}
+where \TYPE{} is one of the integer, real, or complex types supported for the SUM operation and has a corresponding \TYPENAME{} as specified by Table \ref{teamreducetypes}.
+
+\begin{DeprecateBlock}
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_sum\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
+\end{CsynopsisCol}
+\end{DeprecateBlock}
+where \TYPE{} is one of the integer, real, or complex types supported for the SUM operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
+
+\subsubsubsection{PROD}
+\label{subsec:shmem_prod_reduce}
+Performs a product reduction across a set of \acp{PE}.\newline
+
+%% C11
+\begin{C11synopsis}
+int @\FuncDecl{shmem\_prod\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{C11synopsis}
+where \TYPE{} is one of the integer, real, or complex types supported for the PROD operation as specified by Table \ref{teamreducetypes}.
+
+%% C/C++
+\begin{Csynopsis}
+\end{Csynopsis}
+
+\begin{CsynopsisCol}
+int @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_prod\_reduce}@(shmem_team_t team, TYPE *dest, const TYPE *source, size_t nreduce);
+\end{CsynopsisCol}
+where \TYPE{} is one of the integer, real, or complex types supported for the PROD operation and has a corresponding \TYPENAME{} as specified by Table \ref{teamreducetypes}.
+
+\begin{DeprecateBlock}
+\begin{CsynopsisCol}
+void @\FuncDecl{shmem\_\FuncParam{TYPENAME}\_prod\_to\_all}@(TYPE *dest, const TYPE *source, int nreduce, int PE_start, int logPE_stride, int PE_size, TYPE *pWrk, long *pSync);
+\end{CsynopsisCol}
+\end{DeprecateBlock}
+where \TYPE{} is one of the integer, real, or complex types supported for the PROD operation and has a corresponding \TYPENAME{} as specified by Table \ref{asetreducetypes}.
 
 \begin{apiarguments}
 


### PR DESCRIPTION
* Delete incorrect type table
* Move correct team/active set type tables to the top of the reductions section
* Add missing type table references for team-based C APIs

Closes #460