### PR TITLE
Ignore missing packages in Github CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended texlive-fonts-recommended texlive-fonts-extra
+        sudo apt-get install --ignore-missing texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended texlive-fonts-recommended texlive-fonts-extra
     - name: Build PDF
       run: make LATEXOPT="-interaction nonstopmode -halt-on-error"
     - name: Rename PDF

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install --ignore-missing texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-generic-recommended texlive-fonts-recommended texlive-fonts-extra
+        sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-fonts-extra
     - name: Build PDF
       run: make LATEXOPT="-interaction nonstopmode -halt-on-error"
     - name: Rename PDF


### PR DESCRIPTION
PR #449 has an error in the GitHub CI:
```
E: Unable to locate package texlive-generic-recommended
```

Looks like it's due to the `ubuntu-latest` image now being 20.04 (Focal), where this package is no longer available.

This fix one option: to ignore missing packages in `apt-get update`.  Another option is to remove this package entirely, which I tested and seems to build the spec successfully.  Any preference?