### PR TITLE
Fix inconsistency in return value for shmem_test_all{_vector}

### DIFF
--- a/content/shmem_test_all.tex
+++ b/content/shmem_test_all.tex
@@ -52,7 +52,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
     the element is excluded from the test set.  Elements of \VAR{status} set to
     0 will be included in the test set, and elements set to a nonzero value will be ignored.  If all elements
     in \VAR{status} are nonzero or \VAR{nelems} is 0, the test set is empty
-    and this routine returns 0.  If \VAR{status} is a null pointer, it is
+    and this routine returns 1.  If \VAR{status} is a null pointer, it is
     ignored and all elements in \VAR{ivars} are included in the test set.  The
     \VAR{ivars}, \VAR{indices}, and \VAR{status} arrays must not overlap in
     memory.

--- a/content/shmem_test_all_vector.tex
+++ b/content/shmem_test_all_vector.tex
@@ -54,7 +54,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
     the element is excluded from the test set.  Elements of \VAR{status} set to
     0 will be included in the test set, and elements set to a nonzero value will be ignored.  If all elements
     in \VAR{status} are nonzero or \VAR{nelems} is 0, the test set is empty
-    and this routine returns 0.  If \VAR{status} is a null pointer, it is
+    and this routine returns 1.  If \VAR{status} is a null pointer, it is
     ignored and all elements in \VAR{ivars} are included in the test set.  The
     \VAR{ivars}, \VAR{indices}, and \VAR{status} arrays must not overlap in
     memory.


### PR DESCRIPTION
Fixes inconsistency in return value for `shmem_test_all{_vector}`

Closes #442 