### PR TITLE
Split memory management routines into separate entries

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -276,10 +276,10 @@ supported before removal.
     \CorCpp: \FuncRef{\_num\_pes} & 1.2 & Current & \hyperref[subsec:shmem_n_pes]{\FUNC{shmem\_n\_pes}} \\ \hline
     \Fortran: \FuncRef{MY\_PE} & 1.2 & 1.4 & \hyperref[subsec:shmem_my_pe]{\FUNC{SHMEM\_MY\_PE}} \\ \hline
     \Fortran: \FuncRef{NUM\_PES} & 1.2 & 1.4 & \hyperref[subsec:shmem_n_pes]{\FUNC{SHMEM\_N\_PES}} \\ \hline
-    \CorCpp: \FuncRef{shmalloc} & 1.2 & Current & \hyperref[subsec:shfree]{\FUNC{shmem\_malloc}} \\ \hline
-    \CorCpp: \FuncRef{shfree} & 1.2 & Current & \hyperref[subsec:shfree]{\FUNC{shmem\_free}} \\ \hline
-    \CorCpp: \FuncRef{shrealloc} & 1.2 & Current & \hyperref[subsec:shfree]{\FUNC{shmem\_realloc}} \\ \hline
-    \CorCpp: \FuncRef{shmemalign} & 1.2 & Current & \hyperref[subsec:shfree]{\FUNC{shmem\_align}} \\ \hline
+    \CorCpp: \FuncRef{shmalloc} & 1.2 & Current & \hyperref[sec:memory_management]{\FUNC{shmem\_malloc}} \\ \hline
+    \CorCpp: \FuncRef{shfree} & 1.2 & Current & \hyperref[sec:memory_management]{\FUNC{shmem\_free}} \\ \hline
+    \CorCpp: \FuncRef{shrealloc} & 1.2 & Current & \hyperref[sec:memory_management]{\FUNC{shmem\_realloc}} \\ \hline
+    \CorCpp: \FuncRef{shmemalign} & 1.2 & Current & \hyperref[sec:memory_management]{\FUNC{shmem\_align}} \\ \hline
     \Fortran: \FuncRef{SHMEM\_PUT} & 1.2 & 1.4 & \hyperref[subsec:shmem_put]{\FUNC{SHMEM\_PUT8} or \FUNC{SHMEM\_PUT64}} \\ \hline
     %% Deprecated in 1.3
     \minitab{
@@ -824,7 +824,7 @@ environment variables.
     symmetric heap management routines that perform no action do not perform a
     barrier; and that the \VAR{alignment} argument to \FUNC{shmem\_align} must
     be power of two multiple of \CONST{sizeof(void*)}.
-\ChangelogRef{subsec:shfree}%
+\ChangelogRef{subsec:shmem_malloc, subsec:shmem_align, subsec:shmem_realloc}%
 %
 \item Clarified that the \openshmem lock \ac{API} provides a non-reentrant mutex and
     that \FUNC{shmem\_clear\_lock} performs a quiet operation on the default
@@ -1075,10 +1075,10 @@ The following list describes the specific changes in \openshmem[1.2]:
 %
 \item \openshmem library \ac{API} normalization. All \Cstd symmetric memory management
       \ac{API} begins with \FUNC{shmem\_}.
-\ChangelogRef{subsec:shfree, dep:func_not_shmemunder}%
+\ChangelogRef{sec:memory_management, dep:func_not_shmemunder}%
 %
 \item Notes and clarifications added to \FUNC{shmem\_malloc}.
-\ChangelogRef{subsec:shfree}%
+\ChangelogRef{subsec:shmem_malloc}%
 %
 \item Deprecation of \Fortran \ac{API} routine \FUNC{SHMEM\_PUT}.
 \ChangelogRef{dep:fortran_shmem_put}%
@@ -1173,7 +1173,7 @@ calls are encountered.
 \ChangelogRef{subsec:shmem_atomic_inc}%
 %
 \item Clarification of the size of the symmetric heap and when it is set.
-\ChangelogRef{subsec:shfree}%
+\ChangelogRef{sec:memory_management}%
 %
 \item Clarification of the integer and real sizes for \Fortran \ac{API}.
 \ChangelogRef{
@@ -1201,7 +1201,7 @@ include appropriate header files.
 \item Removing requirement that implementations should detect size mismatch and
 return error information for \FUNC{shmalloc} and ensuring consistent
 language.
-\ChangelogRef{subsec:shfree, sec:undefined}%
+\ChangelogRef{subsec:shmem_malloc, sec:undefined}%
 %
 \item \Fortran programming fixes for examples.
 \ChangelogRef{subsec:shmem_reductions, subsec:shmem_wait_until}%

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -673,6 +673,11 @@ The following list describes the specific changes in \openshmem[1.6]:
     \openshmem[1.5] Table 10, and clarified the types, names, and supporting
     operations for team-based reductions.
 \ChangelogRef{teamreducetypes}%
+%
+\item Split the listings for the \FUNC{shmem\_\{malloc, free, realloc, align\}}
+  functions from a single entry in \openshmem[1.5] into separate entries.
+\ChangelogRef{subsec:shmem_malloc, subsec:shmem_free, subsec:shmem_realloc,
+  subsec:shmem_align}%
 \end{itemize}
 
 \section{Version 1.5}

--- a/content/memmgmt_intro.tex
+++ b/content/memmgmt_intro.tex
@@ -1,0 +1,45 @@
+\openshmem provides a set of \acp{API} for managing the symmetric heap. The
+\acp{API} allow one to dynamically allocate, deallocate, reallocate, and align
+symmetric data objects in the symmetric heap.
+
+The symmetric memory allocation routines differ from the private heap
+allocation routines in that they must be called by all \acp{PE} in a
+the world team.  When specified, each of these routines includes at
+least one call to a procedure that is semantically equivalent to
+\FUNC{shmem\_barrier\_all}.  This ensures that all \acp{PE}
+participate in the memory management, and that the memory on other
+\acp{PE} can be used as soon as the local \ac{PE} returns.  The
+implicit barriers performed by these routines quiet the default
+context.  It is the user's responsibility to ensure that no
+communication operations involving the given memory block are pending
+on other contexts prior to calling the \FUNC{shmem\_free} and
+\FUNC{shmem\_realloc} routines.
+
+The total size of the symmetric heap is determined at job startup.  One can
+specify the size of the heap using the \ENVVAR{SHMEM\_SYMMETRIC\_SIZE} environment
+variable (where available).	
+
+\begin{DeprecateBlock}
+  As of \openshmem[1.2] the use of \FUNC{shmalloc}, \FUNC{shmemalign},
+  \FUNC{shfree},  and \FUNC{shrealloc} has been deprecated. Although \openshmem
+  libraries are required to support the calls, users are encouraged to use
+  \FUNC{shmem\_malloc}, \FUNC{shmem\_align}, \FUNC{shmem\_free}, and
+  \FUNC{shmem\_realloc} instead.  The behavior and signature  of the routines
+  remains unchanged from the deprecated versions.
+\end{DeprecateBlock}
+
+\parimpnotes{
+  The symmetric heap allocation routines always return the symmetric
+  addresses of corresponding symmetric objects across all
+  \acp{PE}. The \openshmem specification does not require that the
+  virtual addresses are equal across all \acp{PE}. Nevertheless, the
+  implementation must avoid costly address translation operations in
+  the communication path, including $O(N)$ memory translation tables,
+  where $N$ is the number of \acp{PE}.  In order to avoid address
+  translations, the implementation may re-map the allocated block of
+  memory based on agreed virtual address.  Additionally, some
+  operating systems provide an option to disable virtual address
+  randomization, which enables predictable allocation of virtual
+  memory addresses.
+}
+

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -16,7 +16,7 @@ corresponding object with the same name, type, and size on all \acp{PE} where th
 accessible via the \openshmem \ac{API}\footnote{For efficiency reasons,
 the same offset (from an arbitrary memory address) for symmetric data
 objects might be used on all \acp{PE}. Further discussion about symmetric heap
-layout and implementation efficiency can be found in Section~\ref{subsec:shfree}}.
+layout and implementation efficiency can be found in Section~\ref{sec:memory_management}}.
 (For the definition of what is accessible, see the
 descriptions for \FUNC{shmem\_pe\_accessible} and \FUNC{shmem\_addr\_accessible}
 in Sections~\ref{subsec:shmem_pe_accessible} and

--- a/content/shmem_align.tex
+++ b/content/shmem_align.tex
@@ -1,0 +1,38 @@
+\apisummary{
+  Collectively allocate symmetric memory with a specified alignment.
+}
+
+\begin{apidefinition}
+
+\begin{Csynopsis}
+void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
+\end{Csynopsis}
+
+\begin{apiarguments}
+  \apiargument{IN}{alignment}{Byte alignment of the block allocated from the
+    symmetric heap.}
+  \apiargument{IN}{size}{The size, in bytes, of a block to be
+    allocated from the symmetric heap.}
+\end{apiarguments}
+
+
+\apidescription{
+  The \FUNC{shmem\_align} routine allocates a block in the symmetric
+  heap that has a byte alignment specified by the \VAR{alignment}
+  argument.  The value of \VAR{alignment} shall be a multiple of
+  \CONST{sizeof(void *)} that is also a power of two; otherwise, the
+  behavior is undefined.  When \VAR{size} is zero, the
+  \FUNC{shmem\_align} routine performs no action and returns a null
+  pointer; otherwise, \FUNC{shmem\_align} calls a barrier on exit.
+
+  The value of the \VAR{alignment} and \VAR{size} arguments must be
+  identical on all \acp{PE}; otherwise, the behavior is undefined.
+}
+
+\apireturnvalues{
+  The \FUNC{shmem\_align} routine returns an aligned symmetric address
+  whose value is a multiple of \VAR{alignment}; otherwise, it returns
+  a null pointer.
+}
+
+\end{apidefinition}

--- a/content/shmem_free.tex
+++ b/content/shmem_free.tex
@@ -1,0 +1,32 @@
+\apisummary{
+  Collectively deallocate symmetric memory.
+}
+
+\begin{apidefinition}
+
+\begin{Csynopsis}
+void @\FuncDecl{shmem\_free}@(void *ptr);
+\end{Csynopsis}
+
+\begin{apiarguments}
+  \apiargument{IN}{ptr}{Symmetric address of an object in the symmetric heap.}
+\end{apiarguments}
+
+\apidescription{
+  The \FUNC{shmem\_free} routine causes the block to which \VAR{ptr}
+  points to be deallocated, that is, made available for further
+  allocation.  If \VAR{ptr} is a null pointer, no action is performed;
+  otherwise, \FUNC{shmem\_free} calls a barrier on entry.
+  It is the user's responsibility to ensure that no communication
+  operations involving the given memory block are pending on other
+  communication contexts prior to calling \FUNC{shmem\_free}.
+
+  The value of the \VAR{ptr} argument must be identical on all
+  \acp{PE}; otherwise, the behavior is undefined.
+}
+
+\apireturnvalues{
+  None.
+}
+
+\end{apidefinition}

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -1,132 +1,36 @@
 \apisummary{
-    Collective symmetric heap memory management routines.
+  Collectively allocate symmetric memory.
 }
 
 \begin{apidefinition}
 
 \begin{Csynopsis}
 void *@\FuncDecl{shmem\_malloc}@(size_t size);
-void @\FuncDecl{shmem\_free}@(void *ptr);
-void *@\FuncDecl{shmem\_realloc}@(void *ptr, size_t size);
-void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
 \end{Csynopsis}
 
 \begin{apiarguments}
-    \apiargument{IN}{size}{The size, in bytes, of a block to be
-        allocated from the symmetric heap.}
-    \apiargument{IN}{ptr}{Symmetric address of an object in the symmetric heap.}
-    \apiargument{IN}{alignment}{Byte alignment of the block allocated from the
-        symmetric heap.}
+  \apiargument{IN}{size}{The size, in bytes, of a block to be
+    allocated from the symmetric heap.}
 \end{apiarguments}
 
 
 \apidescription{
-    The \FUNC{shmem\_malloc}, \FUNC{shmem\_free}, \FUNC{shmem\_realloc}, and
-    \FUNC{shmem\_align} routines are collective operations that require
-    participation by all \acp{PE} in the world team.
+  The \FUNC{shmem\_malloc} routine returns the symmetric address of a
+  block of at least \VAR{size} bytes, which shall be suitably aligned
+  so that it may be assigned to a pointer to any type of object.
+  This space is allocated from the symmetric heap (in contrast to
+  \FUNC{malloc}, which allocates from the private heap).
+  When \VAR{size} is zero, the \FUNC{shmem\_malloc} routine performs
+  no action and returns a null pointer; otherwise,
+  \FUNC{shmem\_malloc} calls a barrier on exit.
 
-    The \FUNC{shmem\_malloc} routine returns the symmetric address of a block of at least
-    \VAR{size} bytes, which shall be suitably aligned so that it may be
-    assigned to a pointer to any type of object.  This space is allocated from
-    the symmetric heap (in contrast to \FUNC{malloc}, which allocates from the
-    private heap).  When \VAR{size} is zero, the \FUNC{shmem\_malloc} routine
-    performs no action and returns a null pointer.
-    
-    The \FUNC{shmem\_align} routine allocates a block in the symmetric heap that has
-    a byte alignment specified by the \VAR{alignment} argument.  The value of
-    \VAR{alignment} shall be a multiple of \CONST{sizeof(void *)} that is also
-    a power of two.  Otherwise, the behavior is undefined.  When \VAR{size} is
-    zero, the \FUNC{shmem\_align} routine performs no action and returns a null
-    pointer.
-    
-    The \FUNC{shmem\_free} routine causes the block to which \VAR{ptr} points to be
-    deallocated, that is, made available for further allocation.  If \VAR{ptr} is a
-    null pointer, no action is performed.
-           
-    The \FUNC{shmem\_realloc} routine changes the size of the block to which
-    \VAR{ptr} points to the size (in bytes) specified by \VAR{size}.  The contents
-    of the block are unchanged up to the lesser of the new and old sizes.
-	The \FUNC{shmem\_realloc} routine preserves allocation hints (e.g., if \VAR{ptr}
-	was allocated by \FUNC{shmem\_malloc\_with\_hints}).
-	If the new size is larger, the newly allocated portion of the block is
-    uninitialized.  If \VAR{ptr} is a null pointer, the
-    \FUNC{shmem\_realloc} routine behaves like the \FUNC{shmem\_malloc} routine for
-    the specified size.  If \VAR{size} is \CONST{0} and \VAR{ptr} is not a
-    null pointer, the block to which it points is freed. If the space cannot
-    be allocated or if hints cannot be preserved, the block to which \VAR{ptr}
-	points is unchanged.
-    
-    The \FUNC{shmem\_malloc}, \FUNC{shmem\_align}, \FUNC{shmem\_free}, and \FUNC{shmem\_realloc} routines
-    are provided  so that multiple \acp{PE} in a program can allocate symmetric,
-    remotely accessible memory blocks.  These memory blocks can then be used with
-    \openshmem communication routines.  When no action is performed, these
-    routines return without performing a barrier.
-    Otherwise, each of these routines includes at least one
-    call to a procedure that is semantically equivalent to \FUNC{shmem\_barrier\_all}:
-    \FUNC{shmem\_malloc} and \FUNC{shmem\_align} call a
-    barrier on exit; \FUNC{shmem\_free} calls a barrier on entry; and
-    \FUNC{shmem\_realloc} may call barriers on both entry and exit, depending on
-    whether an existing allocation is modified and whether new memory is allocated, respectively.
-    This ensures that all
-    \acp{PE} participate in the memory allocation, and that the memory on other
-    \acp{PE} can be used as soon as the local \ac{PE} returns.
-    The implicit barriers performed by these routines quiet the
-    default context.  It is the user's responsibility to ensure that no
-    communication operations involving the given memory block are pending on
-    other contexts prior to calling
-    the \FUNC{shmem\_free} and \FUNC{shmem\_realloc} routines.
-    The user is also
-    responsible for calling these routines with identical argument(s) on all
-    \acp{PE}; if differing \VAR{ptr}, \VAR{size}, or \VAR{alignment} arguments are used, the behavior of the call
-    and any subsequent \openshmem calls is undefined.
+  The value of the \VAR{size} argument must be identical on all
+  \acp{PE}; otherwise, the behavior is undefined.
 }
 
 \apireturnvalues{
-    The \FUNC{shmem\_malloc} routine returns the symmetric address of the allocated space;
-    otherwise, it returns a null pointer.
-    
-    The \FUNC{shmem\_free} routine returns no value.
-    
-    The \FUNC{shmem\_realloc} routine returns the symmetric address of the allocated space
-    (which may have moved); otherwise, all \acp{PE} return a null pointer.
-    
-    The \FUNC{shmem\_align} routine returns an aligned symmetric address whose value is a
-    multiple of \VAR{alignment}; otherwise, it returns a null pointer.
-}
-
-\apinotes{ 
-    As of \openshmem[1.2] the use of \FUNC{shmalloc}, \FUNC{shmemalign},
-    \FUNC{shfree},  and \FUNC{shrealloc} has been deprecated. Although \openshmem
-    libraries are required to support the calls, users are encouraged to use
-    \FUNC{shmem\_malloc}, \FUNC{shmem\_align}, \FUNC{shmem\_free}, and
-    \FUNC{shmem\_realloc} instead.  The behavior and signature  of the routines
-    remains unchanged from the deprecated versions.
-    					 
-    The total size of the symmetric heap is determined at job startup.  One can
-    specify the size of the heap using the \ENVVAR{SHMEM\_SYMMETRIC\_SIZE} environment
-    variable (where available).	
-    
-    The \FUNC{shmem\_malloc}, \FUNC{shmem\_free}, and \FUNC{shmem\_realloc} routines
-    differ from the private heap allocation routines in that all \acp{PE} in a
-    program must call them (a barrier is used to ensure this).
-
-    When the \VAR{ptr} argument in a call to \FUNC{shmem\_realloc} corresponds
-    to a buffer allocated using \FUNC{shmem\_align}, the buffer returned by
-    \FUNC{shmem\_realloc} is not guaranteed to maintain the alignment requested
-    in the original call to \FUNC{shmem\_align}.
-}
-
-\apiimpnotes{
-    The symmetric heap allocation routines always return the symmetric addresses of corresponding
-    symmetric objects across all \acp{PE}. The \openshmem specification does not
-    require that the virtual addresses are equal across all \acp{PE}. Nevertheless,
-    the implementation must avoid costly address translation operations in the
-    communication path, including $O(N)$ memory translation tables,
-    where $N$ is the number of \acp{PE}.  In order to avoid address translations, the
-    implementation may re-map the allocated block of memory based on agreed virtual
-    address.  Additionally, some operating systems provide an option to disable
-    virtual address randomization, which enables predictable allocation of virtual
-    memory addresses.
+  The \FUNC{shmem\_malloc} routine returns the symmetric address of
+  the allocated space; otherwise, it returns a null pointer.
 }
 
 \end{apidefinition}

--- a/content/shmem_realloc.tex
+++ b/content/shmem_realloc.tex
@@ -1,0 +1,59 @@
+\apisummary{
+  Collectively resize an allocation of symmetric memory.
+}
+
+\begin{apidefinition}
+
+\begin{Csynopsis}
+void *@\FuncDecl{shmem\_realloc}@(void *ptr, size_t size);
+\end{Csynopsis}
+
+\begin{apiarguments}
+  \apiargument{IN}{ptr}{Symmetric address of an object in the symmetric heap.}
+  \apiargument{IN}{size}{The size, in bytes, of a block to be
+    allocated from the symmetric heap.}
+\end{apiarguments}
+
+
+\apidescription{
+  The \FUNC{shmem\_realloc} routine changes the size of the block to
+  which \VAR{ptr} points to the size (in bytes) specified by
+  \VAR{size}.  The contents of the block are unchanged up to the
+  lesser of the new and old sizes.
+
+  The \FUNC{shmem\_realloc} routine preserves allocation hints (e.g.,
+  if \VAR{ptr} was allocated by \FUNC{shmem\_malloc\_with\_hints}).
+  If the new size is larger, the newly allocated portion of the block
+  is uninitialized.  If \VAR{ptr} is a null pointer, the
+  \FUNC{shmem\_realloc} routine behaves like the \FUNC{shmem\_malloc}
+  routine for the specified size.  If \VAR{size} is \CONST{0} and
+  \VAR{ptr} is not a null pointer, the block to which it points is
+  freed as if with \FUNC{shmem\_free}. If the space cannot be
+  allocated or if hints cannot be preserved, the block to which
+  \VAR{ptr} points is unchanged and a null pointer is returned.
+
+  \FUNC{shmem\_realloc} may call barriers on both entry and exit,
+  depending on whether an existing allocation is modified and whether
+  new memory is allocated, respectively.
+  It is the user's responsibility to ensure that no communication
+  operations involving the given memory block are pending on other
+  communication contexts prior to calling \FUNC{shmem\_realloc}.
+
+  The value of the \VAR{ptr} and \VAR{size} arguments must be
+  identical on all \acp{PE}; otherwise, the behavior is undefined.
+}
+
+\apireturnvalues{
+  The \FUNC{shmem\_realloc} routine returns the symmetric address of
+  the allocated space (which may have moved); otherwise, all \acp{PE}
+  return a null pointer.
+}
+
+\apinotes{
+  When the \VAR{ptr} argument in a call to \FUNC{shmem\_realloc} corresponds
+  to a buffer allocated using \FUNC{shmem\_align}, the buffer returned by
+  \FUNC{shmem\_realloc} is not guaranteed to maintain the alignment requested
+  in the original call to \FUNC{shmem\_align}.
+}
+
+\end{apidefinition}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -95,13 +95,19 @@ environment of the \acp{PE}.
 
 \subsection{Memory Management Routines}
 \label{sec:memory_management}
+\input{content/memmgmt_intro.tex}
 
-\openshmem provides a set of \acp{API} for managing the symmetric heap. The
-\acp{API} allow one to dynamically allocate, deallocate, reallocate and align
-symmetric data objects in the symmetric heap.
-
-\subsubsection{\textbf{SHMEM\_MALLOC, SHMEM\_FREE, SHMEM\_REALLOC, SHMEM\_ALIGN}}\label{subsec:shfree}
+\subsubsection{\textbf{SHMEM\_MALLOC}}\label{subsec:shmem_malloc}
 \input{content/shmem_malloc.tex}
+
+\subsubsection{\textbf{SHMEM\_FREE}}\label{subsec:shmem_free}
+\input{content/shmem_free.tex}
+
+\subsubsection{\textbf{SHMEM\_REALLOC}}\label{subsec:shmem_realloc}
+\input{content/shmem_realloc.tex}
+
+\subsubsection{\textbf{SHMEM\_ALIGN}}\label{subsec:shmem_align}
+\input{content/shmem_align.tex}
 
 \subsubsection{\textbf{SHMEM\_MALLOC\_WITH\_HINTS}}\label{subsec:shmmallochint}
 \input{content/shmem_malloc_hints.tex}


### PR DESCRIPTION
This PR moves the combined entries of `shmem_{malloc, free, align, realloc}` into separate API entries for each. It also expands on the memory management introduction with text common across all four routines.

No semantic changes are intended. The git diff may not be very helpful. Comparing PDFs is probably the best approach.

Closes #212 