### PR TITLE
Specify interoperability with fork and subprocess creation

### DIFF
--- a/content/interoperability.tex
+++ b/content/interoperability.tex
@@ -7,6 +7,39 @@ clarification of undefined behaviors caused by mixed use of different models,
 and advice to \openshmem library users and developers that may improve the portability
 and performance of hybrid programs.
 
+\section{Subprocesses}
+
+In some cases, an \openshmem application may be used to create or
+orchestrate other processes, which can be created through a number of
+system-level interfaces.  In these instances, such subprocesses are
+subject to the following interoperability constraints.
+
+On platforms that provide the referenced POSIX\footnotemark[1] \acp{API}:
+
+\footnotetext[1]{POSIX, the Portable Operating System Interface, is
+  formally specified in IEEE Std 1003.1-2017 and The Open Group
+  Technical Standard Base Specifications, Issue 7.}
+
+\begin{itemize}
+\item When \FUNC{fork} is invoked before the \openshmem library is
+  initialized, only one of either the parent or child processes may
+  initialize the \openshmem library.
+\item When \FUNC{fork} is invoked within the \openshmem portion of the
+  program or after the \openshmem library has been finalized, the
+  newly created child process shall not call any \openshmem routines;
+  otherwise, the behavior is undefined.
+\item Not all \openshmem implementations may support the use of
+  \FUNC{fork} during or after the \openshmem portion of a
+  program. When subprocess creation is needed in these instances, the
+  application is encouraged to make use of the \FUNC{posix\_spawn} and
+  \FUNC{posix\_spawnp} \acp{API}.
+\end{itemize}
+
+\parimpnotes{
+  All \openshmem implementations should ensure interoperability with
+  the \FUNC{posix\_spawn} and \FUNC{posix\_spawnp} \acp{API}.
+}
+
 
 \section{MPI Interoperability}
 


### PR DESCRIPTION
This PR specifies interoperability with `fork` and subprocess creation via `posix_spawn`.

Feedback is very much requested.

Closes #223 