### PR TITLE
In reductions, src and dest must be same at all PEs

### DIFF
--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -283,6 +283,8 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     provides one element for each reduction.  The results of the reductions are placed in the
     \dest{} array on all \acp{PE} participating in the reduction.
 
+    The same \source{} and \dest{} arrays must be passed by all PEs that
+    participate in the collective.
     The \source{} and \dest{} arguments must either be the same symmetric
     address, or two different symmetric addresses corresponding to buffers that
     do not overlap in memory. That is, they must be completely overlapping or

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -287,7 +287,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     participate in the collective.
     The \source{} and \dest{} arguments must either be the same symmetric
     address, or two different symmetric addresses corresponding to buffers that
-    do not overlap in memory. That is, they must be completely overlapping or
+    do not overlap in memory. That is, they must be completely overlapping (sometimes referred to as an ``in place'' reduction) or
     completely disjoint.
 
     Team-based reduction routines operate over all \acp{PE} in the provided team argument. All


### PR DESCRIPTION
In OpenSHMEM 1.4, we required that the `source` and `dest` pointers correspond to the same symmetric object:

> The same dest and source arrays, and the same pWrk and pSync work arrays, must be passed to all PEs in the active set.

However, we lost this text in OpenSHMEM 1.5. This PR adds it back.