### PR TITLE
Clarify fence orders only within same context

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -660,6 +660,10 @@ Major changes in \openshmem[1.6] include the addition of a new
 The following list describes the specific changes in \openshmem[1.6]:
 \begin{itemize}
 %
+\item Clarified that \OPR{Fence} operations only guarantee ordering for
+    operations that are performed on the same context.
+\ChangelogRef{subsec:shmem_fence}%
+%
 \item Added a team-based pointer query routine:
   \FUNC{shmem\_team\_ptr}.
 \ChangelogRef{subsec:shmem_team_ptr}%

--- a/content/shmem_fence.tex
+++ b/content/shmem_fence.tex
@@ -24,7 +24,7 @@ void @\FuncDecl{shmem\_ctx\_fence}@(shmem_ctx_t ctx);
     \ac{PE} on the given context prior
     to the call to \FUNC{shmem\_fence} are guaranteed to be delivered before any
     subsequent operations on symmetric data
-    objects to the same \ac{PE}. \FUNC{shmem\_fence} guarantees order of delivery,
+    objects to the same \ac{PE} on the same context. \FUNC{shmem\_fence} guarantees order of delivery,
     not completion. It does not guarantee order of delivery of nonblocking
     \GET{} or values fetched by nonblocking \ac{AMO} routines.
     If \VAR{ctx} has the value \CONST{SHMEM\_CTX\_INVALID}, no operation is


### PR DESCRIPTION
Clarify that Fence operations only guarantee ordering for operations that are performed on the same context.