### PR TITLE
 Update/Deprecate Active-set-based Language

### DIFF
--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -1,7 +1,7 @@
 \emph{Collective routines} are defined as coordinated communication or synchronization
 operations performed by a group of \acp{PE}.
 
-\openshmem provides three types of collective routines:
+\openshmem provides four types of collective routines:
 
 \begin{enumerate}
 \item Collective routines that operate on teams use a team handle parameter to determine
@@ -11,9 +11,12 @@ operations performed by a group of \acp{PE}.
 \begin{DeprecateBlock}
 \item Collective routines that operate on active sets use a set of parameters to determine
   which \acp{PE} will participate and what resources are used to perform operations.
+
+\item  Collective routines that do not accept an active set
+  parameters and, as required, the default context.
 \end{DeprecateBlock}
 
-\item Collective routines that accept neither team nor active set
+\item Collective routines that do not accept team
   parameters, which implicitly operate on the world team and, as
   required, the default context.
 \end{enumerate}

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -144,7 +144,7 @@ An overview of the \openshmem routines is described below:
       data object on another symmetric data object.
   \item \OPR{All-to-All}: All \acp{PE} participating in the routine exchange
       a fixed amount of contiguous or strided data with all other \acp{PE}
-      in the active set.
+      in the team.
 \end{enumerate}
 
 \item \textbf{Mutual Exclusion}

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -131,6 +131,7 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
 
     Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine,
     the following conditions must be ensured:
+
     \begin{itemize}
     	\item The \VAR{dest} data object on all \acp{PE} in the active set is
     	ready to accept the \FUNC{shmem\_alltoall} data.
@@ -138,6 +139,7 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
     	on all \acp{PE} in the active set is not still in use from a prior call
     	to a \FUNC{shmem\_alltoall} routine.
     \end{itemize}
+
     Otherwise, the behavior is undefined.
 
     Upon return from a \FUNC{shmem\_alltoall} routine, the following is true for

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -35,10 +35,10 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
 
 \apiargument{OUT}{dest}{Symmetric address of a data object large enough to receive
     the combined total of \VAR{nelems} elements from each \ac{PE} in the
-    active set.
+    particpating \acp{PE}.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{source}{Symmetric address of a data object that contains \VAR{nelems}
-    elements of data for each \ac{PE} in the active set, ordered according to
+    elements of data for each \ac{PE} in the participating \acp{PE}, ordered according to
     destination \ac{PE}.
     The type of \source{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{nelems}{
@@ -100,6 +100,21 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
+    Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine,
+    the following conditions must be ensured:
+    \begin{itemize}
+    	\item The \VAR{dest} data object on all \acp{PE} in the team is
+    	ready to accept the \FUNC{shmem\_alltoall} data.
+	\end{itemize}
+
+    Upon return from a \FUNC{shmem\_alltoall} routine, the following is true for
+    the local PE:
+    \begin{itemize}
+	    \item Its \VAR{dest} symmetric data object is completely updated and the 
+		data has been copied out of the source data object.
+	\end{itemize}
+
+\begin{DeprecateBlock}
     Active-set-based collective routines operate over all \acp{PE} in the active set
     defined by the \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet.
 
@@ -117,22 +132,23 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
     Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine,
     the following conditions must be ensured:
     \begin{itemize}
-    \item The \VAR{dest} data object on all \acp{PE} in the active set is
-      ready to accept the \FUNC{shmem\_alltoall} data.
-    \item For active-set-based routines, the \VAR{pSync} array
-    on all \acp{PE} in the active set is not still in use from a prior call
-    to a \FUNC{shmem\_alltoall} routine.
+    	\item The \VAR{dest} data object on all \acp{PE} in the active set is
+    	ready to accept the \FUNC{shmem\_alltoall} data.
+    	\item For active-set-based routines, the \VAR{pSync} array
+    	on all \acp{PE} in the active set is not still in use from a prior call
+    	to a \FUNC{shmem\_alltoall} routine.
     \end{itemize}
     Otherwise, the behavior is undefined.
 
     Upon return from a \FUNC{shmem\_alltoall} routine, the following is true for
     the local PE:
     \begin{itemize}
-    \item Its \VAR{dest} symmetric data object is completely updated and
-    the data has been copied out of the \VAR{source} data object.
-    \item For active-set-based routines,
-    the values in the \VAR{pSync} array are restored to the original values.
+	    \item Its \VAR{dest} symmetric data object is completely updated and the 
+		data has been copied out of the source data object.
+    	\item For active-set-based routines,
+    	the values in the \VAR{pSync} array are restored to the original values.
     \end{itemize}
+\end{DeprecateBlock}
 }
 
 \apireturnvalues{

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -35,10 +35,10 @@ void @\FuncDecl{shmem\_alltoalls64}@(void *dest, const void *source, ptrdiff_t d
 
 \apiargument{OUT}{dest}{Symmetric address of a data object large enough to receive 
     the combined total of \VAR{nelems} elements from each \ac{PE} in the
-    active set.
+    participating \acp{PE}.
     The type of \dest{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{source}{Symmetric address of a data object that contains \VAR{nelems}
-    elements of data for each \ac{PE} in the active set, ordered according to
+    elements of data for each \ac{PE} in the participating \acp{PE}, ordered according to
     destination \ac{PE}.
     The type of \source{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -45,7 +45,7 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
   respectively.
 }
 \apiargument{IN}{PE\_root}{Zero-based ordinal of the \ac{PE}, with respect to
-    the team or active set, from which the data is copied.}
+    the calling PEs, from which the data is copied.}
 
 \begin{DeprecateBlock}
 
@@ -61,8 +61,7 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
 \end{apiarguments}
 
 \apidescription{   
-    \openshmem broadcast routines are collective routines over an active set or
-    valid \openshmem team.
+    \openshmem team-based broadcast routines are collective routines over a valid \openshmem team.
     They copy the \source{} data object on the \ac{PE} specified by
     \VAR{PE\_root} to the \dest{} data object on the \acp{PE}
     participating in the collective operation.
@@ -75,6 +74,9 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
     \item The \dest{} object is updated on all \acp{PE}.
     \item All \acp{PE} in the \VAR{team} argument must participate in
       the operation.
+    \item Only \acp{PE} in the team  may call the routine.  If a
+      \ac{PE} not in the team calls a team-based
+      collective routine, the behavior is undefined.
     \item If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
       otherwise invalid, the behavior is undefined.
     \item \ac{PE} numbering is relative to the team. The specified
@@ -82,12 +84,34 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
       between \CONST{0} and \VAR{N$-$1}, where \VAR{N} is the size of
       the team.
     \end{itemize}
+
+    Before any \ac{PE} calls a broadcast routine, the following
+    conditions must be ensured:
+    \begin{itemize}
+    \item The \dest{} array on all \acp{PE} participating in the broadcast
+      is ready to accept the broadcast data.
+	\end{itemize}
+    Otherwise, the behavior is undefined. 
+
+	Upon return from a team-based broadcast routine, the following are true for the local
+    \ac{PE}:
+    \begin{itemize}
+    \item The \dest{} data object is updated.
+    \item The \source{} data object may be safely reused.
+	\end{itemize}
     
 \begin{DeprecateBlock}
+    \openshmem active-set broadcast routines are collective routines over an active set. 
+    They copy the \source{} data object on the \ac{PE} specified by
+    \VAR{PE\_root} to the \dest{} data object on the \acp{PE}
+    participating in the collective operation.
+    The same \dest{} and \source{} data objects and the same value of
+    \VAR{PE\_root} must be passed by all \acp{PE} participating in the
+    collective operation.
+
     For active-set-based broadcasts:
     \begin{itemize}
-    \item The \dest{} object is updated on all \acp{PE} other than the
-      root \ac{PE}.
+	\item The \VAR{dest} object is updated on all PEs other than the root PE.
     \item All \acp{PE} in the active set defined by the
       \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet
       must participate in the operation.
@@ -103,31 +127,24 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
       in the active set.
     \end{itemize}
 
-    Before any \ac{PE} calls a broadcast routine, the following
+    Before any \ac{PE} calls a active-set-based broadcast routine, the following
     conditions must be ensured:
     \begin{itemize}
     \item The \dest{} array on all \acp{PE} participating in the broadcast
       is ready to accept the broadcast data.
-    \item For active-set-based broadcasts, the
-      \VAR{pSync} array on all \acp{PE} in the
+    \item The \VAR{pSync} array on all \acp{PE} in the
       active set is not still in use from a prior call to an \openshmem
       collective routine.
     \end{itemize}
-    Otherwise, the behavior is undefined.
+    Otherwise, the behavior is undefined. 
 
-    Upon return from a broadcast routine, the following are true for the local
+	Upon return from a active-based broadcast routine, the following are true for the local
     \ac{PE}:
     \begin{itemize}
-    \item For team-based broadcasts, the \dest{} data object is
-      updated.
-    \item For active-set-based broadcasts:
-      \begin{itemize}
-      \item If the current \ac{PE} is not the root \ac{PE}, the
-        \dest{} data object is updated.
+      \item If the current PE is not the root PE, the \dest{} data object is updated.
+      \item The \source{} data object may be safely reused.
       \item The values in the \VAR{pSync} array are restored to the
         original values.
-      \end{itemize}
-    \item The \source{} data object may be safely reused.
     \end{itemize}
 \end{DeprecateBlock}
 }

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -83,6 +83,7 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
       the team.
     \end{itemize}
     
+\begin{DeprecateBlock}
     For active-set-based broadcasts:
     \begin{itemize}
     \item The \dest{} object is updated on all \acp{PE} other than the
@@ -128,13 +129,17 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
       \end{itemize}
     \item The \source{} data object may be safely reused.
     \end{itemize}
+\end{DeprecateBlock}
 }
 
 
 \apireturnvalues{
   For team-based broadcasts, zero on successful local completion; otherwise, nonzero.
 
+\begin{DeprecateBlock}
   For active-set-based broadcasts, none.
+\end{DeprecateBlock}
+
 }
 
 \apinotes{

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -70,9 +70,7 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     in processor number order. The resultant \dest{} array contains the contribution from
     \acp{PE} as follows:
     
-    \begin{itemize}
-    \item For an active set, the data from \ac{PE} \VAR{PE\_start} is first, then the
-    contribution from \ac{PE} \VAR{PE\_start} + \VAR{PE\_stride} second, and so on.
+	\begin{itemize}
     \item For a team, the data from \ac{PE} number \CONST{0} in the team is first, then the
     contribution from \ac{PE} \CONST{1} in the team, and so on.
     \end{itemize}
@@ -91,6 +89,25 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     otherwise invalid, the behavior is undefined.
 
 \begin{DeprecateBlock}
+    \openshmem \FUNC{collect} and \FUNC{fcollect} routines perform a collective
+    operation to concatenate \VAR{nelems}
+    data items from the \source{} array into the
+    \dest{} array, over an \openshmem active set
+    in processor number order. The resultant \dest{} array contains the contribution from
+	\acp{PE} as follows:
+    \begin{itemize}
+   		 \item For an active set, the data from \ac{PE} \VAR{PE\_start} is first, then the
+   		 contribution from \ac{PE} \VAR{PE\_start} + \VAR{PE\_stride} second, and so on.
+   	\end{itemize}
+
+    The collected result is written to the \dest{} array for all \acp{PE}
+    that participate in the operation. The same \dest{} and \source{}
+    arrays must be passed by all \acp{PE} that participate in the operation.
+    
+    The \FUNC{fcollect} routines require that \VAR{nelems} be the same value in all
+    participating \acp{PE}, while the \FUNC{collect} routines allow \VAR{nelems} to
+    vary from \ac{PE} to \ac{PE}.
+
     Active-set-based collective routines operate over all \acp{PE} in the active set
     defined by the \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet.
     As with all active-set-based collective routines,

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -90,6 +90,7 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
+\begin{DeprecateBlock}
     Active-set-based collective routines operate over all \acp{PE} in the active set
     defined by the \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet.
     As with all active-set-based collective routines,
@@ -108,6 +109,7 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     \item For active-set-based collective routines, the values in the \VAR{pSync} array are
     restored to the original values.
     \end{itemize}
+\end{DeprecateBlock}
 }
 
 \apireturnvalues{
@@ -115,9 +117,15 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
 }
 
 \apinotes{
+\begin{DeprecateBlock}
     The collective routines operate on active \ac{PE} sets that have a
     non-power-of-two \VAR{PE\_size} with some performance degradation.  They operate
     with no performance degradation when \VAR{nelems} is a non-power-of-two value.
+\end{DeprecateBlock}
+    The collective routines that operate on teams containing a
+    non-power-of-two of PEs do so with some performance degradation. They operate
+    with no performance degradation when \VAR{nelems} is a non-power-of-two value.
+
 }
 
 \begin{apiexamples}

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -66,8 +66,8 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     \openshmem \FUNC{collect} and \FUNC{fcollect} routines perform a collective
     operation to concatenate \VAR{nelems}
     data items from the \source{} array into the
-    \dest{} array, over an \openshmem team or active set
-    in processor number order. The resultant \dest{} array contains the contribution from
+    \dest{} array, over an \openshmem team in processor number order. 
+	The resultant \dest{} array contains the contribution from
     \acp{PE} as follows:
     
 	\begin{itemize}

--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -57,19 +57,15 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
     \tabularnewline \hline
     \endhead
     %%
-    \newline
     \CONST{0} &
-    \newline
     Behavior same as \FUNC{shmem\_malloc}
     \tabularnewline \hline
 
     \LibConstDecl{SHMEM\_MALLOC\_ATOMICS\_REMOTE} &
-    \newline 
     Memory used for \VAR{atomic} operations
     \tabularnewline \hline
 
     \LibConstDecl{SHMEM\_MALLOC\_SIGNAL\_REMOTE} &
-    \newline
     Memory used for \VAR{signal} operations
     \tabularnewline \hline
 

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -251,12 +251,14 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 \apiargument{IN}{source}{Symmetric address of an array, of length \VAR{nreduce} elements, that
     contains one element for each separate reduction routine.
     The type of \source{} should match that implied in the SYNOPSIS section.}
-\apiargument{IN}{nreduce}{The number of elements in the \dest{} and \source{}
-    arrays. In teams based \ac{API} calls, \VAR{nreduce} must be of type size\_t.
+\apiargument{IN}{nreduce}{the number of elements in the \dest{} and \source{}
+    arrays. in teams based \ac{API} calls, \VAR{nreduce} must be of type size\_t.
     In deprecated active-set based \ac{API} calls,
     \VAR{nreduce} must be of type integer.}
 
 \begin{DeprecateBlock}
+\apiargument{IN}{nreduce}{In active-set based \ac{API} calls,
+    \VAR{nreduce} must be of type integer.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between consecutive
@@ -273,7 +275,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 \end{apiarguments}
 
 \apidescription{
-    \openshmem reduction routines are collective routines over an active set or
+    \openshmem reduction routines are collective routines over an
     existing \openshmem team that compute one or more reductions across symmetric
     arrays on multiple \acp{PE}.  A reduction performs an associative binary routine
     across a set of values.
@@ -294,6 +296,37 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     \acp{PE} in the provided team must participate in the reduction.
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
+
+    Before any \ac{PE} calls a reduction routine, the following conditions must be ensured:
+    \begin{itemize}
+    \item The \dest{} array on all \acp{PE} participating in the reduction
+      is ready to accept the results of the \OPR{reduction}.
+    \end{itemize}
+    Otherwise, the behavior is undefined.
+    
+    Upon return from a reduction routine, the following are true for the local
+    \ac{PE}:
+    \begin{itemize}
+    \item The \dest{} array is updated and the \source{} array may be safely reused.
+    \end{itemize}
+
+\begin{DeprecateBlock}
+    \openshmem reduction routines are collective routines over an active set 
+	that compute one or more reductions across symmetric
+    arrays on multiple \acp{PE}.  A reduction performs an associative binary routine
+    across a set of values.
+
+    The \VAR{nreduce} argument determines the number of separate reductions to
+    perform.  The \source{} array on all \acp{PE} participating in the reduction
+    provides one element for each reduction.  The results of the reductions are placed in the
+    \dest{} array on all \acp{PE} participating in the reduction.
+
+    The same \source{} and \dest{} arrays must be passed by all PEs that
+    participate in the collective.
+    The \source{} and \dest{} arguments must either be the same symmetric
+    address, or two different symmetric addresses corresponding to buffers that
+    do not overlap in memory. That is, they must be completely overlapping (sometimes referred to as an ``in place'' reduction) or
+    completely disjoint.
 
     Active-set-based sync routines operate over all \acp{PE} in the active set
     defined by the \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet.
@@ -327,6 +360,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     \item If using active-set-based routines,
     the values in the \VAR{pSync} array are restored to the original values.
     \end{itemize}
+\end{DeprecateBlock}
 
     The complex-typed interfaces are only provided for sum and product reductions.
     When the \Cstd translation environment does not support complex types

--- a/content/shmem_sync.tex
+++ b/content/shmem_sync.tex
@@ -38,18 +38,27 @@ void @\FuncDecl{shmem\_sync}@(int PE_start, int logPE_stride, int PE_size, long 
 
 \apidescription{
     \FUNC{shmem\_sync} is a collective synchronization routine over an
-    existing \openshmem team or active set.
+    existing \openshmem team.
 
     The routine registers the arrival of a \ac{PE} at a synchronization point in the program.
     This is a fast mechanism for synchronizing all \acp{PE} that participate in this
     collective call. The routine blocks the calling \ac{PE} until all \acp{PE} in the
-    specified team or active set have called \FUNC{shmem\_sync}. In a multithreaded \openshmem
+    specified team have called \FUNC{shmem\_sync}. In a multithreaded \openshmem
     program, only the calling thread is blocked.
 
     Team-based sync routines operate over all \acp{PE} in the provided team argument. All
     \acp{PE} in the provided team must participate in the sync operation.
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
+
+\begin{DeprecateBlock}
+    \FUNC{shmem\_sync} is a collective synchronization routine over an active set.
+
+    The routine registers the arrival of a \ac{PE} at a synchronization point in the program.
+    This is a fast mechanism for synchronizing all \acp{PE} that participate in this
+    collective call. The routine blocks the calling \ac{PE} until all \acp{PE} in the
+    active set have called \FUNC{shmem\_sync}. In a multithreaded \openshmem
+    program, only the calling thread is blocked.
 
     Active-set-based sync routines operate over all \acp{PE} in the active set
     defined by the \VAR{PE\_start}, \VAR{logPE\_stride}, \VAR{PE\_size} triplet.
@@ -64,12 +73,14 @@ void @\FuncDecl{shmem\_sync}@(int PE_start, int logPE_stride, int PE_size, long 
     \VAR{PE\_size} must be equal on all \acp{PE} in the active set.  The same
     work array must be passed in \VAR{pSync} to all \acp{PE} in the active set.
 
+    The same \VAR{pSync} array may be reused on consecutive calls to
+    \FUNC{shmem\_sync} if the same active set is used.
+\end{DeprecateBlock}
+
     In contrast with the \FUNC{shmem\_barrier} routine, \FUNC{shmem\_sync} only
     ensures completion and visibility of previously issued memory stores and does not ensure
     completion of remote memory updates issued via \openshmem routines.
 
-    The same \VAR{pSync} array may be reused on consecutive calls to
-    \FUNC{shmem\_sync} if the same active set is used.
 }
 
 \apireturnvalues{

--- a/content/shmem_sync.tex
+++ b/content/shmem_sync.tex
@@ -1,7 +1,11 @@
 \apisummary{
     Registers the arrival of a \ac{PE} at a synchronization point.
     This routine does not return until all other \acp{PE} in a given OpenSHMEM team
-    or active set arrive at this synchronization point.
+    arrive at this synchronization point.
+\begin{DeprecateBlock}
+    Registers the arrival of a \ac{PE} at a synchronization point.
+    This routine does not return until all other \acp{PE} in a given OpenSHMEM active set arrive at this synchronization point.
+\end{DeprecateBlock}
 }
 
 \begin{apidefinition}
@@ -51,6 +55,10 @@ void @\FuncDecl{shmem\_sync}@(int PE_start, int logPE_stride, int PE_size, long 
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
+    In contrast with the \FUNC{shmem\_barrier} routine, \FUNC{shmem\_sync} only
+    ensures completion and visibility of previously issued memory stores and does not ensure
+    completion of remote memory updates issued via \openshmem routines.
+
 \begin{DeprecateBlock}
     \FUNC{shmem\_sync} is a collective synchronization routine over an active set.
 
@@ -77,9 +85,6 @@ void @\FuncDecl{shmem\_sync}@(int PE_start, int logPE_stride, int PE_size, long 
     \FUNC{shmem\_sync} if the same active set is used.
 \end{DeprecateBlock}
 
-    In contrast with the \FUNC{shmem\_barrier} routine, \FUNC{shmem\_sync} only
-    ensures completion and visibility of previously issued memory stores and does not ensure
-    completion of remote memory updates issued via \openshmem routines.
 
 }
 

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -97,10 +97,8 @@ behavior is undefined.
 
 \apinotes{
   The \FUNC{shmem\_team\_split\_strided} operation uses an arbitrary
-  \VAR{stride} argument, whereas the \VAR{logPE\_stride} argument to the
-  active set collective operations only permits strides that are a power of two.
-  Arbitrary strides allow a greater number of PE subsets to be expressed
-  and can support a broader range of usage models.
+  \VAR{stride} argument. Arbitrary strides allow a greater number of 
+  PE subsets to be expressed and can support a broader range of usage models.
 
   See the description of team handles and predefined teams in
   Section~\ref{subsec:team} for more information about team handle semantics and usage.

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -362,8 +362,7 @@
 \hfill
 \item[Return Values] \hfill \\
     #1
-\\
-\hfill
+\hfill \\
 }
 
 \newcommand{\apitablerow}[2]{


### PR DESCRIPTION
# Goal

Place all active set language in deprecated blocks. Since the 1.5 specification has been released, active set language has been deprecated. There are were elements of the documents that did not reflect this. With this update "deprecated" blocks can be removed and the teams based collectives can stand on their own with have active set language interleaved in them. This tackles issue #504. Some language is duplicated in the document, however it is within a deprecate block. No API changes are intended, just spec cosmetics.

# Changes


## Programing Model

- Updated programming model to have the Collective Communication `All-to-All` section reflect the shift to teams from active set.

## Collective Introduction

-  Added an additional item to the collective intro to separate active set and team collectives.

## Collective Operations

- Modified API arguments desciption from "each PEs in the active set" to "PEs in the participating PEs"
- Separated language in API description to contain a team based section and a now deprecated active set section. Some language is duplicated for ease of removal for later.
- Functions modified 'alltoall', `alltoalls`, `broadcast`, `collect/fcollect`, `sync`, `reductions`

## Team Split Strided

- The notes for `shmem_team_split_strided` had a reference to active set language, where strided must be a power of two for the now deprecated active base language.

## Tex Formatting

- `shmem_malloc_with_hints` table had a breaking \newline within it. Could not compile the document with the lines in it. Removal had no consequences seen by the author.
- Fixed formatting issue in `Return Values` function that prevented a `DeprecateBlock` to be used with in the `Return Values` environment. This was needed for `shmem_collect`, which changed its return value with team based collectives.