### PR TITLE
Suggested v1.6 doc-edits throughout the spec

### DIFF
--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -19,7 +19,7 @@ operations performed by a group of \acp{PE}.
 \end{enumerate}
 
 Concurrent accesses to symmetric memory by an \openshmem collective
-routine and any other means of access---where at least one updates the
+routine and any other means of access---where at least one PE updates the
 symmetric memory---results in undefined behavior.
 Since \acp{PE} can enter and exit collectives at different times,
 accessing such memory remotely may require additional synchronization.

--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -19,7 +19,7 @@ operations performed by a group of \acp{PE}.
 \end{enumerate}
 
 Concurrent accesses to symmetric memory by an \openshmem collective
-routine and any other means of access---where at least one PE updates the
+routine and any other means of access---where at least one \ac{PE} updates the
 symmetric memory---results in undefined behavior.
 Since \acp{PE} can enter and exit collectives at different times,
 accessing such memory remotely may require additional synchronization.

--- a/content/memmgmt_intro.tex
+++ b/content/memmgmt_intro.tex
@@ -3,7 +3,7 @@
 symmetric data objects in the symmetric heap.
 
 The symmetric memory allocation routines differ from the private heap
-allocation routines in that they must be called by all \acp{PE} in a
+allocation routines in that they must be called by all \acp{PE} in
 the world team.  When specified, each of these routines includes at
 least one call to a procedure that is semantically equivalent to
 \FUNC{shmem\_barrier\_all}.  This ensures that all \acp{PE}

--- a/content/teams_intro.tex
+++ b/content/teams_intro.tex
@@ -21,7 +21,7 @@ All predefined teams are valid for the duration of the \openshmem
 portion of an application.
 Any team successfully created by a \FUNC{shmem\_team\_split\_*}
 routine is valid until it is destroyed.
-All valid teams have a least one member.
+All valid teams have at least one member.
 
 \subsubsection*{Team Handles}
 
@@ -84,7 +84,7 @@ is detailed further in Section~\ref{subsec:shmem_team_config_t}.
 
 \acp{PE} in a newly created team are consecutively numbered starting with
 \ac{PE} number 0. \acp{PE} are ordered by their \ac{PE} number in
-the parent team. Team relative \ac{PE}
+the parent team. Team-relative \ac{PE}
 numbers can be used for point-to-point operations through team-based
 contexts (see Section~\ref{sec:ctx}) or using the translation routine
 \FUNC{shmem\_team\_translate\_pe}.


### PR DESCRIPTION
## Summary of changes
This is a short list of typos (and a helpful hyphen) throughout the spec.
