### PR TITLE
Clarify memory managment routines are world-collective

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -697,6 +697,12 @@ The following list describes the specific changes in \openshmem[1.6]:
   functions from a single entry in \openshmem[1.5] into separate entries.
 \ChangelogRef{subsec:shmem_malloc, subsec:shmem_free, subsec:shmem_realloc,
   subsec:shmem_align}%
+%
+\item Clarified that the \FUNC{shmem\_\{malloc, free, realloc, align,
+    malloc\_with\_hints, calloc\}} functions are collective operations on
+    the world team.
+\ChangelogRef{subsec:shmem_malloc, subsec:shmem_free, subsec:shmem_realloc,
+  subsec:shmem_align, subsec:shmmallochint, subsec:shmem_calloc}%
 \item Corrected the level argument's recommended value in API notes for
     \FUNC{shmem\_pcontrol} to indicate that the value should be greater than
     2 to enable profiling with profile library defined effects and

--- a/content/shmem_align.tex
+++ b/content/shmem_align.tex
@@ -17,7 +17,8 @@ void *@\FuncDecl{shmem\_align}@(size_t alignment, size_t size);
 
 
 \apidescription{
-  The \FUNC{shmem\_align} routine allocates a block in the symmetric
+  The \FUNC{shmem\_align} routine is a collective operation on the
+  world team that allocates a block in the symmetric
   heap that has a byte alignment specified by the \VAR{alignment}
   argument.  The value of \VAR{alignment} shall be a multiple of
   \CONST{sizeof(void *)} that is also a power of two; otherwise, the

--- a/content/shmem_free.tex
+++ b/content/shmem_free.tex
@@ -13,7 +13,8 @@ void @\FuncDecl{shmem\_free}@(void *ptr);
 \end{apiarguments}
 
 \apidescription{
-  The \FUNC{shmem\_free} routine causes the block to which \VAR{ptr}
+  The \FUNC{shmem\_free} routine is a collective operation on the
+  world team that causes the block to which \VAR{ptr}
   points to be deallocated, that is, made available for further
   allocation.  If \VAR{ptr} is a null pointer, no action is performed;
   otherwise, \FUNC{shmem\_free} calls a barrier on entry.

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -15,7 +15,8 @@ void *@\FuncDecl{shmem\_malloc}@(size_t size);
 
 
 \apidescription{
-  The \FUNC{shmem\_malloc} routine returns the symmetric address of a
+  The \FUNC{shmem\_malloc} routine is a collective operation on the
+  world team and returns the symmetric address of a
   block of at least \VAR{size} bytes, which shall be suitably aligned
   so that it may be assigned to a pointer to any type of object.
   This space is allocated from the symmetric heap (in contrast to

--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -18,7 +18,8 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
 
 \apidescription{
 
-    The \FUNC{shmem\_malloc\_with\_hints} routine, like \FUNC{shmem\_malloc}, returns a pointer to a block of at least
+    The \FUNC{shmem\_malloc\_with\_hints} routine, like \FUNC{shmem\_malloc},
+    is a collective operation on the world team that returns a pointer to a block of at least
     \VAR{size} bytes, which shall be suitably aligned so that it may be
     assigned to a pointer to any type of object.  This space is allocated from
     the symmetric heap (similar to \FUNC{shmem\_malloc}).  When the \VAR{size} is zero, 

--- a/content/shmem_realloc.tex
+++ b/content/shmem_realloc.tex
@@ -16,7 +16,8 @@ void *@\FuncDecl{shmem\_realloc}@(void *ptr, size_t size);
 
 
 \apidescription{
-  The \FUNC{shmem\_realloc} routine changes the size of the block to
+  The \FUNC{shmem\_realloc} routine is a collective operation on
+  the world team that changes the size of the block to
   which \VAR{ptr} points to the size (in bytes) specified by
   \VAR{size}.  The contents of the block are unchanged up to the
   lesser of the new and old sizes.


### PR DESCRIPTION
## Summary of changes
This clarifies that all memory management routines are collective on the world team.

These changes may not be strictly necessary (it seems to be covered in the `Memory Management Routines` intro), but might provide some explicit clarity for new users.
