### PR TITLE
Blocking fetching AMOs are unaffected by fence/quiet

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -703,6 +703,10 @@ The following list describes the specific changes in \openshmem[1.6]:
     additional arguments.
 \ChangelogRef{subsec:shmem_pcontrol}
 %
+\item Clarified in Table~\ref{mem-order} that only blocking non-fetching
+    \acs{AMO} are affected by \openshmem memory ordering routines.
+\ChangelogRef{subsec:memory_order}
+%
 \end{itemize}
 
 \section{Version 1.5}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -489,14 +489,15 @@ affected by \openshmem memory ordering routines.
   Memory Store \footnote{Ordering and/or delivery of memory store operations are
   ensured only on contexts created with certain options. For details, refer the
   description of context options in Section~\ref{subsec:shmem_ctx_create}.}
-                                     & X & X \\
-  Blocking \OPR{Put}                 & X & X \\
-  Blocking \OPR{Get}                 &   &   \\
-  Blocking \OPR{\acs{AMO}}           & X & X \\
-  Blocking \OPR{put-with-signal}     & X & X \\
-  Nonblocking \OPR{Put}              & X & X \\
-  Nonblocking \OPR{Get}              &   & X \\
-  Nonblocking \OPR{\acs{AMO}}        & X\footnote{\openshmem fence routines does
+                                        & X & X \\
+  Blocking \OPR{Put}                    & X & X \\
+  Blocking \OPR{Get}                    &   &   \\
+  Blocking Fetching \OPR{\acs{AMO}}     &   &   \\
+  Blocking Non-fetching \OPR{\acs{AMO}} & X & X \\
+  Blocking \OPR{put-with-signal}        & X & X \\
+  Nonblocking \OPR{Put}                 & X & X \\
+  Nonblocking \OPR{Get}                 &   & X \\
+  Nonblocking \OPR{\acs{AMO}}           & X\footnote{\openshmem fence routines does
   not guarantee order of delivery of values fetched by nonblocking \ac{AMO}
   routines.}
                                          & X \\


### PR DESCRIPTION
## Summary of changes
This clarifies that blocking fetching AMOs are unaffected by fence/quiet, but blocking non-fetching AMOs _are_ affected by fence/quiet.  Previously this was a bit unclear from Table 14 in OpenSHMEM v1.5.
