### PR TITLE
team_get_config: clarify config_mask == 0 and config == NULL cases

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -703,6 +703,10 @@ The following list describes the specific changes in \openshmem[1.6]:
     additional arguments.
 \ChangelogRef{subsec:shmem_pcontrol}
 %
+\item Clarified the behavior of \FUNC{shmem\_team\_get\_config} when the
+    \VAR{config\_mask} is 0 and/or the \VAR{config} argument is a null pointer.
+\ChangelogRef{subsec:shmem_team_get_config}
+%
 \end{itemize}
 
 \section{Version 1.5}

--- a/content/shmem_team_get_config.tex
+++ b/content/shmem_team_get_config.tex
@@ -25,6 +25,10 @@ to input configuration parameters when the team was created.
 If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID},
 then no operation is performed.
 If \VAR{team} is otherwise invalid, the behavior is undefined.
+If \VAR{config\_mask} is 0, then \VAR{shmem\_team\_get\_config} performs no action
+and \VAR{config} may or may not be a null pointer.
+If \VAR{config} is a null pointer, then \VAR{config\_mask} must be 0, otherwise
+the behavior is undefined.
 }
 
 \apireturnvalues{


### PR DESCRIPTION
## Summary of changes
This attempts to clarify the behavior of `shmem_team_get_config` when `config_mask` is 0 and/or `config` is a null pointer.  It relates to issue #447.

## Proposal Checklist
- [X] Link to issue(s)
- [X] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
