### PR TITLE
team_get_config: return the *current* config values

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -703,6 +703,10 @@ The following list describes the specific changes in \openshmem[1.6]:
     additional arguments.
 \ChangelogRef{subsec:shmem_pcontrol}
 %
+\item Clarified that \FUNC{shmem\_team\_get\_config} returns the current
+    configuration values, which may differ from the values assigned at the
+        time of the team's creation.
+\ChangelogRef{subsec:shmem_team_get_config}
 \end{itemize}
 
 \section{Version 1.5}

--- a/content/shmem_team_get_config.tex
+++ b/content/shmem_team_get_config.tex
@@ -21,6 +21,10 @@ int @\FuncDecl{shmem\_team\_get\_config}@(shmem_team_t team, long config_mask, s
 \FUNC{shmem\_team\_get\_config} returns through the \VAR{config} argument
 the configuration parameters as described by the mask, which were assigned according
 to input configuration parameters when the team was created.
+The output \VAR{config} argument indicates the \openshmem library's
+parameter values at the time \FUNC{shmem\_team\_get\_config} is called.
+These values may differ from the parameter values that were assigned at the
+time of the team's creation.
 
 If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID},
 then no operation is performed.


### PR DESCRIPTION
## Summary of changes
This PR attempts to address #374.

I'm a bit unsure this expresses the desired behavior... I'm at least hoping to start discussing how best to clarify this.

## Proposal Checklist
- [X] Link to issue(s)
- [X] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
