### PR TITLE
Remove /newline shmem_malloc_hints table, prevents compilation

### DIFF
--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -57,19 +57,15 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
     \tabularnewline \hline
     \endhead
     %%
-    \newline
     \CONST{0} &
-    \newline
     Behavior same as \FUNC{shmem\_malloc}
     \tabularnewline \hline
 
     \LibConstDecl{SHMEM\_MALLOC\_ATOMICS\_REMOTE} &
-    \newline 
     Memory used for \VAR{atomic} operations
     \tabularnewline \hline
 
     \LibConstDecl{SHMEM\_MALLOC\_SIGNAL\_REMOTE} &
-    \newline
     Memory used for \VAR{signal} operations
     \tabularnewline \hline
 


### PR DESCRIPTION
# Summary of changes

Remove `/newline` in `shmem_malloc_hints` table. Prevents compilation in TeX Live 2023 and 2024.
