### PR TITLE
[SHMEM 1.6 Sec. 9.11] Sychronization

### DIFF
--- a/content/shmem_test_all_vector.tex
+++ b/content/shmem_test_all_vector.tex
@@ -46,8 +46,7 @@ corresponding \TYPENAME{} specified by Table \ref{stdamotypes}.
     conditions.  This routine compares each element of the
     \VAR{ivars} array in the test set with each respective value in
     \VAR{cmp\_values} according to the comparison operator \VAR{cmp} at the
-    calling \ac{PE}.  If \VAR{nelems} is 0, the test set is empty and this
-    routine returns 1.
+    calling \ac{PE}.  
 
     The optional \VAR{status} is a mask array of length \VAR{nelems} where each element
     corresponds to the respective element in \VAR{ivars} and indicates whether


### PR DESCRIPTION
# Summary of changes
Fix duplicate text in the description for shmem_test_all_vector

In the API description for shmem_test_all_vector there is duplicate text that says when nelems is 0 the function returns 1.

# Proposal Checklist
- [ ] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
