### PR TITLE
[SHMEM 1.6 Sec 9.1 - 9.3] Clarifications and updates to setup, thread, and memory 

### DIFF
--- a/content/shmem_calloc.tex
+++ b/content/shmem_calloc.tex
@@ -1,5 +1,5 @@
 \apisummary{
-  Allocate a zeroed block of symmetric memory.
+  Collectively allocate a zeroed block of symmetric memory.
 }
 
 \begin{apidefinition}

--- a/content/shmem_finalize.tex
+++ b/content/shmem_finalize.tex
@@ -44,7 +44,7 @@ void @\FuncDecl{shmem\_finalize}@(void);
     All processes
     that represent the \acp{PE} will still exist after the
     call to \FUNC{shmem\_finalize} returns, but they will no longer have access
-    to resources that have been released.
+    to \openshmem library resources that have been released.
 }
 
 \apireturnvalues{

--- a/content/shmem_global_exit.tex
+++ b/content/shmem_global_exit.tex
@@ -48,7 +48,7 @@ void @\FuncDecl{shmem\_global\_exit}@(int status);
     terminate regardless of their current execution state. While I/O must be
     flushed for standard language I/O calls from \CorCpp, it is
     implementation dependent as to how I/O done by other means (e.g., third
-    party I/O libraries) is handled. Similarly, resources are released
+    party I/O libraries) are handled. Similarly, resources are released
     according to \CorCpp standard language requirements, but this may not
     include all resources allocated for the \openshmem program. However, a
     quality implementation will make a best effort to flush all I/O and clean

--- a/content/shmem_init.tex
+++ b/content/shmem_init.tex
@@ -16,9 +16,10 @@ void @\FuncDecl{shmem\_init}@(void);
 \apidescription{
     \FUNC{shmem\_init} allocates and initializes resources used by the \openshmem
     library. It is a collective operation that all \acp{PE} must call before any
-    other \openshmem routine may be called. At the end of the \openshmem program
-    which it initialized, the call to \FUNC{shmem\_init} must be matched with a
-    call to \FUNC{shmem\_finalize}.
+    other \openshmem routine may be called, except \FUNC{shmem\_query\_initialized} 
+    which checks the current initialized state of the library. At the end of the 
+    \openshmem program which it initialized, the call to \FUNC{shmem\_init} must 
+    be matched with a call to \FUNC{shmem\_finalize}.
 
     The \FUNC{shmem\_init} and \FUNC{shmem\_init\_thread} initialization
     routines may be called multiple times within an \openshmem program. A

--- a/content/shmem_init.tex
+++ b/content/shmem_init.tex
@@ -41,7 +41,7 @@ void @\FuncDecl{shmem\_init}@(void);
     users are encouraged to use \FUNC{shmem\_init}. An important difference between
     \FUNC{shmem\_init} and \FUNC{start\_pes} is that every call to
     \FUNC{shmem\_init} within a program must be matched with a call to \FUNC{shmem\_finalize}.
-    while in the case of \FUNC{start\_pes}, any subsequent calls to \FUNC{start\_pes} after the
+    In the case of \FUNC{start\_pes}, any subsequent calls to \FUNC{start\_pes} after the
     first one results in a no-op.
 }
 \end{DeprecateBlock}

--- a/content/shmem_init.tex
+++ b/content/shmem_init.tex
@@ -17,9 +17,9 @@ void @\FuncDecl{shmem\_init}@(void);
     \FUNC{shmem\_init} allocates and initializes resources used by the \openshmem
     library. It is a collective operation that all \acp{PE} must call before any
     other \openshmem routine may be called, except \FUNC{shmem\_query\_initialized} 
-    which checks the current initialized state of the library. At the end of the 
-    \openshmem program which it initialized, the call to \FUNC{shmem\_init} must 
-    be matched with a call to \FUNC{shmem\_finalize}.
+    which checks the current initialized state of the library. In the 
+    \openshmem program which it initialized, each call to \FUNC{shmem\_init} must 
+    be matched with a corresponding call to \FUNC{shmem\_finalize}.
 
     The \FUNC{shmem\_init} and \FUNC{shmem\_init\_thread} initialization
     routines may be called multiple times within an \openshmem program. A

--- a/content/shmem_init.tex
+++ b/content/shmem_init.tex
@@ -39,9 +39,9 @@ void @\FuncDecl{shmem\_init}@(void);
     deprecated and calls to it should be replaced with calls to \FUNC{shmem\_init}.
     While support for \FUNC{start\_pes} is still required in \openshmem libraries,
     users are encouraged to use \FUNC{shmem\_init}. An important difference between
-    \FUNC{shmem\_init} and \FUNC{start\_pes} is that multiple calls to
-    \FUNC{shmem\_init} within a program results in undefined behavior, while in the
-    case of \FUNC{start\_pes}, any subsequent calls to \FUNC{start\_pes} after the
+    \FUNC{shmem\_init} and \FUNC{start\_pes} is that every call to
+    \FUNC{shmem\_init} within a program must be matched with a call to \FUNC{shmem\_finalize}.
+    while in the case of \FUNC{start\_pes}, any subsequent calls to \FUNC{start\_pes} after the
     first one results in a no-op.
 }
 \end{DeprecateBlock}

--- a/content/shmem_init.tex
+++ b/content/shmem_init.tex
@@ -33,6 +33,7 @@ void @\FuncDecl{shmem\_init}@(void);
     None.
 }
 
+\begin{DeprecateBlock}
 \apinotes{
     As of \openshmem[1.2], the use of \FUNC{start\_pes} has been
     deprecated and calls to it should be replaced with calls to \FUNC{shmem\_init}.
@@ -43,6 +44,7 @@ void @\FuncDecl{shmem\_init}@(void);
     case of \FUNC{start\_pes}, any subsequent calls to \FUNC{start\_pes} after the
     first one results in a no-op.
 }
+\end{DeprecateBlock}
 
 \begin{apiexamples}
 

--- a/content/shmem_malloc.tex
+++ b/content/shmem_malloc.tex
@@ -23,8 +23,10 @@ void *@\FuncDecl{shmem\_malloc}@(size_t size);
   \FUNC{malloc}, which allocates from the private heap).
   When \VAR{size} is zero, the \FUNC{shmem\_malloc} routine performs
   no action and returns a null pointer; otherwise,
-  \FUNC{shmem\_malloc} calls a barrier on exit.
-
+  \FUNC{shmem\_malloc} calls a procedure that is semantically equivalent 
+  to \FUNC{shmem\_barrier\_all} on exit. This ensures that all \acp{PE} participate
+  in the memory allocation, and that the memory on other \acp{PE} can be used as soon as the local
+  \ac{PE} returns. 
   The value of the \VAR{size} argument must be identical on all
   \acp{PE}; otherwise, the behavior is undefined.
 }

--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -18,8 +18,8 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
 
 \apidescription{
 
-    The \FUNC{shmem\_malloc\_with\_hints} routine, like \FUNC{shmem\_malloc},
-    is a collective operation on the world team that returns a pointer to a block of at least
+    The \FUNC{shmem\_malloc\_with\_hints} routine, like \FUNC{shmem\_malloc}, is a collective operation
+    on the world team that returns a pointer to a block of at least
     \VAR{size} bytes, which shall be suitably aligned so that it may be
     assigned to a pointer to any type of object.  This space is allocated from
     the symmetric heap (similar to \FUNC{shmem\_malloc}).  When the \VAR{size} is zero, 

--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -18,8 +18,8 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
 
 \apidescription{
 
-    The \FUNC{shmem\_malloc\_with\_hints} routine, like \FUNC{shmem\_malloc}, is a collective operation
-    on the world team that returns a pointer to a block of at least
+    The \FUNC{shmem\_malloc\_with\_hints} routine, like \FUNC{shmem\_malloc},
+    is a collective operation on the world team that returns a pointer to a block of at least
     \VAR{size} bytes, which shall be suitably aligned so that it may be
     assigned to a pointer to any type of object.  This space is allocated from
     the symmetric heap (similar to \FUNC{shmem\_malloc}).  When the \VAR{size} is zero, 

--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -27,7 +27,7 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
     
     In addition to the \VAR{size} argument, the \VAR{hints} argument is provided by the user. 
     The \VAR{hints} describes the expected manner in which the \openshmem program may use the allocated memory.
-    The valid usage hints are described in Table~\ref{usagehints}. Multiple hints may be requested by combining them with a bitwise \CONST{OR} operation.
+    The valid usage of hints are described in Table~\ref{usagehints}. Multiple hints may be requested by combining them with a bitwise \CONST{OR} operation.
     A zero option can be given if no options are requested.
     
     The information provided by the \VAR{hints} is used to optimize for performance by the implementation. 
@@ -37,11 +37,9 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
             
     The \FUNC{shmem\_malloc\_with\_hints} routine is provided  so that multiple \acp{PE} in a program can allocate symmetric,
     remotely accessible memory blocks.  When no action is performed, these
-    routines return without performing a barrier. Otherwise, the routine will call a procedure that is semantically equivalent to \FUNC{shmem\_barrier\_all} on exit, similar to the behavior of \FUNC{shmem\_malloc}..
-    % Why are these two sentences here? should the go in the shmem_malloc text instead if they are relevant?  BES
-    %  It is the user's responsibility to ensure that no communication operations involving the given memory block are pending on
-    %other contexts prior to calling the \FUNC{shmem\_free} and \FUNC{shmem\_realloc} routines.
-    The user is also responsible for calling these routines with identical argument(s) on all
+    routines return without performing a barrier. Otherwise, the routine will call a procedure that is
+    semantically equivalent to \FUNC{shmem\_barrier\_all} on exit, similar to the behavior of \FUNC{shmem\_malloc}.
+    The user is responsible for calling this routine with identical argument(s) on all
     \acp{PE}; if differing \VAR{size}, or \VAR{hints} arguments are used, the behavior of the call
     is undefined.
 }

--- a/content/shmem_malloc_hints.tex
+++ b/content/shmem_malloc_hints.tex
@@ -37,14 +37,13 @@ void *@\FuncDecl{shmem\_malloc\_with\_hints}@(size_t size, long hints);
             
     The \FUNC{shmem\_malloc\_with\_hints} routine is provided  so that multiple \acp{PE} in a program can allocate symmetric,
     remotely accessible memory blocks.  When no action is performed, these
-    routines return without performing a barrier. Otherwise, the routine will call a procedure that is semantically equivalent to \FUNC{shmem\_barrier\_all} on exit.
-    This ensures that all \acp{PE} participate in the memory allocation, and that the memory on other
-    \acp{PE} can be used as soon as the local \ac{PE} returns. The implicit barrier performed by this routine will quiet the
-    default context.  It is the user's responsibility to ensure that no communication operations involving the given memory block are pending on
-    other contexts prior to calling the \FUNC{shmem\_free} and \FUNC{shmem\_realloc} routines.
+    routines return without performing a barrier. Otherwise, the routine will call a procedure that is semantically equivalent to \FUNC{shmem\_barrier\_all} on exit, similar to the behavior of \FUNC{shmem\_malloc}..
+    % Why are these two sentences here? should the go in the shmem_malloc text instead if they are relevant?  BES
+    %  It is the user's responsibility to ensure that no communication operations involving the given memory block are pending on
+    %other contexts prior to calling the \FUNC{shmem\_free} and \FUNC{shmem\_realloc} routines.
     The user is also responsible for calling these routines with identical argument(s) on all
     \acp{PE}; if differing \VAR{size}, or \VAR{hints} arguments are used, the behavior of the call
-    and any subsequent \openshmem calls is undefined.
+    is undefined.
 }
 
 \apireturnvalues{

--- a/content/shmem_ptr.tex
+++ b/content/shmem_ptr.tex
@@ -24,7 +24,7 @@ void *@\FuncDecl{shmem\_ptr}@(const void *dest, int pe);
     of an \openshmem routine that requires a symmetric address results in
     undefined behavior.
     
-    The \FUNC{shmem\_ptr} routine can provide an efficient means to accomplish
+    The \FUNC{shmem\_ptr} routine can provide efficient means to accomplish
     communication, for example when a sequence of reads and writes to a data
     object on a remote \ac{PE} does not match the access pattern provided in an
     \openshmem data transfer routine like \FUNC{shmem\_put} or

--- a/content/shmem_query_initialized.tex
+++ b/content/shmem_query_initialized.tex
@@ -20,7 +20,7 @@ void @\FuncDecl{shmem\_query\_initialized}@(int *initialized);
     zero.
 
     This function may be called at any time, regardless of the thread safety
-    level of the \openshmem library.
+    level or the current initialized state of the \openshmem library.
 }
 
 \apireturnvalues{

--- a/content/shmem_team_ptr.tex
+++ b/content/shmem_team_ptr.tex
@@ -25,7 +25,7 @@ void *@\FuncDecl{shmem\_team\_ptr}@(shmem_team_t team, const void *dest, int pe)
     an \openshmem routine that requires a symmetric address results in
     undefined behavior.
     
-    The \FUNC{shmem\_team\_ptr} routine can provide an efficient means to accomplish
+    The \FUNC{shmem\_team\_ptr} routine can provide efficient means to accomplish
     communication, for example when a sequence of reads and writes to a data
     object on a remote \ac{PE} does not match the access pattern provided in an
     \openshmem data transfer routine like \FUNC{shmem\_put} or

--- a/content/threads_intro.tex
+++ b/content/threads_intro.tex
@@ -30,7 +30,7 @@ The following semantics apply to the usage of these models:
 \begin{enumerate}
 \item
 In the \CONST{SHMEM\_THREAD\_FUNNELED}, \CONST{SHMEM\_THREAD\_SERIALIZED}, and
-\CONST{SHMEM\_THREAD\_MULTIPLE} thread levels, the \FUNC{shmem\_init} and
+\CONST{SHMEM\_THREAD\_MULTIPLE} thread levels, the \FUNC{shmem\_init\_thread} and
 \FUNC{shmem\_finalize} calls must be invoked by the same thread.
 
 \item

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -56,6 +56,10 @@ finalize, and monitor the parallel environment of the \acp{PE}, respectively.
 \subsubsection{\textbf{SHMEM\_FINALIZE}}\label{subsec:shmem_finalize}
 \input{content/shmem_finalize}
 
+\subsubsection{\textbf{SHMEM\_QUERY\_INITIALIZED}}
+\label{subsec:shmem_query_initialized}
+\input{content/shmem_query_initialized}
+
 \subsubsection{\textbf{SHMEM\_GLOBAL\_EXIT}}\label{subsec:shmem_global_exit}
 \input{content/shmem_global_exit}
 
@@ -91,11 +95,6 @@ finalize, and monitor the parallel environment of the \acp{PE}, respectively.
 \subsubsection{\textbf{SHMEM\_QUERY\_THREAD}}
 \label{subsec:shmem_query_thread}
 \input{content/shmem_query_thread}
-
-\subsubsection{\textbf{SHMEM\_QUERY\_INITIALIZED}}
-\label{subsec:shmem_query_initialized}
-\input{content/shmem_query_initialized}
-
 
 \subsection{Memory Management Routines}
 \label{sec:memory_management}

--- a/main_spec.tex
+++ b/main_spec.tex
@@ -41,8 +41,8 @@
 \section{OpenSHMEM Library \acs{API}}\label{sec:openshmem_library_api}
 
 \subsection{Library Setup, Exit, and Query Routines}
-The library setup and query interfaces that initialize and monitor the parallel
-environment of the \acp{PE}.
+This section specifies the library setup, exit, and query interfaces that initialize,
+finalize, and monitor the parallel environment of the \acp{PE}, respectively.
 
 \subsubsection{\textbf{SHMEM\_INIT}}\label{subsec:shmem_init}
 \input{content/shmem_init}


### PR DESCRIPTION
# Summary of changes
This PR includes text updates, clarifications, and changes related to the recent additions to the OpenSHMEM spec. Some of the key changes are - 
1. Deprecated block for `start_pes`
2. Clarifications on when `query_initialized` can be called and moved it to Section 9.1
3. Reorganizing texts between `malloc` and `malloc_hints`
4. Text edits, typo fixes

# Proposal Checklist
- [ ] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
