### PR TITLE
[SHMEM 1.6 Sec 1-8] Updates and additions to front matter 

### DIFF
--- a/content/coverpage.tex
+++ b/content/coverpage.tex
@@ -47,8 +47,60 @@ Version \insertDocVersion
 \end{itemize}
 
 \section*{Authors and Collaborators}
-This document is a collaborative effort consisting of several releases of \openshmem versions 1.0 through 1.5. This section lists the authors and contributors in reverse chronological order, starting with \openshmem 1.5.
+This document is a collaborative effort consisting of several releases of \openshmem versions 1.0 through 1.6. This section lists the authors and contributors in reverse chronological order, starting with \openshmem 1.6.
 
+\subsection*{\openshmem 1.6}
+\begin{multicols}{2}
+\begin{itemize}
+\setlength\itemsep{0.1em}
+\item Ferrol Aderholdt, NVIDIA
+\item Muhammad Awad, \ac{AMD}
+\item Matthew Baker, \ac{ORNL}
+\item Swen Boehm, \ac{ORNL}
+\item Aurelien Bouteiller, \ac{UTK}
+\item Mark Brown, Intel
+\item Bob Cernohous, \ac{HPE}
+\item James Dinan\footnotemark[1], NVIDIA
+\item Megan Grodowitz, Arm Inc.
+\item Max Grossman, Georgia Tech
+\item Yanfei Guo, \ac{ANL}
+\item Khaled Hamidouche, NVIDIA
+\item Jeff Hammond, NVIDIA
+\item Akihiro Hayashi, Georgia Tech
+\item Oscar Hernandez, \ac{ORNL}
+\item Kieran Holland, Intel
+\item Robert Kierski, \ac{HPE}
+\item Bryant Lam, \ac{DoD}
+\item Akhil Langer, NVIDIA
+\item Tiffany M. Mintz, \ac{ORNL}
+\item Bryan Morgan, Intel
+\item William Okuno\footnotemark[2], \ac{HPE}
+\item David Ozog\footnotemark[5], Intel
+\item Nicholas Park, \ac{DoD}
+\item Wendy Poole, \ac{LANL}
+\item Steve Poole\footnotemark[6], \ac{OSSS}
+\item Swaroop Pophale, \ac{ORNL}
+\item Sreeram Potluri, NVIDIA
+\item Brandon Potter\footnotemark[4], \ac{AMD}
+\item Howard Pritchard, \ac{LANL}
+\item Md. Wasi-ur- Rahman\footnotemark[11], Intel
+\item Naveen Ravichandrasekaran\footnotemark[9], \ac{HPE}
+\item Michael Raymond, \ac{HPE}
+\item Elliot Ronaghan\footnotemark[8], \ac{HPE}
+\item James Ross, \ac{ARL}
+\item Pavel Shamis, NVIDIA
+\item Sameer Shende, \ac{UO}
+\item Danielle Sikich, \ac{HPE}
+\item Brian Smith, Cornelis Networks
+\item Lawrence Stewart\footnotemark[7], Intel
+\item Zach Tiffany, NVIDIA
+\item Manjunath Gorentla Venkata\footnotemark[10], NVIDIA
+\item Kevin Waters\footnotemark[3], \ac{DoD}
+\item Aaron Welch, \ac{ORNL}
+\item Nathan Wichmann, \ac{HPE}
+\item Jeffrey Young, Georgia Tech
+\end{itemize}
+\end{multicols}
 
 \subsection*{\openshmem 1.5}
 \begin{multicols}{2}

--- a/content/library_constants.tex
+++ b/content/library_constants.tex
@@ -84,6 +84,19 @@ ordering of memory store operations.
 See Section~\ref{subsec:shmem_ctx_create} for more detail about its use.
 \tabularnewline \hline
 %%
+\LibConstDecl{SHMEM\_CTX\_SESSION\_TOTAL\_OPS} &
+The bitwise flag which specifies that a session start routine should use the
+\VAR{total\_ops} member of the provided \CTYPE{shmem\_ctx\_session\_config\_t}
+configuration parameter as a hint. See \ref{subsec:shmem_ctx_session_config_t}
+for more detail about its use.
+\tabularnewline \hline
+%%
+\LibConstDecl{SHMEM\_CTX\_SESSION\_BATCH} &
+The session start option which specifies that operations in the given session
+are latency tolerant and may be candidates for batching. See
+\ref{subsec:shmem_ctx_session_start} for more detail about its use.
+\tabularnewline \hline
+%%
 \LibConstDecl{SHMEM\_SIGNAL\_SET} &
 An integer constant expression corresponding to the signal update set operation.
 See Section~\ref{subsec:shmem_put_signal} and

--- a/content/memory_model.tex
+++ b/content/memory_model.tex
@@ -71,7 +71,7 @@ used with \CorCpp{} structures.
 The ``mem'' interfaces (e.g., \FUNC{shmem\_putmem}) have no alignment
 requirements.
 
-The \FUNC{shmem\_ptr} routine allows the programmer to query a {\em local
+The \FUNC{shmem\_ptr} and \FUNC{shmem\_team\_ptr} routines allow the application to query a {\em local
 address} to a remotely accessible data object at a specified \ac{PE}.  The
 resulting pointer is valid for direct memory access; however, providing this
 address as an argument of an \openshmem routine that requires a symmetric

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -111,9 +111,16 @@ An overview of the \openshmem routines is described below:
 
 \item \textbf{Signaling Operations}
 \begin{enumerate}
-  \item \OPR{Signaling Put}: The \source{} data is copied to the symmetric
-        object on the remote \ac{PE} and a flag on the remote \ac{PE} is subsequently
-        updated to signal completion.
+  \item \OPR{Put Signal}: The local \ac{PE} specifies the \source{} data object
+      to be copied to the symmetric data object on the remote \ac{PE} and
+      another symmetric data object on the remote \ac{PE} is subsequently
+      updated to signal completion.
+  \item \OPR{Signal Add}: The local \ac{PE} specifies a value to be added to
+      the symmetric data object on the remote \ac{PE}.
+  \item \OPR{Signal Set}: The local \ac{PE} specifies a value to be copied to
+      the symmetric data object on the remote \ac{PE}.
+  \item \OPR{Signal Fetch}: The local \ac{PE} returns the value of a local data
+      object.
 \end{enumerate}
 
 \item \textbf{Synchronization and Ordering}

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -43,11 +43,11 @@ An overview of the \openshmem routines is described below:
 
 \item \textbf{Symmetric Data Object Management}
 \begin{enumerate}
-  \item \OPR{Allocation}: All executing \acp{PE} must participate in the
+  \item \OPR{Allocation}: All executing \acp{PE} must collectively participate in the
       allocation of a symmetric data object with identical arguments.
-  \item  \OPR{Deallocation}: All executing \acp{PE} must participate in the
+  \item  \OPR{Deallocation}: All executing \acp{PE} must collectively participate in the
       deallocation of the same symmetric data object with identical arguments.
-  \item  \OPR{Reallocation}: All executing \acp{PE} must participate in the
+  \item  \OPR{Reallocation}: All executing \acp{PE} must collectively participate in the
       reallocation of the same symmetric data object with identical arguments.
 \end{enumerate}
 

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -123,6 +123,13 @@ An overview of the \openshmem routines is described below:
       object.
 \end{enumerate}
 
+\item \textbf{Session Management}
+\begin{enumerate}
+  \item \OPR{Sessions}: Sessions are a mechanism for the application to inform
+      the implementation about an upcoming sequence of operations that exhibit
+      a pattern that may be suitable for runtime optimization.
+\end{enumerate}
+
 \item \textbf{Synchronization and Ordering}
 \begin{enumerate}
   \item \OPR{Fence}: The \ac{PE} calling fence ensures ordering of

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -81,9 +81,12 @@ An overview of the \openshmem routines is described below:
 
 \item \textbf{\acfp{AMO}}
 \begin{enumerate}
-    \item \OPR{Swap}: The \ac{PE} initiating the swap gets the old value of a
-        symmetric data object from a remote \ac{PE} and copies a new value to
-        that symmetric data object on the remote \ac{PE}.
+  \item \OPR{Fetch}: The \ac{PE} initiating the fetch returns the value of the
+      symmetric data object on the remote \ac{PE}.
+  \item \OPR{Set}: The \ac{PE} initiating the set copies a new value to the
+      symmetric data object on the remote \ac{PE}.
+  \item \OPR{Swap}: The \ac{PE} initiating the swap copies a new value to the
+      symmetric data object on the remote \ac{PE} and returns the old value.
   \item \OPR{Increment}: The \ac{PE} initiating the increment adds 1 to the
       symmetric data object on the remote \ac{PE}.
   \item \OPR{Add}: The \ac{PE} initiating the add specifies the value to be added
@@ -91,14 +94,14 @@ An overview of the \openshmem routines is described below:
   \item \OPR{Bitwise Operations}: The \ac{PE} initiating the bitwise
       operation specifies the operand value to the bitwise operation to be
       performed on the symmetric data object on the remote \ac{PE}.
-  \item \OPR{Compare and Swap}: The \ac{PE} initiating the swap gets the old value
-      of the symmetric data object based on a value to be compared and copies a
-      new value to the symmetric data object on the remote \ac{PE}.
-  \item \OPR{Fetch and Increment}: The \ac{PE} initiating the increment adds 1 to
-      the symmetric data object on the remote \ac{PE} and returns with the old
+  \item \OPR{Compare and Swap}: The \ac{PE} initiating the compare and swap
+      conditionally copies a new value to the symmetric data object on the
+      remote \ac{PE} and returns the old value.
+  \item \OPR{Fetch and Increment}: The \ac{PE} initiating the increment adds 1
+      to the symmetric data object on the remote \ac{PE} and returns the old
       value.
   \item \OPR{Fetch and Add}: The \ac{PE} initiating the add specifies the value to
-      be added to the symmetric data object on the remote \ac{PE} and returns with
+      be added to the symmetric data object on the remote \ac{PE} and returns
       the old value.
   \item \OPR{Fetch and Bitwise Operations}: The \ac{PE} initiating the bitwise
       operation specifies the operand value to the bitwise operation to be

--- a/content/programming_model_overview.tex
+++ b/content/programming_model_overview.tex
@@ -138,7 +138,7 @@ An overview of the \openshmem routines is described below:
 \begin{enumerate}
   \item \OPR{Broadcast}: The \VAR{root} \ac{PE} specifies a symmetric data
       object to be copied to a symmetric data object on one or more remote
-      \acp{PE} (not including itself).
+      \acp{PE}.
   \item \OPR{Collection}: All \acp{PE} participating in the routine get the result
       of concatenated symmetric objects contributed by each of the \acp{PE} in
       another symmetric data object.
@@ -146,8 +146,11 @@ An overview of the \openshmem routines is described below:
       of an associative binary routine over elements of the specified symmetric
       data object on another symmetric data object.
   \item \OPR{All-to-All}: All \acp{PE} participating in the routine exchange
-      a fixed amount of contiguous or strided data with all other \acp{PE}
-      in the active set.
+      a fixed amount of contiguous or strided data with all other participating
+      \acp{PE}.
+  \item \OPR{Scan}: All \acp{PE} participating in the routine perform an
+      inclusive or exclusive prefix sum over elements of the specified
+      symmetric data object.
 \end{enumerate}
 
 \item \textbf{Mutual Exclusion}

--- a/example_code/amo_scenario_3.c
+++ b/example_code/amo_scenario_3.c
@@ -1,19 +1,14 @@
 #include <shmem.h>
 
 int main(void) {
-  static long psync[SHMEM_REDUCE_SYNC_SIZE];
-  static int pwrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
   static int x = 0, y = 0;
-
-  for (int i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++)
-    psync[i] = SHMEM_SYNC_VALUE;
 
   shmem_init();
   shmem_int_atomic_inc(&x, (shmem_my_pe() + 1) % shmem_n_pes());
   /* Undefined behavior: The following reduction operation performs accesses to
    * symmetric variable 'x' that are concurrent with previously issued atomic
    * increment operations on the same variable. */
-  shmem_int_sum_to_all(&y, &x, 1, 0, 0, shmem_n_pes(), pwrk, psync);
+  shmem_int_sum_reduce(SHMEM_TEAM_WORLD, &y, &x, 1);
 
   shmem_finalize();
   return 0;

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -105,7 +105,7 @@
 \acro{API}{\emph{Application Programming Interface}}
 \acro{MPI}{\emph{Message Passing Interface}}
 \acro{SPMD}{\emph{Single Program Multiple Data}}
-\acro{ANL}{Argonne National Labratory}
+\acro{ANL}{Argonne National Laboratory}
 \acro{ARL}{Army Research Laboratory}
 \acro{AMD}{Advanced Micro Devices}
 \acro{MPMD}{\emph{Multiple Program Multiple Data}}
@@ -120,7 +120,7 @@
 \acro{SGI}{Silicon Graphics International}
 \acro{DoD}{U.S. Department of Defense}
 \acro{SBU}{Stonybrook University}
-\acro{UTK}{University of Tenneesee at Knoxville}
+\acro{UTK}{University of Tennessee at Knoxville}
 \acro{HPE}{Hewlett Packard Enterprise}
 \end{acronym}
 


### PR DESCRIPTION
# Summary of changes
This adds new 1.6 features to the front matter overview list and constant table and cleans up a few other areas. Specifically this:
- Adds new routines to the overview list and constant table for sessions, new signaling operations, and scan
- Updates the collectives overview to avoid talking about active-set specific behavior
- Tries to make the atomic overview language more consistent and adds missing routines
- Specifies that allocation routines are collective to match changes in the memory management section
- Removes deprecated functions from amo example 3 (`sum_to_all` -> `reduce`)
- Adds initial list of 1.6 contributors

# Proposal Checklist
- [ ] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
