### PR TITLE
[SHMEM 1.6 Sec 9.4-9.5] Updates to Teams and Context

### DIFF
--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -13,8 +13,7 @@ int @\FuncDecl{shmem\_team\_split\_strided}@(shmem_team_t parent_team, int start
 \begin{apiarguments}
 \apiargument{IN}{parent\_team}{An \openshmem team.}
 
-\apiargument{IN}{start}{The lowest \ac{PE} number of the subset of \acp{PE} from
-the parent team that will form the new team.}
+\apiargument{IN}{start}{The first \acs{PE} number of the subset of \acp{PE} from the parent team that will form the new team. If the stride is less than zero, the first \acs{PE} number is the highest \acs{PE} of the parent team; if it is  greater than zero, it is the lowest; if the stride is zero, it is the starting \acs{PE}.}
 
 \apiargument{IN}{stride}{The stride between team \ac{PE}
 numbers in the parent team that comprise the subset of \acp{PE} that will form

--- a/content/shmem_team_split_strided.tex
+++ b/content/shmem_team_split_strided.tex
@@ -59,6 +59,18 @@ When $stride$ is less than zero, PEs in the new team are in \textit{reverse}
 relative order with respect to the parent team.
 If a $stride$ value equal to 0 is passed to \FUNC{shmem\_team\_split\_strided},
 then the $size$ argument passed must be 1, or the behavior is undefined.
+If the triplet provided to \FUNC{shmem\_team\_split\_strided} implies a
+wrap-around sequence, the input is considered invalid and the behavior is
+undefined.
+In other words, when $stride$ is nonzero, a newly created team must only
+include \acp{PE} whose subsequent parent \ac{PE} values are either all
+increasing (for positive $stride$) or all decreasing (for negative
+$stride$).
+That is, \textit{wrap-around} with respect to the parent team's \ac{PE} values
+is not permitted.
+For example, the list of \acp{PE} in the parent team should not start at a high
+number and then continue to include \acp{PE} in the lower end of the parent
+team's \ac{PE} range.
 
 This routine must be called by all \acp{PE} in the parent team.
 All \acp{PE} must provide the same values for the \ac{PE} triplet.

--- a/example_code/shmem_ctx.c
+++ b/example_code/shmem_ctx.c
@@ -1,9 +1,6 @@
 #include <shmem.h>
 #include <stdio.h>
 
-long pwrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
-long psync[SHMEM_REDUCE_SYNC_SIZE];
-
 long task_cntr = 0;  /* Next task counter */
 long tasks_done = 0; /* Tasks done by this PE */
 long total_done = 0; /* Total tasks done by all PEs */
@@ -11,9 +8,6 @@ long total_done = 0; /* Total tasks done by all PEs */
 int main(void) {
   int tl, i;
   long ntasks = 1024; /* Total tasks per PE */
-
-  for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++)
-    psync[i] = SHMEM_SYNC_VALUE;
 
   shmem_init_thread(SHMEM_THREAD_MULTIPLE, &tl);
   if (tl != SHMEM_THREAD_MULTIPLE)
@@ -49,7 +43,7 @@ int main(void) {
     shmem_ctx_destroy(ctx);
   }
 
-  shmem_long_sum_to_all(&total_done, &tasks_done, 1, 0, 0, npes, pwrk, psync);
+  shmem_long_sum_reduce(SHMEM_TEAM_WORLD, &total_done, &tasks_done, 1);
 
   int result = (total_done != ntasks * npes);
   shmem_finalize();


### PR DESCRIPTION
# Summary of changes
This PR updates the teams and context section for 1.6. It includes:

[wokuno#1](https://github.com/wokuno/specification/pull/1): Fix shmem_team_split_strided's start argument wording
[wokuno#2](https://github.com/wokuno/specification/pull/2): teams: split does not permit parent PE wrap-around
[wokuno#3](https://github.com/wokuno/specification/pull/3): Updated example 14 for OpenSHMEM 1.5
[kwaters4#6](https://github.com/kwaters4/specification/pull/6) backmatter: add changelog for no team wrap-arounds



# Proposal Checklist
- [ ] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
