### PR TITLE
[SHMEM 1.6rc2 Sec 9.1-9.3] Clarification of team_ptr with TEAM_WORLD and multi-init with different thread levels 

### DIFF
--- a/content/shmem_team_ptr.tex
+++ b/content/shmem_team_ptr.tex
@@ -37,6 +37,9 @@ void *@\FuncDecl{shmem\_team\_ptr}@(shmem_team_t team, const void *dest, int pe)
     when it can be accessed using memory loads and stores.  Otherwise, a null
     pointer is returned.
 
+    If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_WORLD}, then
+    the behavior is identical to that of \FUNC{shmem\_ptr} with same \VAR{dest}
+    and \VAR{pe} arguments.
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID},
     then a null pointer is returned.
     If \VAR{team} is otherwise invalid, the behavior is undefined.

--- a/content/threads_intro.tex
+++ b/content/threads_intro.tex
@@ -29,10 +29,10 @@ The following semantics apply to the usage of these models:
 
 \begin{enumerate}
 \item
-In the \CONST{SHMEM\_THREAD\_FUNNELED} and \CONST{SHMEM\_THREAD\_SERIALIZED}
-thread levels, all invocations of \FUNC{shmem\_init\_thread} and
-\FUNC{shmem\_finalize} must be made by the same thread.
- 
+In the \CONST{SHMEM\_THREAD\_FUNNELED}, \CONST{SHMEM\_THREAD\_SERIALIZED}, and
+\CONST{SHMEM\_THREAD\_MULTIPLE} thread levels, the \FUNC{shmem\_finalize}
+call must be invoked by the same thread that called \FUNC{shmem\_init\_thread}.
+
 \item
 Any \openshmem operation initiated by a thread is considered an action of the
 \ac{PE} as a whole. The symmetric heap and symmetric variables scope are not

--- a/content/threads_intro.tex
+++ b/content/threads_intro.tex
@@ -29,10 +29,10 @@ The following semantics apply to the usage of these models:
 
 \begin{enumerate}
 \item
-In the \CONST{SHMEM\_THREAD\_FUNNELED}, \CONST{SHMEM\_THREAD\_SERIALIZED}, and
-\CONST{SHMEM\_THREAD\_MULTIPLE} thread levels, the \FUNC{shmem\_init\_thread} and
-\FUNC{shmem\_finalize} calls must be invoked by the same thread.
-
+In the \CONST{SHMEM\_THREAD\_FUNNELED} and \CONST{SHMEM\_THREAD\_SERIALIZED}
+thread levels, all invocations of \FUNC{shmem\_init\_thread} and
+\FUNC{shmem\_finalize} must be made by the same thread.
+ 
 \item
 Any \openshmem operation initiated by a thread is considered an action of the
 \ac{PE} as a whole. The symmetric heap and symmetric variables scope are not


### PR DESCRIPTION
# Summary of changes
This PR addresses #541 and also clarifies that `shmem_team_ptr` behavior is same as `shmem_ptr` when the team argument equals `SHMEM_TEAM_WORLD`.

# Proposal Checklist
- [ ] Link to issue(s)
- [ ] Changelog entry
- [ ] Reviewed for changes to front matter
- [ ] Reviewed for changes to back matter
