### PR TITLE
Collectives Section Committee RC2 changes

### DIFF
--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -58,6 +58,7 @@ The team-based collective routines defined in the \openshmem Specification are:
 \item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]collect[mem]}
 \item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]fcollect[mem]}
 \item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]\{and, or, xor, max, min, sum, prod\}\_reduce}
+\item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]sum\_\{in, ex\}scan}
 \end{itemize}
 
 In addition, all team creation functions are collective operations. In addition to the ordering

--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -98,7 +98,7 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
-    Before any \ac{PE} calls a \FUNC{shmem\_alltoall} routine, the following
+    Before the local \ac{PE} calls a \FUNC{shmem\_alltoall} routine, the following
     conditions must be ensured, otherwise the behavior is undefined:
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -85,7 +85,7 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
       the team.
     \end{itemize}
 
-    Before any \ac{PE} calls a broadcast routine, the following conditions
+    Before the local \ac{PE} calls a broadcast routine, the following conditions
     must be ensured, otherwise the behavior is undefined:
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -88,7 +88,7 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
-    Before any \ac{PE} calls a collect routine, the following conditions must
+    Before the local \ac{PE} calls a collect routine, the following conditions must
     be ensured, otherwise the behavior is undefined:
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -295,7 +295,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     If \VAR{team} compares equal to \LibConstRef{SHMEM\_TEAM\_INVALID} or is
     otherwise invalid, the behavior is undefined.
 
-    Before any \ac{PE} calls a reduction routine, the following conditions
+    Before the local \ac{PE} calls a reduction routine, the following conditions
     must be ensured, otherwise the behavior is undefined:
     \begin{itemize}
         \item The \dest{} array on all \acp{PE} in the team is ready to

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -376,6 +376,18 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
     Zero on successful local completion. Nonzero otherwise.
 }
 
+\apinotes{
+    The binary operations performed by \openshmem reductions are intended to be
+    associative and commutative.
+    However, floating point arithmetic is not associative or commutative due to
+    the inherent inaccuracies of floating-point representations caused by
+    rounding errors and finite precision.
+    This can lead to variations in the result of \openshmem arithmetic
+    reduction operations on floating-point datatypes, including NaN values.
+    A future version of the \openshmem specification may clarify the behavior
+    of reductions on floating point datatypes.
+}
+
 \begin{apiexamples}
 
 \apicexample

--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -373,7 +373,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
 }
 
 \apireturnvalues{
-  Zero on successful local completion. Nonzero otherwise.
+    Zero on successful local completion. Nonzero otherwise.
 }
 
 \begin{apiexamples}

--- a/content/shmem_scan.tex
+++ b/content/shmem_scan.tex
@@ -90,7 +90,7 @@ by Table \ref{teamreducetypes}.
   \LibConstRef{SHMEM\_TEAM\_INVALID} or is otherwise invalid, the
   behavior is undefined.
 
-  Before any \ac{PE} calls a scan routine, the following conditions must be
+  Before the local \ac{PE} calls a scan routine, the following conditions must be
   ensured, otherwise the behavior is undefined:
   \begin{itemize}
       \item The \dest{} array on all \acp{PE} in the team is ready to accept


### PR DESCRIPTION
# Summary of changes
This PR is a placeholder for any changes from the Collectives section subcommittee for v1.6 RC2.

It ~~currently only~~ adds a whitespace fix.

It ~~will likely~~ includes the following doc-edit adding scan to the list of team-based collectives:
https://github.com/davidozog/openshmem-specification/pull/15

And ~~_possibly_~~ a note about reduction associativity/commutativity:
https://github.com/davidozog/openshmem-specification/pull/16

And ~~possibly~~ a wording change for clarity:
https://github.com/davidozog/openshmem-specification/pull/13

~~Now just waiting on reviews for those last 2 PRs @kwaters4 @isubsmith @BKP @maawad~~

# Proposal Checklist
- [x] Link to issue(s)
- [X] Changelog entry
- [X] Reviewed for changes to front matter
- [X] Reviewed for changes to back matter
