### PR TITLE
Add v1.6 team split undefined behaviors to Annex C

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -190,9 +190,9 @@ team, the user is responsible for destroying all contexts created from that team
 with the \LibConstRef{SHMEM\_CTX\_PRIVATE} option enabled; otherwise, the
 behavior is undefined.\tabularnewline
 \hline
-Creating a team with a $stride$ value equal to 0 and the $size$ value not equal to 1 &
-If a $stride$ value equal to 0 is passed to \FUNC{shmem\_team\_split\_strided},
-then the $size$ argument passed must be 1, or the behavior is undefined. \tabularnewline
+Creating a team with a \VAR{stride} value equal to 0 and the \VAR{size} value not equal to 1 &
+If a \VAR{stride} value equal to 0 is passed to \FUNC{shmem\_team\_split\_strided},
+then the \VAR{size} argument passed must be 1, or the behavior is undefined. \tabularnewline
 \hline
 Creating a team that implies a wrap-around sequence &
 If the triplet provided to \FUNC{shmem\_team\_split\_strided} implies a
@@ -200,13 +200,13 @@ wrap-around sequence, the input is considered invalid and the behavior is
 undefined.
 In other words, when $stride$ is nonzero, a newly created team must only
 include \acp{PE} whose subsequent parent \ac{PE} values are either all
-increasing (for positive $stride$) or all decreasing (for negative
-$stride$).
+increasing (for positive \VAR{stride}) or all decreasing (for negative
+\VAR{stride}).
 That is, \textit{wrap-around} with respect to the parent team's \ac{PE} values
 is not permitted.
 For example, given a parent team with a size of 8 \acp{PE}, a call to
 \FUNC{shmem\_team\_split\_strided} with the following arguments would
-be invalid: $start$ equal to 3, $stride$ equal to 3, and $size$ equal to 3. \tabularnewline
+be invalid: \VAR{start} equal to 3, \VAR{stride} equal to 3, and \VAR{size} equal to 3. \tabularnewline
 \hline
 \end{longtable}
 

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -190,6 +190,10 @@ team, the user is responsible for destroying all contexts created from that team
 with the \LibConstRef{SHMEM\_CTX\_PRIVATE} option enabled; otherwise, the
 behavior is undefined.\tabularnewline
 \hline
+Creating a team with a $stride$ value equal to 0 and the $size$ value not equal to 1 &
+If a $stride$ value equal to 0 is passed to \FUNC{shmem\_team\_split\_strided},
+then the $size$ argument passed must be 1, or the behavior is undefined. \tabularnewline
+\hline
 Creating a team that implies a wrap-around sequence &
 If the triplet provided to \FUNC{shmem\_team\_split\_strided} implies a
 wrap-around sequence, the input is considered invalid and the behavior is

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -198,7 +198,7 @@ Creating a team that implies a wrap-around sequence &
 If the triplet provided to \FUNC{shmem\_team\_split\_strided} implies a
 wrap-around sequence, the input is considered invalid and the behavior is
 undefined.
-In other words, when $stride$ is nonzero, a newly created team must only
+In other words, when \VAR{stride} is nonzero, a newly created team must only
 include \acp{PE} whose subsequent parent \ac{PE} values are either all
 increasing (for positive \VAR{stride}) or all decreasing (for negative
 \VAR{stride}).

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -190,6 +190,20 @@ team, the user is responsible for destroying all contexts created from that team
 with the \LibConstRef{SHMEM\_CTX\_PRIVATE} option enabled; otherwise, the
 behavior is undefined.\tabularnewline
 \hline
+Creating a team that implies a wrap-around sequence &
+If the triplet provided to \FUNC{shmem\_team\_split\_strided} implies a
+wrap-around sequence, the input is considered invalid and the behavior is
+undefined.
+In other words, when $stride$ is nonzero, a newly created team must only
+include \acp{PE} whose subsequent parent \ac{PE} values are either all
+increasing (for positive $stride$) or all decreasing (for negative
+$stride$).
+That is, \textit{wrap-around} with respect to the parent team's \ac{PE} values
+is not permitted.
+For example, the list of \acp{PE} in the parent team should not start at a high
+number and then continue to include \acp{PE} in the lower end of the parent
+team's \ac{PE} range. \tabularnewline
+\hline
 \end{longtable}
 
 

--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -204,9 +204,9 @@ increasing (for positive $stride$) or all decreasing (for negative
 $stride$).
 That is, \textit{wrap-around} with respect to the parent team's \ac{PE} values
 is not permitted.
-For example, the list of \acp{PE} in the parent team should not start at a high
-number and then continue to include \acp{PE} in the lower end of the parent
-team's \ac{PE} range. \tabularnewline
+For example, given a parent team with a size of 8 \acp{PE}, a call to
+\FUNC{shmem\_team\_split\_strided} with the following arguments would
+be invalid: $start$ equal to 3, $stride$ equal to 3, and $size$ equal to 3. \tabularnewline
 \hline
 \end{longtable}
 


### PR DESCRIPTION
# Summary of changes
This addresses issue https://github.com/openshmem-org/specification/issues/555 by adding the new (as of v1.6) undefined behaviors regarding team splits to Annex C.  The text should be verbatim relative to the API description content.

@ahayashi @kwaters4

# Proposal Checklist
- [X] Link to issue(s)
- [X] Changelog entry
- [X] Reviewed for changes to front matter
- [X] Reviewed for changes to back matter
